### PR TITLE
Add PolicyRegistry implementation

### DIFF
--- a/src/impls/PolicyDataLayout.sol
+++ b/src/impls/PolicyDataLayout.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
+
+/// @title PolicyDataLayout
+/// @notice Internal library for encoding and decoding packed policy storage slots.
+///
+/// @dev Each policy is stored as a single uint256. The low 8 bits are always the
+///      PolicyType discriminator; the remaining bits depend on the type:
+///
+///        WHITELIST / BLACKLIST:
+///          [255:168] unused
+///          [167:8]   admin address (160 bits)
+///          [7:0]     PolicyType
+///
+///        COMPOUND:
+///          [255:194] redeemerPolicyId      (62 bits)
+///          [193:132] mintRecipientPolicyId (62 bits)
+///          [131:70]  recipientPolicyId     (62 bits)
+///          [69:8]    senderPolicyId        (62 bits)
+///          [7:0]     PolicyType = 2
+///
+///      Child policy IDs are stored as 62 bits rather than 64. This lets the type
+///      byte plus all four IDs fit in exactly one 256-bit slot (8 + 4*62 = 256).
+///      Policy IDs are uint64 in the interface but packed as 62 bits in compound slots.
+///      _policyIdCounter would need to reach 2^62 (~4.6e18) for truncation to occur,
+///      which is not practically possible.
+///
+///      All functions are internal so they are inlined at compile time with no
+///      runtime overhead.
+library PolicyDataLayout {
+    uint256 internal constant TYPE_MASK = 0xFF;
+    uint256 internal constant ID_BITS = 62;
+    uint256 internal constant ID_MASK = (uint256(1) << ID_BITS) - 1;
+
+    uint256 internal constant SENDER_SHIFT = 8;
+    uint256 internal constant RECIP_SHIFT = SENDER_SHIFT + ID_BITS; // 70
+    uint256 internal constant MINT_SHIFT = RECIP_SHIFT + ID_BITS; // 132
+    uint256 internal constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
+
+    function encodeSimple(IPolicyRegistry.PolicyType pt, address adm) internal pure returns (uint256) {
+        return uint256(pt) | (uint256(uint160(adm)) << 8);
+    }
+
+    function encodeCompound(uint64 sender, uint64 recipient, uint64 mintRecipient, uint64 redeemer)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(IPolicyRegistry.PolicyType.COMPOUND) | (uint256(sender) << SENDER_SHIFT)
+            | (uint256(recipient) << RECIP_SHIFT) | (uint256(mintRecipient) << MINT_SHIFT)
+            | (uint256(redeemer) << REDEEM_SHIFT);
+    }
+
+    function policyType(uint256 packed) internal pure returns (IPolicyRegistry.PolicyType) {
+        return IPolicyRegistry.PolicyType(packed & TYPE_MASK);
+    }
+
+    function admin(uint256 packed) internal pure returns (address) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return address(uint160(packed >> 8));
+    }
+
+    // Extracts the child policy ID at the given shift offset.
+    function idAt(uint256 packed, uint256 shift) internal pure returns (uint64) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint64((packed >> shift) & ID_MASK);
+    }
+}

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -165,9 +165,8 @@ contract PolicyRegistry is IPolicyRegistry {
     /// @inheritdoc IPolicyRegistry
     function policyData(uint64 policyId) external view returns (PolicyType policyType, address admin) {
         if (!_exists(policyId)) revert PolicyNotFound();
-        // Built-ins have no stored slot; return WHITELIST as a conventional placeholder
-        // since the interface specifies the type is implementation-defined for IDs 0 and 1.
-        if (policyId < FIRST_CUSTOM_ID) return (PolicyType.WHITELIST, address(0));
+        if (policyId == ALWAYS_REJECT_ID) return (PolicyType.ALWAYS_REJECT, address(0));
+        if (policyId == ALWAYS_ALLOW_ID) return (PolicyType.ALWAYS_ALLOW, address(0));
         uint256 packed = _policyData[policyId];
         policyType = packed.decodeType();
         admin = policyType == PolicyType.COMPOUND ? address(0) : packed.decodeAdmin();

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -13,7 +13,7 @@ import {PolicySlot} from "./PolicySlot.sol";
 ///
 ///      Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
 ///      one SLOAD reads the packed slot (yielding all four child IDs), and one SLOAD
-///      reads the relevant child's member set. Compound children cannot themselves be
+///      reads the relevant constituent's member set. Compound constituents cannot themselves be
 ///      COMPOUND (enforced at creation), so evaluation never goes deeper.
 contract PolicyRegistry is IPolicyRegistry {
     using PolicySlot for uint256;
@@ -216,7 +216,7 @@ contract PolicyRegistry is IPolicyRegistry {
         if (packed == 0) revert PolicyNotFound();
     }
 
-    // Validates that policyId is a legal compound child: must exist and must not
+    // Validates that policyId is a legal compound constituent: must exist and must not
     // itself be COMPOUND. Built-in IDs 0 and 1 are always valid.
     function _requireConstituent(uint64 policyId) internal view {
         if (policyId < FIRST_CUSTOM_ID) return;
@@ -239,12 +239,12 @@ contract PolicyRegistry is IPolicyRegistry {
         PolicyType policyType = packed.decodeType();
 
         if (policyType == PolicyType.COMPOUND) {
-            uint64 childId = packed.decodeIdAt(shift);
-            if (childId == ALWAYS_REJECT_ID) return false;
-            if (childId == ALWAYS_ALLOW_ID) return true;
-            packed = _policyData[childId];
+            uint64 constituentId = packed.decodeIdAt(shift);
+            if (constituentId == ALWAYS_REJECT_ID) return false;
+            if (constituentId == ALWAYS_ALLOW_ID) return true;
+            packed = _policyData[constituentId];
             policyType = packed.decodeType();
-            return policyType == PolicyType.WHITELIST ? _members[childId][user] : !_members[childId][user];
+            return policyType == PolicyType.WHITELIST ? _members[constituentId][user] : !_members[constituentId][user];
         }
 
         return policyType == PolicyType.WHITELIST ? _members[policyId][user] : !_members[policyId][user];

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -28,7 +28,7 @@ contract PolicyRegistry is IPolicyRegistry {
     // BLACKLIST: member == true means the address is restricted.
     mapping(uint64 policyId => mapping(address account => bool)) private _members;
 
-    uint64 private _counter = FIRST_CUSTOM_ID;
+    uint64 private _counter = FIRST_USER_POLICY_ID;
 
     /*//////////////////////////////////////////////////////////////
                                CONSTANTS
@@ -36,7 +36,7 @@ contract PolicyRegistry is IPolicyRegistry {
 
     uint64 private constant ALWAYS_REJECT_ID = 0;
     uint64 private constant ALWAYS_ALLOW_ID = 1;
-    uint64 private constant FIRST_CUSTOM_ID = 2;
+    uint64 private constant FIRST_USER_POLICY_ID = 2;
 
     /*//////////////////////////////////////////////////////////////
                            POLICY CREATION
@@ -204,13 +204,13 @@ contract PolicyRegistry is IPolicyRegistry {
     }
 
     function _exists(uint64 policyId) internal view returns (bool) {
-        return policyId < FIRST_CUSTOM_ID || _policyData[policyId] != 0;
+        return policyId < FIRST_USER_POLICY_ID || _policyData[policyId] != 0;
     }
 
     // Loads and returns the packed slot for a custom policy ID, reverting if it does
     // not exist. Built-in IDs (0, 1) are excluded: they have no mutable state.
     function _requireExists(uint64 policyId) internal view returns (uint256 packed) {
-        if (policyId < FIRST_CUSTOM_ID) revert PolicyNotFound();
+        if (policyId < FIRST_USER_POLICY_ID) revert PolicyNotFound();
         packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
     }
@@ -218,7 +218,7 @@ contract PolicyRegistry is IPolicyRegistry {
     // Validates that policyId is a legal compound constituent: must exist and must be
     // WHITELIST or BLACKLIST. Built-in IDs 0 and 1 are always valid.
     function _requireConstituent(uint64 policyId) internal view {
-        if (policyId < FIRST_CUSTOM_ID) return;
+        if (policyId < FIRST_USER_POLICY_ID) return;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
         PolicyType policyType = packed.decodeType();

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -200,6 +200,12 @@ contract PolicyRegistry is IPolicyRegistry {
 
     function _nextPolicyId() internal returns (uint64 id) {
         id = _counter++;
+        // The on-chain compound-policy packing reserves 61 bits per constituent ID.
+        // Bounding the counter here guarantees that every policy ID ever created can
+        // be round-tripped through the compound slot without silent truncation; the
+        // packed-field decoders elsewhere in this contract can therefore rely on
+        // ID <= PolicySlot.ID_MASK without re-checking.
+        if (id > PolicySlot.ID_MASK) revert PolicyIdOverflow();
     }
 
     function _createPolicy(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -12,7 +12,7 @@ import {PolicySlot} from "./PolicySlot.sol";
 ///      is never zero), and COMPOUND always has type byte = 2 (so packed is never zero).
 ///
 ///      Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
-///      one SLOAD reads the packed slot (yielding all four child IDs), and one SLOAD
+///      one SLOAD reads the packed slot (yielding all four constituent IDs), and one SLOAD
 ///      reads the relevant constituent's member set. Compound constituents cannot themselves be
 ///      COMPOUND (enforced at creation), so evaluation never goes deeper.
 contract PolicyRegistry is IPolicyRegistry {
@@ -215,13 +215,14 @@ contract PolicyRegistry is IPolicyRegistry {
         if (packed == 0) revert PolicyNotFound();
     }
 
-    // Validates that policyId is a legal compound constituent: must exist and must not
-    // itself be COMPOUND. Built-in IDs 0 and 1 are always valid.
+    // Validates that policyId is a legal compound constituent: must exist and must be
+    // WHITELIST or BLACKLIST. Built-in IDs 0 and 1 are always valid.
     function _requireConstituent(uint64 policyId) internal view {
         if (policyId < FIRST_CUSTOM_ID) return;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
-        if (packed.decodeType() == PolicyType.COMPOUND) revert ConstituentIsCompound();
+        PolicyType policyType = packed.decodeType();
+        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert ConstituentIsCompound();
     }
 
     // Resolves an authorization check for a single role slot. The shift selects

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -11,9 +11,11 @@ import {PolicySlot} from "./PolicySlot.sol";
 ///      This is safe because WHITELIST/BLACKLIST require a non-zero admin (so packed
 ///      is never zero), and COMPOUND always has type byte = 2 (so packed is never zero).
 ///
-///      Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
-///      one SLOAD reads the packed slot (yielding all four constituent IDs), and one SLOAD
-///      reads the relevant constituent's member set. Compound constituents cannot themselves be
+///      Authorization cost: exactly 2 SLOADs for any custom policy (zero for built-ins).
+///      Compound policies pack each constituent's type bit alongside its ID in the
+///      compound slot, so a hot-path check reads only (a) the compound slot and
+///      (b) the relevant constituent's member set — the constituent's own policy
+///      slot does NOT need to be loaded. Compound constituents cannot themselves be
 ///      COMPOUND (enforced at creation), so evaluation never goes deeper.
 contract PolicyRegistry is IPolicyRegistry {
     using PolicySlot for uint256;
@@ -73,13 +75,19 @@ contract PolicyRegistry is IPolicyRegistry {
         uint64 mintRecipientPolicyId,
         uint64 redeemerPolicyId
     ) external returns (uint64 newPolicyId) {
-        _requireConstituent(senderPolicyId);
-        _requireConstituent(recipientPolicyId);
-        _requireConstituent(mintRecipientPolicyId);
-        _requireConstituent(redeemerPolicyId);
+        // Resolve each constituent's type once, at creation, so the hot path can read
+        // the constituent's type bit directly from the compound slot.
+        PolicyType senderType = _requireConstituent(senderPolicyId);
+        PolicyType recipientType = _requireConstituent(recipientPolicyId);
+        PolicyType mintRecipientType = _requireConstituent(mintRecipientPolicyId);
+        PolicyType redeemerType = _requireConstituent(redeemerPolicyId);
         newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] =
-            PolicySlot.encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
+        _policyData[newPolicyId] = PolicySlot.encodeCompound(
+            PolicySlot.encodeField(senderPolicyId, senderType),
+            PolicySlot.encodeField(recipientPolicyId, recipientType),
+            PolicySlot.encodeField(mintRecipientPolicyId, mintRecipientType),
+            PolicySlot.encodeField(redeemerPolicyId, redeemerType)
+        );
         emit CompoundPolicyCreated(
             newPolicyId, msg.sender, senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId
         );
@@ -180,10 +188,10 @@ contract PolicyRegistry is IPolicyRegistry {
     {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        senderPolicyId = packed.decodeIdAt(PolicySlot.SENDER_SHIFT);
-        recipientPolicyId = packed.decodeIdAt(PolicySlot.RECIPIENT_SHIFT);
-        mintRecipientPolicyId = packed.decodeIdAt(PolicySlot.MINT_SHIFT);
-        redeemerPolicyId = packed.decodeIdAt(PolicySlot.REDEEM_SHIFT);
+        senderPolicyId = packed.decodeId(PolicySlot.SENDER_SHIFT);
+        recipientPolicyId = packed.decodeId(PolicySlot.RECIPIENT_SHIFT);
+        mintRecipientPolicyId = packed.decodeId(PolicySlot.MINT_SHIFT);
+        redeemerPolicyId = packed.decodeId(PolicySlot.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -215,21 +223,24 @@ contract PolicyRegistry is IPolicyRegistry {
         if (packed == 0) revert PolicyNotFound();
     }
 
-    // Validates that policyId is a legal compound constituent: must exist and must be
-    // WHITELIST or BLACKLIST. Built-in IDs 0 and 1 are always valid.
-    function _requireConstituent(uint64 policyId) internal view {
-        if (policyId < FIRST_USER_POLICY_ID) return;
+    // Validates that policyId is a legal compound constituent and returns its type.
+    // Must exist and must be WHITELIST or BLACKLIST. Built-in IDs (0, 1) are always
+    // valid; their returned type is WHITELIST as a placeholder (the type bit is
+    // ignored on the hot path for built-ins because evaluation short-circuits on ID).
+    function _requireConstituent(uint64 policyId) internal view returns (PolicyType) {
+        if (policyId < FIRST_USER_POLICY_ID) return PolicyType.WHITELIST;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
         PolicyType policyType = packed.decodeType();
         if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert ConstituentIsCompound();
+        return policyType;
     }
 
     // Resolves an authorization check for a single role slot. The shift selects
-    // which 62-bit field to read from a compound policy's packed slot.
+    // which 62-bit constituent field to read from a compound policy's packed slot.
     //
     // For a compound policyId:    1 SLOAD (compound slot) + 1 SLOAD (member set) = 2 SLOADs
-    // For a simple policyId:      1 SLOAD (member set)                           = 1 SLOAD
+    // For a simple policyId:      1 SLOAD (policy slot)   + 1 SLOAD (member set) = 2 SLOADs
     // For a built-in policyId:    0 SLOADs
     function _checkRole(uint64 policyId, address user, uint256 shift) internal view returns (bool) {
         if (policyId == ALWAYS_REJECT_ID) return false;
@@ -239,14 +250,14 @@ contract PolicyRegistry is IPolicyRegistry {
         PolicyType policyType = packed.decodeType();
 
         if (policyType == PolicyType.COMPOUND) {
-            uint64 constituentId = packed.decodeIdAt(shift);
+            (uint64 constituentId, bool isBlacklist) = packed.decodeField(shift);
             if (constituentId == ALWAYS_REJECT_ID) return false;
             if (constituentId == ALWAYS_ALLOW_ID) return true;
-            packed = _policyData[constituentId];
-            policyType = packed.decodeType();
-            return policyType == PolicyType.WHITELIST ? _members[constituentId][user] : !_members[constituentId][user];
+            bool member = _members[constituentId][user];
+            return isBlacklist ? !member : member;
         }
 
-        return policyType == PolicyType.WHITELIST ? _members[policyId][user] : !_members[policyId][user];
+        bool simpleMember = _members[policyId][user];
+        return policyType == PolicyType.WHITELIST ? simpleMember : !simpleMember;
     }
 }

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.20 <0.9.0;
+pragma solidity 0.8.30;
 
 import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 import {PolicySlot} from "./PolicySlot.sol";
 
 /// @title PolicyRegistry
 /// @notice Implementation of the IPolicyRegistry precompile interface.
+/// @author Coinbase
 ///
 /// @dev Existence sentinel: `_policyData[id] == 0` means the policy was never created.
 ///      This is safe because WHITELIST/BLACKLIST require a non-zero admin (so packed
@@ -88,12 +89,12 @@ contract PolicyRegistry is IPolicyRegistry {
         PolicyType mintRecipientType = _requireConstituent(mintRecipientPolicyId);
         PolicyType redeemerType = _requireConstituent(redeemerPolicyId);
         newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = PolicySlot.encodeCompound(
-            PolicySlot.encodeField(senderPolicyId, senderType),
-            PolicySlot.encodeField(recipientPolicyId, recipientType),
-            PolicySlot.encodeField(mintRecipientPolicyId, mintRecipientType),
-            PolicySlot.encodeField(redeemerPolicyId, redeemerType)
-        );
+        _policyData[newPolicyId] = PolicySlot.encodeCompound({
+            senderField: PolicySlot.encodeField({id: senderPolicyId, constituentType: senderType}),
+            recipientField: PolicySlot.encodeField({id: recipientPolicyId, constituentType: recipientType}),
+            mintField: PolicySlot.encodeField({id: mintRecipientPolicyId, constituentType: mintRecipientType}),
+            redeemerField: PolicySlot.encodeField({id: redeemerPolicyId, constituentType: redeemerType})
+        });
         emit CompoundPolicyCreated(
             newPolicyId, msg.sender, senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId
         );
@@ -128,7 +129,7 @@ contract PolicyRegistry is IPolicyRegistry {
         // Preserve the frozen bit on rotation. Currently unreachable because the
         // freeze check above short-circuits, but coded defensively in case the
         // freeze semantics evolve (e.g. allowing rotation while frozen).
-        _policyData[policyId] = PolicySlot.encodeSimple(policyType, msg.sender)
+        _policyData[policyId] = PolicySlot.encodeSimple({policyType: policyType, policyAdmin: msg.sender})
             | (packed.decodeFrozen() ? PolicySlot.FROZEN_BIT : 0);
         delete _pendingAdmins[policyId];
         emit PolicyAdminUpdated(policyId, msg.sender, msg.sender);
@@ -186,8 +187,9 @@ contract PolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorized(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicySlot.SENDER_SHIFT)
-            && _checkRole(policyId, user, PolicySlot.RECIPIENT_SHIFT);
+        return
+            _checkRole(policyId, user, PolicySlot.SENDER_SHIFT)
+                && _checkRole(policyId, user, PolicySlot.RECIPIENT_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
@@ -280,7 +282,7 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
         if (admin == address(0)) revert ZeroAddress();
         newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = PolicySlot.encodeSimple(policyType, admin);
+        _policyData[newPolicyId] = PolicySlot.encodeSimple({policyType: policyType, policyAdmin: admin});
         emit PolicyCreated(newPolicyId, msg.sender, policyType);
         emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
     }

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -2,42 +2,22 @@
 pragma solidity >=0.8.20 <0.9.0;
 
 import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
+import {PolicyDataLayout} from "./PolicyDataLayout.sol";
 
 /// @title PolicyRegistry
-/// @notice Reference implementation of the IPolicyRegistry precompile interface.
+/// @notice Implementation of the IPolicyRegistry precompile interface.
 ///
-/// @dev Storage layout
-/// -------------------
-/// Each policy occupies one 256-bit slot in `_policyData`. The low 8 bits are
-/// always the PolicyType discriminator; the remaining bits depend on the type:
+/// @dev Existence sentinel: `_policyData[id] == 0` means the policy was never created.
+///      This is safe because WHITELIST/BLACKLIST require a non-zero admin (so packed
+///      is never zero), and COMPOUND always has type byte = 2 (so packed is never zero).
 ///
-///   WHITELIST / BLACKLIST:
-///     [255:168] unused
-///     [167:8]   admin address (160 bits)
-///     [7:0]     PolicyType
-///
-///   COMPOUND:
-///     [255:194] redeemerPolicyId      (62 bits)
-///     [193:132] mintRecipientPolicyId (62 bits)
-///     [131:70]  recipientPolicyId     (62 bits)
-///     [69:8]    senderPolicyId        (62 bits)
-///     [7:0]     PolicyType = 2
-///
-/// Compound constituent IDs are stored as 62 bits rather than 64. This lets the
-/// type byte plus all four IDs fit in exactly one 256-bit slot (8 + 4*62 = 256).
-/// Policy IDs are uint64 in the interface but packed as 62 bits in compound slots.
-/// _policyIdCounter would need to reach 2^62 (~4.6e18) for truncation to occur,
-/// which is not practically possible.
-///
-/// Existence sentinel: `_policyData[id] == 0` means the policy was never created.
-/// This is safe because WHITELIST/BLACKLIST require a non-zero admin (so packed
-/// is never zero), and COMPOUND always has type byte = 2 (so packed is never zero).
-///
-/// Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
-/// one SLOAD reads the packed slot (yielding all four constituent IDs), and one
-/// SLOAD reads the relevant constituent's member set. Compound constituents cannot
-/// themselves be COMPOUND (enforced at creation), so evaluation never goes deeper.
+///      Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
+///      one SLOAD reads the packed slot (yielding all four child IDs), and one SLOAD
+///      reads the relevant child's member set. Compound children cannot themselves be
+///      COMPOUND (enforced at creation), so evaluation never goes deeper.
 contract PolicyRegistry is IPolicyRegistry {
+    using PolicyDataLayout for uint256;
+
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -57,15 +37,6 @@ contract PolicyRegistry is IPolicyRegistry {
     uint64 private constant ALWAYS_REJECT_ID = 0;
     uint64 private constant ALWAYS_ALLOW_ID = 1;
     uint64 private constant FIRST_CUSTOM_ID = 2;
-
-    uint256 private constant TYPE_MASK = 0xFF;
-    uint256 private constant ID_BITS = 62;
-    uint256 private constant ID_MASK = (uint256(1) << ID_BITS) - 1;
-
-    uint256 private constant SENDER_SHIFT = 8;
-    uint256 private constant RECIP_SHIFT = SENDER_SHIFT + ID_BITS; // 70
-    uint256 private constant MINT_SHIFT = RECIP_SHIFT + ID_BITS; // 132
-    uint256 private constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
 
     /*//////////////////////////////////////////////////////////////
                            POLICY CREATION
@@ -105,7 +76,7 @@ contract PolicyRegistry is IPolicyRegistry {
         _requireSimpleConstituent(redeemerPolicyId);
         newPolicyId = _nextPolicyId();
         _policyData[newPolicyId] =
-            _encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
+            PolicyDataLayout.encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
         emit CompoundPolicyCreated(
             newPolicyId, msg.sender, senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId
         );
@@ -118,25 +89,25 @@ contract PolicyRegistry is IPolicyRegistry {
     function setPolicyAdmin(uint64 policyId, address newAdmin) external {
         if (newAdmin == address(0)) revert ZeroAddress();
         uint256 packed = _requireExists(policyId);
-        PolicyType pt = _decodeType(packed);
+        PolicyType pt = packed.policyType();
         if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
-        _policyData[policyId] = _encodeSimple(pt, newAdmin);
+        if (packed.admin() != msg.sender) revert Unauthorized();
+        _policyData[policyId] = PolicyDataLayout.encodeSimple(pt, newAdmin);
         emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
     }
 
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
         uint256 packed = _requireExists(policyId);
-        if (_decodeType(packed) != PolicyType.WHITELIST) revert IncompatiblePolicyType();
-        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
+        if (packed.policyType() != PolicyType.WHITELIST) revert IncompatiblePolicyType();
+        if (packed.admin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = allowed;
         emit WhitelistUpdated(policyId, msg.sender, account, allowed);
     }
 
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
         uint256 packed = _requireExists(policyId);
-        if (_decodeType(packed) != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
-        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
+        if (packed.policyType() != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
+        if (packed.admin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = restricted;
         emit BlacklistUpdated(policyId, msg.sender, account, restricted);
     }
@@ -147,27 +118,28 @@ contract PolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorized(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, SENDER_SHIFT) && _checkRole(policyId, user, RECIP_SHIFT);
+        return _checkRole(policyId, user, PolicyDataLayout.SENDER_SHIFT)
+            && _checkRole(policyId, user, PolicyDataLayout.RECIP_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, SENDER_SHIFT);
+        return _checkRole(policyId, user, PolicyDataLayout.SENDER_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, RECIP_SHIFT);
+        return _checkRole(policyId, user, PolicyDataLayout.RECIP_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, MINT_SHIFT);
+        return _checkRole(policyId, user, PolicyDataLayout.MINT_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, REDEEM_SHIFT);
+        return _checkRole(policyId, user, PolicyDataLayout.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -186,8 +158,8 @@ contract PolicyRegistry is IPolicyRegistry {
         if (!_exists(policyId)) revert PolicyNotFound();
         if (policyId < FIRST_CUSTOM_ID) return (PolicyType.WHITELIST, address(0));
         uint256 packed = _policyData[policyId];
-        policyType = _decodeType(packed);
-        admin = policyType == PolicyType.COMPOUND ? address(0) : _decodeAdmin(packed);
+        policyType = packed.policyType();
+        admin = policyType == PolicyType.COMPOUND ? address(0) : packed.admin();
     }
 
     function compoundPolicyData(uint64 policyId)
@@ -196,15 +168,11 @@ contract PolicyRegistry is IPolicyRegistry {
         returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId, uint64 redeemerPolicyId)
     {
         uint256 packed = _requireExists(policyId);
-        if (_decodeType(packed) != PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        // forge-lint: disable-next-line(unsafe-typecast)
-        senderPolicyId = uint64((packed >> SENDER_SHIFT) & ID_MASK);
-        // forge-lint: disable-next-line(unsafe-typecast)
-        recipientPolicyId = uint64((packed >> RECIP_SHIFT) & ID_MASK);
-        // forge-lint: disable-next-line(unsafe-typecast)
-        mintRecipientPolicyId = uint64((packed >> MINT_SHIFT) & ID_MASK);
-        // forge-lint: disable-next-line(unsafe-typecast)
-        redeemerPolicyId = uint64((packed >> REDEEM_SHIFT) & ID_MASK);
+        if (packed.policyType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        senderPolicyId = packed.idAt(PolicyDataLayout.SENDER_SHIFT);
+        recipientPolicyId = packed.idAt(PolicyDataLayout.RECIP_SHIFT);
+        mintRecipientPolicyId = packed.idAt(PolicyDataLayout.MINT_SHIFT);
+        redeemerPolicyId = packed.idAt(PolicyDataLayout.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -219,7 +187,7 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
         if (admin == address(0)) revert ZeroAddress();
         newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
+        _policyData[newPolicyId] = PolicyDataLayout.encodeSimple(policyType, admin);
         emit PolicyCreated(newPolicyId, msg.sender, policyType);
         emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
     }
@@ -242,52 +210,29 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyId < FIRST_CUSTOM_ID) return;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
-        if (_decodeType(packed) == PolicyType.COMPOUND) revert PolicyNotSimple();
+        if (packed.policyType() == PolicyType.COMPOUND) revert PolicyNotSimple();
     }
 
-    function _encodeSimple(PolicyType policyType, address admin) internal pure returns (uint256) {
-        return uint256(policyType) | (uint256(uint160(admin)) << 8);
-    }
-
-    function _encodeCompound(uint64 sender, uint64 recipient, uint64 mintRecipient, uint64 redeemer)
-        internal
-        pure
-        returns (uint256)
-    {
-        return uint256(PolicyType.COMPOUND) | (uint256(sender) << SENDER_SHIFT) | (uint256(recipient) << RECIP_SHIFT)
-            | (uint256(mintRecipient) << MINT_SHIFT) | (uint256(redeemer) << REDEEM_SHIFT);
-    }
-
-    function _decodeType(uint256 packed) internal pure returns (PolicyType) {
-        return PolicyType(packed & TYPE_MASK);
-    }
-
-    function _decodeAdmin(uint256 packed) internal pure returns (address) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return address(uint160(packed >> 8));
-    }
-
-    // Resolves an authorization check for a single role slot. The roleShift selects
+    // Resolves an authorization check for a single role slot. The shift selects
     // which 62-bit field to read from a compound policy's packed slot.
     //
     // For a compound policyId:    1 SLOAD (compound slot) + 1 SLOAD (member set) = 2 SLOADs
     // For a simple policyId:      1 SLOAD (member set)                           = 1 SLOAD
     // For a built-in policyId:    0 SLOADs
-    function _checkRole(uint64 policyId, address user, uint256 roleShift) internal view returns (bool) {
+    function _checkRole(uint64 policyId, address user, uint256 shift) internal view returns (bool) {
         if (policyId == ALWAYS_REJECT_ID) return false;
         if (policyId == ALWAYS_ALLOW_ID) return true;
 
         uint256 packed = _policyData[policyId];
-        PolicyType pt = _decodeType(packed);
+        PolicyType pt = packed.policyType();
 
         uint64 effectiveId = policyId;
         if (pt == PolicyType.COMPOUND) {
-            // forge-lint: disable-next-line(unsafe-typecast)
-            effectiveId = uint64((packed >> roleShift) & ID_MASK);
+            effectiveId = packed.idAt(shift);
             if (effectiveId == ALWAYS_REJECT_ID) return false;
             if (effectiveId == ALWAYS_ALLOW_ID) return true;
             packed = _policyData[effectiveId];
-            pt = _decodeType(packed);
+            pt = packed.policyType();
         }
 
         return pt == PolicyType.WHITELIST ? _members[effectiveId][user] : !_members[effectiveId][user];

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -42,10 +42,12 @@ contract PolicyRegistry is IPolicyRegistry {
                            POLICY CREATION
     //////////////////////////////////////////////////////////////*/
 
+    /// @inheritdoc IPolicyRegistry
     function createPolicy(address admin, PolicyType policyType) external returns (uint64 newPolicyId) {
         newPolicyId = _createPolicy(admin, policyType);
     }
 
+    /// @inheritdoc IPolicyRegistry
     function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts)
         external
         returns (uint64 newPolicyId)
@@ -64,6 +66,7 @@ contract PolicyRegistry is IPolicyRegistry {
         }
     }
 
+    /// @inheritdoc IPolicyRegistry
     function createCompoundPolicy(
         uint64 senderPolicyId,
         uint64 recipientPolicyId,
@@ -86,16 +89,18 @@ contract PolicyRegistry is IPolicyRegistry {
                          POLICY ADMINISTRATION
     //////////////////////////////////////////////////////////////*/
 
+    /// @inheritdoc IPolicyRegistry
     function setPolicyAdmin(uint64 policyId, address newAdmin) external {
         if (newAdmin == address(0)) revert ZeroAddress();
         uint256 packed = _requireExists(policyId);
-        PolicyType pt = packed.decodeType();
-        if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        PolicyType policyType = packed.decodeType();
+        if (policyType == PolicyType.COMPOUND) revert IncompatiblePolicyType();
         if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
-        _policyData[policyId] = PolicySlot.encodeSimple(pt, newAdmin);
+        _policyData[policyId] = PolicySlot.encodeSimple(policyType, newAdmin);
         emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
     }
 
+    /// @inheritdoc IPolicyRegistry
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.WHITELIST) revert IncompatiblePolicyType();
@@ -104,6 +109,7 @@ contract PolicyRegistry is IPolicyRegistry {
         emit WhitelistUpdated(policyId, msg.sender, account, allowed);
     }
 
+    /// @inheritdoc IPolicyRegistry
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
@@ -119,7 +125,7 @@ contract PolicyRegistry is IPolicyRegistry {
     /// @inheritdoc IPolicyRegistry
     function isAuthorized(uint64 policyId, address user) external view returns (bool) {
         return _checkRole(policyId, user, PolicySlot.SENDER_SHIFT)
-            && _checkRole(policyId, user, PolicySlot.RECIP_SHIFT);
+            && _checkRole(policyId, user, PolicySlot.RECIPIENT_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
@@ -129,7 +135,7 @@ contract PolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicySlot.RECIP_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.RECIPIENT_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
@@ -146,22 +152,28 @@ contract PolicyRegistry is IPolicyRegistry {
                            POLICY QUERIES
     //////////////////////////////////////////////////////////////*/
 
+    /// @inheritdoc IPolicyRegistry
     function policyIdCounter() external view returns (uint64) {
         return _counter;
     }
 
+    /// @inheritdoc IPolicyRegistry
     function policyExists(uint64 policyId) external view returns (bool) {
         return _exists(policyId);
     }
 
+    /// @inheritdoc IPolicyRegistry
     function policyData(uint64 policyId) external view returns (PolicyType policyType, address admin) {
         if (!_exists(policyId)) revert PolicyNotFound();
+        // Built-ins have no stored slot; return WHITELIST as a conventional placeholder
+        // since the interface specifies the type is implementation-defined for IDs 0 and 1.
         if (policyId < FIRST_CUSTOM_ID) return (PolicyType.WHITELIST, address(0));
         uint256 packed = _policyData[policyId];
         policyType = packed.decodeType();
         admin = policyType == PolicyType.COMPOUND ? address(0) : packed.decodeAdmin();
     }
 
+    /// @inheritdoc IPolicyRegistry
     function compoundPolicyData(uint64 policyId)
         external
         view
@@ -170,7 +182,7 @@ contract PolicyRegistry is IPolicyRegistry {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
         senderPolicyId = packed.decodeIdAt(PolicySlot.SENDER_SHIFT);
-        recipientPolicyId = packed.decodeIdAt(PolicySlot.RECIP_SHIFT);
+        recipientPolicyId = packed.decodeIdAt(PolicySlot.RECIPIENT_SHIFT);
         mintRecipientPolicyId = packed.decodeIdAt(PolicySlot.MINT_SHIFT);
         redeemerPolicyId = packed.decodeIdAt(PolicySlot.REDEEM_SHIFT);
     }
@@ -224,17 +236,17 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyId == ALWAYS_ALLOW_ID) return true;
 
         uint256 packed = _policyData[policyId];
-        PolicyType pt = packed.decodeType();
+        PolicyType policyType = packed.decodeType();
 
-        uint64 effectiveId = policyId;
-        if (pt == PolicyType.COMPOUND) {
-            effectiveId = packed.decodeIdAt(shift);
-            if (effectiveId == ALWAYS_REJECT_ID) return false;
-            if (effectiveId == ALWAYS_ALLOW_ID) return true;
-            packed = _policyData[effectiveId];
-            pt = packed.decodeType();
+        if (policyType == PolicyType.COMPOUND) {
+            uint64 childId = packed.decodeIdAt(shift);
+            if (childId == ALWAYS_REJECT_ID) return false;
+            if (childId == ALWAYS_ALLOW_ID) return true;
+            packed = _policyData[childId];
+            policyType = packed.decodeType();
+            return policyType == PolicyType.WHITELIST ? _members[childId][user] : !_members[childId][user];
         }
 
-        return pt == PolicyType.WHITELIST ? _members[effectiveId][user] : !_members[effectiveId][user];
+        return policyType == PolicyType.WHITELIST ? _members[policyId][user] : !_members[policyId][user];
     }
 }

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -89,25 +89,25 @@ contract PolicyRegistry is IPolicyRegistry {
     function setPolicyAdmin(uint64 policyId, address newAdmin) external {
         if (newAdmin == address(0)) revert ZeroAddress();
         uint256 packed = _requireExists(policyId);
-        PolicyType pt = packed.policyType();
+        PolicyType pt = packed.decodeType();
         if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        if (packed.admin() != msg.sender) revert Unauthorized();
+        if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
         _policyData[policyId] = PolicySlot.encodeSimple(pt, newAdmin);
         emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
     }
 
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
         uint256 packed = _requireExists(policyId);
-        if (packed.policyType() != PolicyType.WHITELIST) revert IncompatiblePolicyType();
-        if (packed.admin() != msg.sender) revert Unauthorized();
+        if (packed.decodeType() != PolicyType.WHITELIST) revert IncompatiblePolicyType();
+        if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = allowed;
         emit WhitelistUpdated(policyId, msg.sender, account, allowed);
     }
 
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
         uint256 packed = _requireExists(policyId);
-        if (packed.policyType() != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
-        if (packed.admin() != msg.sender) revert Unauthorized();
+        if (packed.decodeType() != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
+        if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = restricted;
         emit BlacklistUpdated(policyId, msg.sender, account, restricted);
     }
@@ -158,8 +158,8 @@ contract PolicyRegistry is IPolicyRegistry {
         if (!_exists(policyId)) revert PolicyNotFound();
         if (policyId < FIRST_CUSTOM_ID) return (PolicyType.WHITELIST, address(0));
         uint256 packed = _policyData[policyId];
-        policyType = packed.policyType();
-        admin = policyType == PolicyType.COMPOUND ? address(0) : packed.admin();
+        policyType = packed.decodeType();
+        admin = policyType == PolicyType.COMPOUND ? address(0) : packed.decodeAdmin();
     }
 
     function compoundPolicyData(uint64 policyId)
@@ -168,11 +168,11 @@ contract PolicyRegistry is IPolicyRegistry {
         returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId, uint64 redeemerPolicyId)
     {
         uint256 packed = _requireExists(policyId);
-        if (packed.policyType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        senderPolicyId = packed.idAt(PolicySlot.SENDER_SHIFT);
-        recipientPolicyId = packed.idAt(PolicySlot.RECIP_SHIFT);
-        mintRecipientPolicyId = packed.idAt(PolicySlot.MINT_SHIFT);
-        redeemerPolicyId = packed.idAt(PolicySlot.REDEEM_SHIFT);
+        if (packed.decodeType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        senderPolicyId = packed.decodeIdAt(PolicySlot.SENDER_SHIFT);
+        recipientPolicyId = packed.decodeIdAt(PolicySlot.RECIP_SHIFT);
+        mintRecipientPolicyId = packed.decodeIdAt(PolicySlot.MINT_SHIFT);
+        redeemerPolicyId = packed.decodeIdAt(PolicySlot.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -210,7 +210,7 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyId < FIRST_CUSTOM_ID) return;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
-        if (packed.policyType() == PolicyType.COMPOUND) revert ConstituentIsCompound();
+        if (packed.decodeType() == PolicyType.COMPOUND) revert ConstituentIsCompound();
     }
 
     // Resolves an authorization check for a single role slot. The shift selects
@@ -224,15 +224,15 @@ contract PolicyRegistry is IPolicyRegistry {
         if (policyId == ALWAYS_ALLOW_ID) return true;
 
         uint256 packed = _policyData[policyId];
-        PolicyType pt = packed.policyType();
+        PolicyType pt = packed.decodeType();
 
         uint64 effectiveId = policyId;
         if (pt == PolicyType.COMPOUND) {
-            effectiveId = packed.idAt(shift);
+            effectiveId = packed.decodeIdAt(shift);
             if (effectiveId == ALWAYS_REJECT_ID) return false;
             if (effectiveId == ALWAYS_ALLOW_ID) return true;
             packed = _policyData[effectiveId];
-            pt = packed.policyType();
+            pt = packed.decodeType();
         }
 
         return pt == PolicyType.WHITELIST ? _members[effectiveId][user] : !_members[effectiveId][user];

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -48,7 +48,7 @@ contract PolicyRegistry is IPolicyRegistry {
     // BLACKLIST: member == true means the address is restricted.
     mapping(uint64 policyId => mapping(address account => bool)) private _members;
 
-    uint64 private _counter;
+    uint64 private _counter = FIRST_CUSTOM_ID;
 
     /*//////////////////////////////////////////////////////////////
                                CONSTANTS
@@ -68,36 +68,18 @@ contract PolicyRegistry is IPolicyRegistry {
     uint256 private constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
 
     /*//////////////////////////////////////////////////////////////
-                             CONSTRUCTOR
-    //////////////////////////////////////////////////////////////*/
-
-    constructor() {
-        _counter = FIRST_CUSTOM_ID;
-    }
-
-    /*//////////////////////////////////////////////////////////////
                            POLICY CREATION
     //////////////////////////////////////////////////////////////*/
 
     function createPolicy(address admin, PolicyType policyType) external returns (uint64 newPolicyId) {
-        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
-        if (admin == address(0)) revert ZeroAddress();
-        newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
-        emit PolicyCreated(newPolicyId, msg.sender, policyType);
-        emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
+        newPolicyId = _createSimple(admin, policyType);
     }
 
     function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts)
         external
         returns (uint64 newPolicyId)
     {
-        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
-        if (admin == address(0)) revert ZeroAddress();
-        newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
-        emit PolicyCreated(newPolicyId, msg.sender, policyType);
-        emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
+        newPolicyId = _createSimple(admin, policyType);
         bool isWhitelist = policyType == PolicyType.WHITELIST;
         mapping(address => bool) storage members = _members[newPolicyId];
         for (uint256 i = 0; i < accounts.length; ++i) {
@@ -135,7 +117,7 @@ contract PolicyRegistry is IPolicyRegistry {
 
     function setPolicyAdmin(uint64 policyId, address newAdmin) external {
         if (newAdmin == address(0)) revert ZeroAddress();
-        uint256 packed = _loadCustom(policyId);
+        uint256 packed = _requireExists(policyId);
         PolicyType pt = _decodeType(packed);
         if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
         if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
@@ -144,7 +126,7 @@ contract PolicyRegistry is IPolicyRegistry {
     }
 
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
-        uint256 packed = _loadCustom(policyId);
+        uint256 packed = _requireExists(policyId);
         if (_decodeType(packed) != PolicyType.WHITELIST) revert IncompatiblePolicyType();
         if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
         _members[policyId][account] = allowed;
@@ -152,7 +134,7 @@ contract PolicyRegistry is IPolicyRegistry {
     }
 
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
-        uint256 packed = _loadCustom(policyId);
+        uint256 packed = _requireExists(policyId);
         if (_decodeType(packed) != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
         if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
         _members[policyId][account] = restricted;
@@ -213,7 +195,7 @@ contract PolicyRegistry is IPolicyRegistry {
         view
         returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId, uint64 redeemerPolicyId)
     {
-        uint256 packed = _loadCustom(policyId);
+        uint256 packed = _requireExists(policyId);
         if (_decodeType(packed) != PolicyType.COMPOUND) revert IncompatiblePolicyType();
         // forge-lint: disable-next-line(unsafe-typecast)
         senderPolicyId = uint64((packed >> SENDER_SHIFT) & ID_MASK);
@@ -233,14 +215,22 @@ contract PolicyRegistry is IPolicyRegistry {
         id = _counter++;
     }
 
+    function _createSimple(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {
+        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
+        if (admin == address(0)) revert ZeroAddress();
+        newPolicyId = _nextPolicyId();
+        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
+        emit PolicyCreated(newPolicyId, msg.sender, policyType);
+        emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
+    }
+
     function _exists(uint64 policyId) internal view returns (bool) {
         return policyId < FIRST_CUSTOM_ID || _policyData[policyId] != 0;
     }
 
-    // Loads the packed slot for a custom policy ID, reverting if it does not exist.
-    // Built-in IDs (0, 1) are intentionally excluded: they have no mutable state
-    // and cannot be administered.
-    function _loadCustom(uint64 policyId) internal view returns (uint256 packed) {
+    // Loads and returns the packed slot for a custom policy ID, reverting if it does
+    // not exist. Built-in IDs (0, 1) are excluded: they have no mutable state.
+    function _requireExists(uint64 policyId) internal view returns (uint256 packed) {
         if (policyId < FIRST_CUSTOM_ID) revert PolicyNotFound();
         packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
+
+/// @title PolicyRegistry
+/// @notice Reference implementation of the IPolicyRegistry precompile interface.
+///
+/// @dev Storage layout
+/// -------------------
+/// Each policy occupies one 256-bit slot in `_policyData`. The low 8 bits are
+/// always the PolicyType discriminator; the remaining bits depend on the type:
+///
+///   WHITELIST / BLACKLIST:
+///     [255:168] unused
+///     [167:8]   admin address (160 bits)
+///     [7:0]     PolicyType
+///
+///   COMPOUND:
+///     [255:194] redeemerPolicyId      (62 bits)
+///     [193:132] mintRecipientPolicyId (62 bits)
+///     [131:70]  recipientPolicyId     (62 bits)
+///     [69:8]    senderPolicyId        (62 bits)
+///     [7:0]     PolicyType = 2
+///
+/// Compound constituent IDs are stored as 62 bits rather than 64. This lets the
+/// type byte plus all four IDs fit in exactly one 256-bit slot (8 + 4*62 = 256).
+/// Policy IDs are uint64 in the interface but packed as 62 bits in compound slots.
+/// _policyIdCounter would need to reach 2^62 (~4.6e18) for truncation to occur,
+/// which is not practically possible.
+///
+/// Existence sentinel: `_policyData[id] == 0` means the policy was never created.
+/// This is safe because WHITELIST/BLACKLIST require a non-zero admin (so packed
+/// is never zero), and COMPOUND always has type byte = 2 (so packed is never zero).
+///
+/// Authorization cost: at most 2 SLOADs for any policy. For a compound policy,
+/// one SLOAD reads the packed slot (yielding all four constituent IDs), and one
+/// SLOAD reads the relevant constituent's member set. Compound constituents cannot
+/// themselves be COMPOUND (enforced at creation), so evaluation never goes deeper.
+contract PolicyRegistry is IPolicyRegistry {
+    /*//////////////////////////////////////////////////////////////
+                                 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    mapping(uint64 policyId => uint256 packed) private _policyData;
+
+    // WHITELIST: member == true means the address is allowed.
+    // BLACKLIST: member == true means the address is restricted.
+    mapping(uint64 policyId => mapping(address account => bool)) private _members;
+
+    uint64 private _counter;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    uint64 private constant ALWAYS_REJECT_ID = 0;
+    uint64 private constant ALWAYS_ALLOW_ID = 1;
+    uint64 private constant FIRST_CUSTOM_ID = 2;
+
+    uint256 private constant TYPE_MASK = 0xFF;
+    uint256 private constant ID_BITS = 62;
+    uint256 private constant ID_MASK = (uint256(1) << ID_BITS) - 1;
+
+    uint256 private constant SENDER_SHIFT = 8;
+    uint256 private constant RECIP_SHIFT = SENDER_SHIFT + ID_BITS; // 70
+    uint256 private constant MINT_SHIFT = RECIP_SHIFT + ID_BITS; // 132
+    uint256 private constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
+
+    /*//////////////////////////////////////////////////////////////
+                             CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor() {
+        _counter = FIRST_CUSTOM_ID;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           POLICY CREATION
+    //////////////////////////////////////////////////////////////*/
+
+    function createPolicy(address admin, PolicyType policyType) external returns (uint64 newPolicyId) {
+        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
+        if (admin == address(0)) revert ZeroAddress();
+        newPolicyId = _nextPolicyId();
+        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
+        emit PolicyCreated(newPolicyId, msg.sender, policyType);
+        emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
+    }
+
+    function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts)
+        external
+        returns (uint64 newPolicyId)
+    {
+        if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
+        if (admin == address(0)) revert ZeroAddress();
+        newPolicyId = _nextPolicyId();
+        _policyData[newPolicyId] = _encodeSimple(policyType, admin);
+        emit PolicyCreated(newPolicyId, msg.sender, policyType);
+        emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
+        bool isWhitelist = policyType == PolicyType.WHITELIST;
+        mapping(address => bool) storage members = _members[newPolicyId];
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            address account = accounts[i];
+            members[account] = true;
+            if (isWhitelist) {
+                emit WhitelistUpdated(newPolicyId, msg.sender, account, true);
+            } else {
+                emit BlacklistUpdated(newPolicyId, msg.sender, account, true);
+            }
+        }
+    }
+
+    function createCompoundPolicy(
+        uint64 senderPolicyId,
+        uint64 recipientPolicyId,
+        uint64 mintRecipientPolicyId,
+        uint64 redeemerPolicyId
+    ) external returns (uint64 newPolicyId) {
+        _requireSimpleConstituent(senderPolicyId);
+        _requireSimpleConstituent(recipientPolicyId);
+        _requireSimpleConstituent(mintRecipientPolicyId);
+        _requireSimpleConstituent(redeemerPolicyId);
+        newPolicyId = _nextPolicyId();
+        _policyData[newPolicyId] =
+            _encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
+        emit CompoundPolicyCreated(
+            newPolicyId, msg.sender, senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         POLICY ADMINISTRATION
+    //////////////////////////////////////////////////////////////*/
+
+    function setPolicyAdmin(uint64 policyId, address newAdmin) external {
+        if (newAdmin == address(0)) revert ZeroAddress();
+        uint256 packed = _loadCustom(policyId);
+        PolicyType pt = _decodeType(packed);
+        if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
+        _policyData[policyId] = _encodeSimple(pt, newAdmin);
+        emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
+    }
+
+    function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
+        uint256 packed = _loadCustom(policyId);
+        if (_decodeType(packed) != PolicyType.WHITELIST) revert IncompatiblePolicyType();
+        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
+        _members[policyId][account] = allowed;
+        emit WhitelistUpdated(policyId, msg.sender, account, allowed);
+    }
+
+    function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
+        uint256 packed = _loadCustom(policyId);
+        if (_decodeType(packed) != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
+        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
+        _members[policyId][account] = restricted;
+        emit BlacklistUpdated(policyId, msg.sender, account, restricted);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        AUTHORIZATION QUERIES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IPolicyRegistry
+    function isAuthorized(uint64 policyId, address user) external view returns (bool) {
+        return _checkRole(policyId, user, SENDER_SHIFT) && _checkRole(policyId, user, RECIP_SHIFT);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
+        return _checkRole(policyId, user, SENDER_SHIFT);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
+        return _checkRole(policyId, user, RECIP_SHIFT);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
+        return _checkRole(policyId, user, MINT_SHIFT);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool) {
+        return _checkRole(policyId, user, REDEEM_SHIFT);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           POLICY QUERIES
+    //////////////////////////////////////////////////////////////*/
+
+    function policyIdCounter() external view returns (uint64) {
+        return _counter;
+    }
+
+    function policyExists(uint64 policyId) external view returns (bool) {
+        return _exists(policyId);
+    }
+
+    function policyData(uint64 policyId) external view returns (PolicyType policyType, address admin) {
+        if (!_exists(policyId)) revert PolicyNotFound();
+        if (policyId < FIRST_CUSTOM_ID) return (PolicyType.WHITELIST, address(0));
+        uint256 packed = _policyData[policyId];
+        policyType = _decodeType(packed);
+        admin = policyType == PolicyType.COMPOUND ? address(0) : _decodeAdmin(packed);
+    }
+
+    function compoundPolicyData(uint64 policyId)
+        external
+        view
+        returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId, uint64 redeemerPolicyId)
+    {
+        uint256 packed = _loadCustom(policyId);
+        if (_decodeType(packed) != PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        // forge-lint: disable-next-line(unsafe-typecast)
+        senderPolicyId = uint64((packed >> SENDER_SHIFT) & ID_MASK);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        recipientPolicyId = uint64((packed >> RECIP_SHIFT) & ID_MASK);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        mintRecipientPolicyId = uint64((packed >> MINT_SHIFT) & ID_MASK);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        redeemerPolicyId = uint64((packed >> REDEEM_SHIFT) & ID_MASK);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          INTERNAL HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _nextPolicyId() internal returns (uint64 id) {
+        id = _counter++;
+    }
+
+    function _exists(uint64 policyId) internal view returns (bool) {
+        return policyId < FIRST_CUSTOM_ID || _policyData[policyId] != 0;
+    }
+
+    // Loads the packed slot for a custom policy ID, reverting if it does not exist.
+    // Built-in IDs (0, 1) are intentionally excluded: they have no mutable state
+    // and cannot be administered.
+    function _loadCustom(uint64 policyId) internal view returns (uint256 packed) {
+        if (policyId < FIRST_CUSTOM_ID) revert PolicyNotFound();
+        packed = _policyData[policyId];
+        if (packed == 0) revert PolicyNotFound();
+    }
+
+    // Validates that policyId is a legal compound constituent: must exist and must
+    // not itself be COMPOUND. Built-in IDs 0 and 1 are always valid.
+    function _requireSimpleConstituent(uint64 policyId) internal view {
+        if (policyId < FIRST_CUSTOM_ID) return;
+        uint256 packed = _policyData[policyId];
+        if (packed == 0) revert PolicyNotFound();
+        if (_decodeType(packed) == PolicyType.COMPOUND) revert PolicyNotSimple();
+    }
+
+    function _encodeSimple(PolicyType policyType, address admin) internal pure returns (uint256) {
+        return uint256(policyType) | (uint256(uint160(admin)) << 8);
+    }
+
+    function _encodeCompound(uint64 sender, uint64 recipient, uint64 mintRecipient, uint64 redeemer)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(PolicyType.COMPOUND) | (uint256(sender) << SENDER_SHIFT) | (uint256(recipient) << RECIP_SHIFT)
+            | (uint256(mintRecipient) << MINT_SHIFT) | (uint256(redeemer) << REDEEM_SHIFT);
+    }
+
+    function _decodeType(uint256 packed) internal pure returns (PolicyType) {
+        return PolicyType(packed & TYPE_MASK);
+    }
+
+    function _decodeAdmin(uint256 packed) internal pure returns (address) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return address(uint160(packed >> 8));
+    }
+
+    // Resolves an authorization check for a single role slot. The roleShift selects
+    // which 62-bit field to read from a compound policy's packed slot.
+    //
+    // For a compound policyId:    1 SLOAD (compound slot) + 1 SLOAD (member set) = 2 SLOADs
+    // For a simple policyId:      1 SLOAD (member set)                           = 1 SLOAD
+    // For a built-in policyId:    0 SLOADs
+    function _checkRole(uint64 policyId, address user, uint256 roleShift) internal view returns (bool) {
+        if (policyId == ALWAYS_REJECT_ID) return false;
+        if (policyId == ALWAYS_ALLOW_ID) return true;
+
+        uint256 packed = _policyData[policyId];
+        PolicyType pt = _decodeType(packed);
+
+        uint64 effectiveId = policyId;
+        if (pt == PolicyType.COMPOUND) {
+            // forge-lint: disable-next-line(unsafe-typecast)
+            effectiveId = uint64((packed >> roleShift) & ID_MASK);
+            if (effectiveId == ALWAYS_REJECT_ID) return false;
+            if (effectiveId == ALWAYS_ALLOW_ID) return true;
+            packed = _policyData[effectiveId];
+            pt = _decodeType(packed);
+        }
+
+        return pt == PolicyType.WHITELIST ? _members[effectiveId][user] : !_members[effectiveId][user];
+    }
+}

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.20 <0.9.0;
 
 import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
-import {PolicyDataLayout} from "./PolicyDataLayout.sol";
+import {PolicySlot} from "./PolicySlot.sol";
 
 /// @title PolicyRegistry
 /// @notice Implementation of the IPolicyRegistry precompile interface.
@@ -16,7 +16,7 @@ import {PolicyDataLayout} from "./PolicyDataLayout.sol";
 ///      reads the relevant child's member set. Compound children cannot themselves be
 ///      COMPOUND (enforced at creation), so evaluation never goes deeper.
 contract PolicyRegistry is IPolicyRegistry {
-    using PolicyDataLayout for uint256;
+    using PolicySlot for uint256;
 
     /*//////////////////////////////////////////////////////////////
                                  STORAGE
@@ -43,14 +43,14 @@ contract PolicyRegistry is IPolicyRegistry {
     //////////////////////////////////////////////////////////////*/
 
     function createPolicy(address admin, PolicyType policyType) external returns (uint64 newPolicyId) {
-        newPolicyId = _createSimple(admin, policyType);
+        newPolicyId = _createPolicy(admin, policyType);
     }
 
     function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts)
         external
         returns (uint64 newPolicyId)
     {
-        newPolicyId = _createSimple(admin, policyType);
+        newPolicyId = _createPolicy(admin, policyType);
         bool isWhitelist = policyType == PolicyType.WHITELIST;
         mapping(address => bool) storage members = _members[newPolicyId];
         for (uint256 i = 0; i < accounts.length; ++i) {
@@ -70,13 +70,13 @@ contract PolicyRegistry is IPolicyRegistry {
         uint64 mintRecipientPolicyId,
         uint64 redeemerPolicyId
     ) external returns (uint64 newPolicyId) {
-        _requireSimpleConstituent(senderPolicyId);
-        _requireSimpleConstituent(recipientPolicyId);
-        _requireSimpleConstituent(mintRecipientPolicyId);
-        _requireSimpleConstituent(redeemerPolicyId);
+        _requireConstituent(senderPolicyId);
+        _requireConstituent(recipientPolicyId);
+        _requireConstituent(mintRecipientPolicyId);
+        _requireConstituent(redeemerPolicyId);
         newPolicyId = _nextPolicyId();
         _policyData[newPolicyId] =
-            PolicyDataLayout.encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
+            PolicySlot.encodeCompound(senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId);
         emit CompoundPolicyCreated(
             newPolicyId, msg.sender, senderPolicyId, recipientPolicyId, mintRecipientPolicyId, redeemerPolicyId
         );
@@ -92,7 +92,7 @@ contract PolicyRegistry is IPolicyRegistry {
         PolicyType pt = packed.policyType();
         if (pt == PolicyType.COMPOUND) revert IncompatiblePolicyType();
         if (packed.admin() != msg.sender) revert Unauthorized();
-        _policyData[policyId] = PolicyDataLayout.encodeSimple(pt, newAdmin);
+        _policyData[policyId] = PolicySlot.encodeSimple(pt, newAdmin);
         emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
     }
 
@@ -118,28 +118,28 @@ contract PolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorized(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicyDataLayout.SENDER_SHIFT)
-            && _checkRole(policyId, user, PolicyDataLayout.RECIP_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.SENDER_SHIFT)
+            && _checkRole(policyId, user, PolicySlot.RECIP_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicyDataLayout.SENDER_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.SENDER_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicyDataLayout.RECIP_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.RECIP_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicyDataLayout.MINT_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.MINT_SHIFT);
     }
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool) {
-        return _checkRole(policyId, user, PolicyDataLayout.REDEEM_SHIFT);
+        return _checkRole(policyId, user, PolicySlot.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -169,10 +169,10 @@ contract PolicyRegistry is IPolicyRegistry {
     {
         uint256 packed = _requireExists(policyId);
         if (packed.policyType() != PolicyType.COMPOUND) revert IncompatiblePolicyType();
-        senderPolicyId = packed.idAt(PolicyDataLayout.SENDER_SHIFT);
-        recipientPolicyId = packed.idAt(PolicyDataLayout.RECIP_SHIFT);
-        mintRecipientPolicyId = packed.idAt(PolicyDataLayout.MINT_SHIFT);
-        redeemerPolicyId = packed.idAt(PolicyDataLayout.REDEEM_SHIFT);
+        senderPolicyId = packed.idAt(PolicySlot.SENDER_SHIFT);
+        recipientPolicyId = packed.idAt(PolicySlot.RECIP_SHIFT);
+        mintRecipientPolicyId = packed.idAt(PolicySlot.MINT_SHIFT);
+        redeemerPolicyId = packed.idAt(PolicySlot.REDEEM_SHIFT);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -183,11 +183,11 @@ contract PolicyRegistry is IPolicyRegistry {
         id = _counter++;
     }
 
-    function _createSimple(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {
+    function _createPolicy(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {
         if (policyType != PolicyType.WHITELIST && policyType != PolicyType.BLACKLIST) revert InvalidPolicyType();
         if (admin == address(0)) revert ZeroAddress();
         newPolicyId = _nextPolicyId();
-        _policyData[newPolicyId] = PolicyDataLayout.encodeSimple(policyType, admin);
+        _policyData[newPolicyId] = PolicySlot.encodeSimple(policyType, admin);
         emit PolicyCreated(newPolicyId, msg.sender, policyType);
         emit PolicyAdminUpdated(newPolicyId, msg.sender, admin);
     }
@@ -204,13 +204,13 @@ contract PolicyRegistry is IPolicyRegistry {
         if (packed == 0) revert PolicyNotFound();
     }
 
-    // Validates that policyId is a legal compound constituent: must exist and must
-    // not itself be COMPOUND. Built-in IDs 0 and 1 are always valid.
-    function _requireSimpleConstituent(uint64 policyId) internal view {
+    // Validates that policyId is a legal compound child: must exist and must not
+    // itself be COMPOUND. Built-in IDs 0 and 1 are always valid.
+    function _requireConstituent(uint64 policyId) internal view {
         if (policyId < FIRST_CUSTOM_ID) return;
         uint256 packed = _policyData[policyId];
         if (packed == 0) revert PolicyNotFound();
-        if (packed.policyType() == PolicyType.COMPOUND) revert PolicyNotSimple();
+        if (packed.policyType() == PolicyType.COMPOUND) revert ConstituentIsCompound();
     }
 
     // Resolves an authorization check for a single role slot. The shift selects

--- a/src/impls/PolicyRegistry.sol
+++ b/src/impls/PolicyRegistry.sol
@@ -30,6 +30,12 @@ contract PolicyRegistry is IPolicyRegistry {
     // BLACKLIST: member == true means the address is restricted.
     mapping(uint64 policyId => mapping(address account => bool)) private _members;
 
+    // Pending admin per policy. Set by beginPolicyAdminTransfer, cleared on
+    // accept/cancel/freeze. Kept in its own mapping (rather than packed into the
+    // policy slot) so the hot-path read on _policyData stays minimal; admin
+    // rotation is a cold path and the extra SLOAD on accept is acceptable.
+    mapping(uint64 policyId => address pendingAdmin) private _pendingAdmins;
+
     uint64 private _counter = FIRST_USER_POLICY_ID;
 
     /*//////////////////////////////////////////////////////////////
@@ -98,20 +104,67 @@ contract PolicyRegistry is IPolicyRegistry {
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc IPolicyRegistry
-    function setPolicyAdmin(uint64 policyId, address newAdmin) external {
-        if (newAdmin == address(0)) revert ZeroAddress();
+    function beginPolicyAdminTransfer(uint64 policyId, address newAdmin) external {
+        // Permitting newAdmin == address(0) here is intentional: it lets the current
+        // admin cancel a prior nomination via the same entry point. The pending slot
+        // is just a nomination; the active admin doesn't change until accept.
+        uint256 packed = _requireExists(policyId);
+        PolicyType policyType = packed.decodeType();
+        if (policyType == PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        if (packed.decodeFrozen()) revert PolicyFrozen();
+        if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
+        _pendingAdmins[policyId] = newAdmin;
+        emit PolicyAdminTransferBegun(policyId, msg.sender, newAdmin);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function acceptPolicyAdminTransfer(uint64 policyId) external {
+        uint256 packed = _requireExists(policyId);
+        PolicyType policyType = packed.decodeType();
+        if (policyType == PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        if (packed.decodeFrozen()) revert PolicyFrozen();
+        address pending = _pendingAdmins[policyId];
+        if (pending != msg.sender) revert NotPendingAdmin();
+        // Preserve the frozen bit on rotation. Currently unreachable because the
+        // freeze check above short-circuits, but coded defensively in case the
+        // freeze semantics evolve (e.g. allowing rotation while frozen).
+        _policyData[policyId] = PolicySlot.encodeSimple(policyType, msg.sender)
+            | (packed.decodeFrozen() ? PolicySlot.FROZEN_BIT : 0);
+        delete _pendingAdmins[policyId];
+        emit PolicyAdminUpdated(policyId, msg.sender, msg.sender);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function cancelPolicyAdminTransfer(uint64 policyId) external {
         uint256 packed = _requireExists(policyId);
         PolicyType policyType = packed.decodeType();
         if (policyType == PolicyType.COMPOUND) revert IncompatiblePolicyType();
         if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
-        _policyData[policyId] = PolicySlot.encodeSimple(policyType, newAdmin);
-        emit PolicyAdminUpdated(policyId, msg.sender, newAdmin);
+        address pending = _pendingAdmins[policyId];
+        if (pending == address(0)) revert NoTransferPending();
+        delete _pendingAdmins[policyId];
+        emit PolicyAdminTransferCancelled(policyId, msg.sender, pending);
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function freezePolicy(uint64 policyId) external {
+        uint256 packed = _requireExists(policyId);
+        PolicyType policyType = packed.decodeType();
+        if (policyType == PolicyType.COMPOUND) revert IncompatiblePolicyType();
+        if (packed.decodeFrozen()) revert PolicyFrozen();
+        if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
+        _policyData[policyId] = packed | PolicySlot.FROZEN_BIT;
+        // Any in-flight nomination is moot once frozen; clear it so the post-freeze
+        // state is unambiguous (no zombie pending admin lingering in storage).
+        if (_pendingAdmins[policyId] != address(0)) delete _pendingAdmins[policyId];
+        emit PolicyFrozenEvent(policyId, msg.sender);
     }
 
     /// @inheritdoc IPolicyRegistry
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.WHITELIST) revert IncompatiblePolicyType();
+        if (packed.decodeFrozen()) revert PolicyFrozen();
         if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = allowed;
         emit WhitelistUpdated(policyId, msg.sender, account, allowed);
@@ -121,6 +174,7 @@ contract PolicyRegistry is IPolicyRegistry {
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external {
         uint256 packed = _requireExists(policyId);
         if (packed.decodeType() != PolicyType.BLACKLIST) revert IncompatiblePolicyType();
+        if (packed.decodeFrozen()) revert PolicyFrozen();
         if (packed.decodeAdmin() != msg.sender) revert Unauthorized();
         _members[policyId][account] = restricted;
         emit BlacklistUpdated(policyId, msg.sender, account, restricted);
@@ -178,6 +232,20 @@ contract PolicyRegistry is IPolicyRegistry {
         uint256 packed = _policyData[policyId];
         policyType = packed.decodeType();
         admin = policyType == PolicyType.COMPOUND ? address(0) : packed.decodeAdmin();
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function pendingPolicyAdmin(uint64 policyId) external view returns (address) {
+        return _pendingAdmins[policyId];
+    }
+
+    /// @inheritdoc IPolicyRegistry
+    function isPolicyFrozen(uint64 policyId) external view returns (bool) {
+        if (policyId < FIRST_USER_POLICY_ID) return false;
+        uint256 packed = _policyData[policyId];
+        if (packed == 0) return false;
+        if (packed.decodeType() == PolicyType.COMPOUND) return false;
+        return packed.decodeFrozen();
     }
 
     /// @inheritdoc IPolicyRegistry

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.20 <0.9.0;
 
 import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 
-/// @title PolicyDataLayout
+/// @title PolicySlot
 /// @notice Internal library for encoding and decoding packed policy storage slots.
 ///
 /// @dev Each policy is stored as a single uint256. The low 8 bits are always the
@@ -29,7 +29,7 @@ import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 ///
 ///      All functions are internal so they are inlined at compile time with no
 ///      runtime overhead.
-library PolicyDataLayout {
+library PolicySlot {
     uint256 internal constant TYPE_MASK = 0xFF;
     uint256 internal constant ID_BITS = 62;
     uint256 internal constant ID_MASK = (uint256(1) << ID_BITS) - 1;

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -39,8 +39,8 @@ library PolicySlot {
     uint256 internal constant MINT_SHIFT = RECIP_SHIFT + ID_BITS; // 132
     uint256 internal constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
 
-    function encodeSimple(IPolicyRegistry.PolicyType pt, address adm) internal pure returns (uint256) {
-        return uint256(pt) | (uint256(uint160(adm)) << 8);
+    function encodeSimple(IPolicyRegistry.PolicyType policyType, address policyAdmin) internal pure returns (uint256) {
+        return uint256(policyType) | (uint256(uint160(policyAdmin)) << 8);
     }
 
     function encodeCompound(uint64 sender, uint64 recipient, uint64 mintRecipient, uint64 redeemer)
@@ -53,17 +53,17 @@ library PolicySlot {
             | (uint256(redeemer) << REDEEM_SHIFT);
     }
 
-    function policyType(uint256 packed) internal pure returns (IPolicyRegistry.PolicyType) {
+    function decodeType(uint256 packed) internal pure returns (IPolicyRegistry.PolicyType) {
         return IPolicyRegistry.PolicyType(packed & TYPE_MASK);
     }
 
-    function admin(uint256 packed) internal pure returns (address) {
+    function decodeAdmin(uint256 packed) internal pure returns (address) {
         // forge-lint: disable-next-line(unsafe-typecast)
         return address(uint160(packed >> 8));
     }
 
     // Extracts the child policy ID at the given shift offset.
-    function idAt(uint256 packed, uint256 shift) internal pure returns (uint64) {
+    function decodeIdAt(uint256 packed, uint256 shift) internal pure returns (uint64) {
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint64((packed >> shift) & ID_MASK);
     }

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.20 <0.9.0;
+pragma solidity ^0.8.20;
 
 import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 
 /// @title PolicySlot
 /// @notice Internal library for encoding and decoding packed policy storage slots.
+/// @author Coinbase
 ///
 /// @dev Each policy is stored as a single uint256. The low 8 bits are always the
 ///      PolicyType discriminator; the remaining bits depend on the type:

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -21,7 +21,7 @@ import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 ///          [69:8]    senderPolicyId        (62 bits)
 ///          [7:0]     PolicyType = 2
 ///
-///      Child policy IDs are stored as 62 bits rather than 64. This lets the type
+///      Constituent policy IDs are stored as 62 bits rather than 64. This lets the type
 ///      byte plus all four IDs fit in exactly one 256-bit slot (8 + 4*62 = 256).
 ///      Policy IDs are uint64 in the interface but packed as 62 bits in compound slots.
 ///      _policyIdCounter would need to reach 2^62 (~4.6e18) for truncation to occur,
@@ -62,7 +62,7 @@ library PolicySlot {
         return address(uint160(packed >> 8));
     }
 
-    // Extracts the child policy ID at the given shift offset.
+    // Extracts the constituent policy ID at the given shift offset.
     function decodeIdAt(uint256 packed, uint256 shift) internal pure returns (uint64) {
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint64((packed >> shift) & ID_MASK);

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -10,47 +10,73 @@ import {IPolicyRegistry} from "../interfaces/IPolicyRegistry.sol";
 ///      PolicyType discriminator; the remaining bits depend on the type:
 ///
 ///        WHITELIST / BLACKLIST:
-///          [255:168] unused
+///          [255:169] unused
+///          [168]     frozen flag (1 = policy is permanently immutable)
 ///          [167:8]   admin address (160 bits)
 ///          [7:0]     PolicyType
 ///
 ///        COMPOUND:
-///          [255:194] redeemerPolicyId      (62 bits)
-///          [193:132] mintRecipientPolicyId (62 bits)
-///          [131:70]  recipientPolicyId     (62 bits)
-///          [69:8]    senderPolicyId        (62 bits)
+///          [255:194] redeemerField      (62 bits = 1 type bit + 61 ID bits)
+///          [193:132] mintRecipientField (62 bits)
+///          [131:70]  recipientField     (62 bits)
+///          [69:8]    senderField        (62 bits)
 ///          [7:0]     PolicyType = 2
 ///
-///      Constituent policy IDs are stored as 62 bits rather than 64. This lets the type
-///      byte plus all four IDs fit in exactly one 256-bit slot (8 + 4*62 = 256).
-///      Policy IDs are uint64 in the interface but packed as 62 bits in compound slots.
-///      _policyIdCounter would need to reach 2^62 (~4.6e18) for truncation to occur,
-///      which is not practically possible.
+///      Each constituent field carries both the constituent policy ID (61 bits)
+///      and a single type bit (0 = WHITELIST or built-in, 1 = BLACKLIST) so that
+///      `isAuthorized*` evaluation needs at most one SLOAD to read the compound
+///      slot plus one SLOAD to read the relevant constituent's member set — the
+///      constituent's policy slot does NOT need to be loaded on the hot path.
+///      The type bit is meaningless for built-in constituents (IDs 0 and 1)
+///      because evaluation short-circuits on ID before consulting type.
+///
+///      Constituent policy IDs are stored as 61 bits. The contract bounds the
+///      policy ID counter to never exceed `ID_MASK` so this truncation is
+///      structurally impossible.
 ///
 ///      All functions are internal so they are inlined at compile time with no
 ///      runtime overhead.
 library PolicySlot {
     uint256 internal constant TYPE_MASK = 0xFF;
-    uint256 internal constant ID_BITS = 62;
+
+    // Simple-policy layout.
+    uint256 internal constant ADMIN_SHIFT = 8;
+    uint256 internal constant FROZEN_SHIFT = 168;
+    uint256 internal constant FROZEN_BIT = uint256(1) << FROZEN_SHIFT;
+
+    // Compound-policy layout.
+    uint256 internal constant ID_BITS = 61;
     uint256 internal constant ID_MASK = (uint256(1) << ID_BITS) - 1;
+    uint256 internal constant FIELD_BITS = 62; // 1 type bit + 61 ID bits
+    uint256 internal constant FIELD_MASK = (uint256(1) << FIELD_BITS) - 1;
+    uint256 internal constant TYPE_BIT_OFFSET = ID_BITS; // type bit sits above the 61-bit ID
+    uint256 internal constant TYPE_BIT = uint256(1) << TYPE_BIT_OFFSET;
 
     uint256 internal constant SENDER_SHIFT = 8;
-    uint256 internal constant RECIPIENT_SHIFT = SENDER_SHIFT + ID_BITS; // 70
-    uint256 internal constant MINT_SHIFT = RECIPIENT_SHIFT + ID_BITS; // 132
-    uint256 internal constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
+    uint256 internal constant RECIPIENT_SHIFT = SENDER_SHIFT + FIELD_BITS; // 70
+    uint256 internal constant MINT_SHIFT = RECIPIENT_SHIFT + FIELD_BITS; // 132
+    uint256 internal constant REDEEM_SHIFT = MINT_SHIFT + FIELD_BITS; // 194
 
     function encodeSimple(IPolicyRegistry.PolicyType policyType, address policyAdmin) internal pure returns (uint256) {
-        return uint256(policyType) | (uint256(uint160(policyAdmin)) << 8);
+        return uint256(policyType) | (uint256(uint160(policyAdmin)) << ADMIN_SHIFT);
     }
 
-    function encodeCompound(uint64 sender, uint64 recipient, uint64 mintRecipient, uint64 redeemer)
+    /// @dev Packs a constituent (policy ID + type bit) into a single 62-bit field.
+    ///      Built-in IDs (0, 1) can be passed with any `constituentType`; the type
+    ///      bit is ignored at decode time for built-ins.
+    function encodeField(uint64 id, IPolicyRegistry.PolicyType constituentType) internal pure returns (uint256) {
+        uint256 typeBit = constituentType == IPolicyRegistry.PolicyType.BLACKLIST ? uint256(1) : uint256(0);
+        return uint256(id) | (typeBit << TYPE_BIT_OFFSET);
+    }
+
+    /// @dev Composes a full compound-policy slot from four pre-encoded constituent fields.
+    function encodeCompound(uint256 senderField, uint256 recipientField, uint256 mintField, uint256 redeemerField)
         internal
         pure
         returns (uint256)
     {
-        return uint256(IPolicyRegistry.PolicyType.COMPOUND) | (uint256(sender) << SENDER_SHIFT)
-            | (uint256(recipient) << RECIPIENT_SHIFT) | (uint256(mintRecipient) << MINT_SHIFT)
-            | (uint256(redeemer) << REDEEM_SHIFT);
+        return uint256(IPolicyRegistry.PolicyType.COMPOUND) | (senderField << SENDER_SHIFT)
+            | (recipientField << RECIPIENT_SHIFT) | (mintField << MINT_SHIFT) | (redeemerField << REDEEM_SHIFT);
     }
 
     function decodeType(uint256 packed) internal pure returns (IPolicyRegistry.PolicyType) {
@@ -59,12 +85,27 @@ library PolicySlot {
 
     function decodeAdmin(uint256 packed) internal pure returns (address) {
         // forge-lint: disable-next-line(unsafe-typecast)
-        return address(uint160(packed >> 8));
+        return address(uint160(packed >> ADMIN_SHIFT));
     }
 
-    // Extracts the constituent policy ID at the given shift offset.
-    function decodeIdAt(uint256 packed, uint256 shift) internal pure returns (uint64) {
+    function decodeFrozen(uint256 packed) internal pure returns (bool) {
+        return (packed & FROZEN_BIT) != 0;
+    }
+
+    /// @dev Extracts the constituent policy ID at the given shift offset.
+    ///      Used by view functions that only care about the ID, not the type.
+    function decodeId(uint256 packed, uint256 shift) internal pure returns (uint64) {
         // forge-lint: disable-next-line(unsafe-typecast)
         return uint64((packed >> shift) & ID_MASK);
+    }
+
+    /// @dev Extracts the constituent policy ID and type bit in one operation.
+    ///      Used on the authorization hot path so the constituent's own policy slot
+    ///      does not need to be loaded.
+    function decodeField(uint256 packed, uint256 shift) internal pure returns (uint64 id, bool isBlacklist) {
+        uint256 field = (packed >> shift) & FIELD_MASK;
+        // forge-lint: disable-next-line(unsafe-typecast)
+        id = uint64(field & ID_MASK);
+        isBlacklist = (field & TYPE_BIT) != 0;
     }
 }

--- a/src/impls/PolicySlot.sol
+++ b/src/impls/PolicySlot.sol
@@ -35,8 +35,8 @@ library PolicySlot {
     uint256 internal constant ID_MASK = (uint256(1) << ID_BITS) - 1;
 
     uint256 internal constant SENDER_SHIFT = 8;
-    uint256 internal constant RECIP_SHIFT = SENDER_SHIFT + ID_BITS; // 70
-    uint256 internal constant MINT_SHIFT = RECIP_SHIFT + ID_BITS; // 132
+    uint256 internal constant RECIPIENT_SHIFT = SENDER_SHIFT + ID_BITS; // 70
+    uint256 internal constant MINT_SHIFT = RECIPIENT_SHIFT + ID_BITS; // 132
     uint256 internal constant REDEEM_SHIFT = MINT_SHIFT + ID_BITS; // 194
 
     function encodeSimple(IPolicyRegistry.PolicyType policyType, address policyAdmin) internal pure returns (uint256) {
@@ -49,7 +49,7 @@ library PolicySlot {
         returns (uint256)
     {
         return uint256(IPolicyRegistry.PolicyType.COMPOUND) | (uint256(sender) << SENDER_SHIFT)
-            | (uint256(recipient) << RECIP_SHIFT) | (uint256(mintRecipient) << MINT_SHIFT)
+            | (uint256(recipient) << RECIPIENT_SHIFT) | (uint256(mintRecipient) << MINT_SHIFT)
             | (uint256(redeemer) << REDEEM_SHIFT);
     }
 

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.20 <0.9.0;
+pragma solidity ^0.8.20;
 
 /// @title IPolicyRegistry
+/// @author Coinbase
 /// @notice Singleton registry of transfer-authorization policies for B-20
 ///         tokens. Each B-20 token holds a single `transferPolicyId`
 ///         pointing into this registry; on every transfer, mint, or redeem,
@@ -47,11 +48,11 @@ interface IPolicyRegistry {
     ///         reserved for the built-in IDs (0 and 1) and cannot be assigned
     ///         to created policies.
     enum PolicyType {
-        WHITELIST,     // 0: address-set membership; authorized if in set
-        BLACKLIST,     // 1: address-set membership; authorized if NOT in set
-        COMPOUND,      // 2: per-role slots delegating to constituent policies
+        WHITELIST, // 0: address-set membership; authorized if in set
+        BLACKLIST, // 1: address-set membership; authorized if NOT in set
+        COMPOUND, // 2: per-role slots delegating to constituent policies
         ALWAYS_REJECT, // 3: built-in; all authorization queries return false
-        ALWAYS_ALLOW   // 4: built-in; all authorization queries return true
+        ALWAYS_ALLOW // 4: built-in; all authorization queries return true
     }
 
     /// @notice Constituent policy IDs for a compound policy. Each slot maps to one
@@ -59,14 +60,14 @@ interface IPolicyRegistry {
     ///         fulfilling that role. Slots may reference any simple policy (WHITELIST,
     ///         BLACKLIST) or a built-in ID. Use ID `1` (always-allow) for any slot
     ///         with no constraint, or `0` (always-reject) to hard-block a role.
-    /// @param senderPolicyId        Policy checked for transfer senders.
-    /// @param recipientPolicyId     Policy checked for transfer recipients.
-    /// @param mintRecipientPolicyId Policy checked for mint recipients.
-    /// @param redeemerPolicyId      Policy checked for redeem callers.
     struct CompoundPolicyData {
+        /// @dev Policy checked for transfer senders.
         uint64 senderPolicyId;
+        /// @dev Policy checked for transfer recipients.
         uint64 recipientPolicyId;
+        /// @dev Policy checked for mint recipients.
         uint64 mintRecipientPolicyId;
+        /// @dev Policy checked for redeem callers.
         uint64 redeemerPolicyId;
     }
 
@@ -139,9 +140,7 @@ interface IPolicyRegistry {
     /// @notice Emitted when the current admin nominates a new admin via
     ///         `beginPolicyAdminTransfer`. The transfer does not take effect until
     ///         `pendingAdmin` calls `acceptPolicyAdminTransfer`.
-    event PolicyAdminTransferBegun(
-        uint64 indexed policyId, address indexed currentAdmin, address indexed pendingAdmin
-    );
+    event PolicyAdminTransferBegun(uint64 indexed policyId, address indexed currentAdmin, address indexed pendingAdmin);
 
     /// @notice Emitted when an in-flight admin transfer is cancelled by the current
     ///         admin (clearing the pending admin without changing the active admin).
@@ -166,11 +165,14 @@ interface IPolicyRegistry {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Creates a new simple (WHITELIST or BLACKLIST) policy.
+    ///
     /// @dev    Permissionless. Reverts with `InvalidPolicyType` if `policyType`
     ///         is `COMPOUND` (use `createCompoundPolicy`), and with `ZeroAddress`
     ///         if `admin` is `address(0)`.
+    ///
     /// @param admin       The address authorized to modify this policy.
     /// @param policyType  WHITELIST or BLACKLIST.
+    ///
     /// @return newPolicyId The newly assigned policy ID.
     function createPolicy(address admin, PolicyType policyType) external returns (uint64 newPolicyId);
 
@@ -186,6 +188,7 @@ interface IPolicyRegistry {
     ///         cannot be changed after creation, and there is no admin. To rotate
     ///         the configuration, create a new compound policy and re-point the
     ///         token's `transferPolicyId`.
+    ///
     /// @dev    Permissionless. Each constituent MUST exist and MUST NOT be COMPOUND.
     ///         Built-in IDs (0 and 1) are always valid. Reverts with
     ///         `PolicyNotFound` for unknown IDs and `ConstituentIsCompound` if
@@ -204,6 +207,7 @@ interface IPolicyRegistry {
     /// @notice Nominates a new admin for a simple policy. The transfer is two-step:
     ///         this call records `newAdmin` as the pending admin without changing the
     ///         active admin. The nominee must then call `acceptPolicyAdminTransfer`.
+    ///
     /// @dev    Caller must be the current admin. Reverts on COMPOUND policies (they
     ///         have no admin) and on frozen policies. Calling this again overwrites
     ///         any previously pending admin for this policy. Pass `address(0)` to
@@ -226,6 +230,7 @@ interface IPolicyRegistry {
     ///         and it cannot be unfrozen. Compound policies that reference this
     ///         policy as a constituent continue to work; only this policy's own
     ///         membership state is locked.
+    ///
     /// @dev    Caller must be the current admin. Reverts on COMPOUND policies and
     ///         on already-frozen policies. Any in-flight admin transfer is
     ///         cleared as a side effect.
@@ -233,12 +238,14 @@ interface IPolicyRegistry {
 
     /// @notice Adds or removes an account from a WHITELIST policy. Caller
     ///         must be the policy admin.
+    ///
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not
     ///         WHITELIST, and with `PolicyFrozen` if the policy has been frozen.
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external;
 
     /// @notice Adds or removes an account from a BLACKLIST policy. Caller
     ///         must be the policy admin.
+    ///
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not
     ///         BLACKLIST, and with `PolicyFrozen` if the policy has been frozen.
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external;
@@ -305,16 +312,12 @@ interface IPolicyRegistry {
     function isPolicyFrozen(uint64 policyId) external view returns (bool);
 
     /// @notice Returns the constituent policy IDs of a compound policy.
+    ///
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not
     ///         COMPOUND, and with `PolicyNotFound` if the policy does not
     ///         exist.
     function compoundPolicyData(uint64 policyId)
         external
         view
-        returns (
-            uint64 senderPolicyId,
-            uint64 recipientPolicyId,
-            uint64 mintRecipientPolicyId,
-            uint64 redeemerPolicyId
-        );
+        returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId, uint64 redeemerPolicyId);
 }

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -4,16 +4,18 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IPolicyRegistry
 /// @notice Singleton registry of transfer-authorization policies for B-20
 ///         tokens. Each B-20 token holds a single `transferPolicyId`
-///         pointing into this registry; on every transfer or mint, the
-///         token consults the registry to determine whether the involved
+///         pointing into this registry; on every transfer, mint, or redeem,
+///         the token consults the registry to determine whether the involved
 ///         addresses are authorized.
 ///
-///         Three policy types are supported in v1:
+///         Five policy types are defined:
 ///         - WHITELIST: only listed addresses are authorized.
 ///         - BLACKLIST: all addresses except listed ones are authorized.
-///         - COMPOUND: references three simple policies, one for senders,
-///           one for recipients, one for mint recipients. Lets a single
-///           policy ID carry asymmetric rules.
+///         - COMPOUND: references four constituent policies, one each for
+///           senders, recipients, mint recipients, and redeemers. Lets a
+///           single policy ID carry asymmetric per-role rules.
+///         - ALWAYS_REJECT: built-in; all authorization queries return false.
+///         - ALWAYS_ALLOW: built-in; all authorization queries return true.
 ///
 /// @dev    Adapted from Tempo TIP-403 + TIP-1015 with three deliberate
 ///         omissions: no virtual-address rejection logic (no TIP-1022 on
@@ -41,27 +43,15 @@ interface IPolicyRegistry {
                                   TYPES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Policy type discriminator.
-    /// @param WHITELIST An address is authorized only if it is in the policy's set.
-    /// @param BLACKLIST An address is authorized unless it is in the policy's set.
-    /// @param COMPOUND  The policy carries no member set of its own. It
-    ///                  references three simple policies and delegates the
-    ///                  per-role check.
+    /// @notice Policy type discriminator. ALWAYS_REJECT and ALWAYS_ALLOW are
+    ///         reserved for the built-in IDs (0 and 1) and cannot be assigned
+    ///         to created policies.
     enum PolicyType {
         WHITELIST,     // 0: address-set membership; authorized if in set
         BLACKLIST,     // 1: address-set membership; authorized if NOT in set
         COMPOUND,      // 2: per-role slots delegating to constituent policies
         ALWAYS_REJECT, // 3: built-in; all authorization queries return false
         ALWAYS_ALLOW   // 4: built-in; all authorization queries return true
-    }
-
-    /// @notice Top-level data for any policy (simple or compound).
-    /// @param policyType The type of the policy.
-    /// @param admin      The address that may modify this policy. Zero for
-    ///                   COMPOUND policies (they are structurally immutable).
-    struct PolicyData {
-        PolicyType policyType;
-        address admin;
     }
 
     /// @notice Constituent policy IDs for a compound policy. Each slot maps to one

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -98,6 +98,11 @@ interface IPolicyRegistry {
     /// @notice A required address argument was the zero address.
     error ZeroAddress();
 
+    /// @notice The policy ID counter has been exhausted. Custom policy IDs are
+    ///         bounded by the on-chain packing format (61 bits, or ~2.3e18 IDs);
+    ///         creating one more policy would overflow that bound.
+    error PolicyIdOverflow();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -110,8 +110,8 @@ interface IPolicyRegistry {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a new WHITELIST or BLACKLIST policy is created.
-    ///         For compound policies, see `CompoundPolicyCreated`.
+    /// @notice Emitted when a new simple (WHITELIST or BLACKLIST) policy is
+    ///         created. For compound policies, see `CompoundPolicyCreated`.
     event PolicyCreated(uint64 indexed policyId, address indexed creator, PolicyType policyType);
 
     /// @notice Emitted when a new compound policy is created.
@@ -140,7 +140,7 @@ interface IPolicyRegistry {
                             POLICY CREATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a new WHITELIST or BLACKLIST policy.
+    /// @notice Creates a new simple (WHITELIST or BLACKLIST) policy.
     /// @dev    Permissionless. Reverts with `InvalidPolicyType` if `policyType`
     ///         is `COMPOUND` (use `createCompoundPolicy`), and with `ZeroAddress`
     ///         if `admin` is `address(0)`.
@@ -176,9 +176,9 @@ interface IPolicyRegistry {
                           POLICY ADMINISTRATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Transfers admin rights for a WHITELIST or BLACKLIST policy.
-    ///         Caller must be the current admin. Reverts on COMPOUND policies
-    ///         (they have no admin).
+    /// @notice Transfers admin rights for a simple policy. Caller must be
+    ///         the current admin. Reverts on COMPOUND policies (they have
+    ///         no admin).
     function setPolicyAdmin(uint64 policyId, address newAdmin) external;
 
     /// @notice Adds or removes an account from a WHITELIST policy. Caller
@@ -204,9 +204,9 @@ interface IPolicyRegistry {
     function isAuthorized(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a transfer sender under
-    ///         `policyId`. For WHITELIST/BLACKLIST policies this is a single
-    ///         membership check; for compound policies it delegates to the
-    ///         policy's `senderPolicyId`.
+    ///         `policyId`. For simple policies this is equivalent to a
+    ///         single membership check; for compound policies it delegates
+    ///         to the policy's `senderPolicyId`.
     function isAuthorizedSender(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a transfer recipient under
@@ -215,15 +215,15 @@ interface IPolicyRegistry {
     function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a mint recipient under
-    ///         `policyId`. Distinct from `isAuthorizedRecipient` for compound
-    ///         policies, which carry separate per-role slots. For WHITELIST/
-    ///         BLACKLIST policies this returns the same result as
-    ///         `isAuthorizedRecipient`.
+    ///         `policyId`. Distinct from `isAuthorizedRecipient` for
+    ///         compound policies, which carry separate sender / recipient
+    ///         / mint-recipient slots. For simple policies this returns
+    ///         the same result as `isAuthorizedRecipient`.
     function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a redeemer under `policyId`.
     ///         For compound policies, delegates to the policy's `redeemerPolicyId`.
-    ///         For WHITELIST/BLACKLIST policies, equivalent to `isAuthorizedRecipient`.
+    ///         For simple policies, equivalent to `isAuthorizedRecipient`.
     function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool);
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -63,7 +63,7 @@ interface IPolicyRegistry {
     }
 
     /// @notice Constituent policy IDs for a compound policy. Each slot maps to one
-    ///         transfer role; the referenced policy is evaluated against the address
+    ///         transfer role; the constituent policy is evaluated against the address
     ///         fulfilling that role. Slots may reference any simple policy (WHITELIST,
     ///         BLACKLIST) or a built-in ID. Use ID `1` (always-allow) for any slot
     ///         with no constraint, or `0` (always-reject) to hard-block a role.
@@ -156,15 +156,15 @@ interface IPolicyRegistry {
         external
         returns (uint64 newPolicyId);
 
-    /// @notice Creates a new compound policy referencing four child policy IDs,
-    ///         one per transfer role. Compound policies are immutable: child IDs
+    /// @notice Creates a new compound policy referencing four constituent policy IDs,
+    ///         one per transfer role. Compound policies are immutable: constituent IDs
     ///         cannot be changed after creation, and there is no admin. To rotate
     ///         the configuration, create a new compound policy and re-point the
     ///         token's `transferPolicyId`.
-    /// @dev    Permissionless. Each child MUST exist and MUST NOT be COMPOUND.
+    /// @dev    Permissionless. Each constituent MUST exist and MUST NOT be COMPOUND.
     ///         Built-in IDs (0 and 1) are always valid. Reverts with
     ///         `PolicyNotFound` for unknown IDs and `ConstituentIsCompound` if
-    ///         any child is itself COMPOUND.
+    ///         any constituent is itself COMPOUND.
     function createCompoundPolicy(
         uint64 senderPolicyId,
         uint64 recipientPolicyId,

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -62,14 +62,20 @@ interface IPolicyRegistry {
         address admin;
     }
 
-    /// @notice Constituent policy IDs for a compound policy.
+    /// @notice Constituent policy IDs for a compound policy. Each slot maps to one
+    ///         transfer role; the referenced policy is evaluated against the address
+    ///         fulfilling that role. Slots may reference any simple policy (WHITELIST,
+    ///         BLACKLIST) or a built-in ID. Use ID `1` (always-allow) for any slot
+    ///         with no constraint, or `0` (always-reject) to hard-block a role.
     /// @param senderPolicyId        Policy checked for transfer senders.
     /// @param recipientPolicyId     Policy checked for transfer recipients.
     /// @param mintRecipientPolicyId Policy checked for mint recipients.
+    /// @param redeemerPolicyId      Policy checked for redeem callers.
     struct CompoundPolicyData {
         uint64 senderPolicyId;
         uint64 recipientPolicyId;
         uint64 mintRecipientPolicyId;
+        uint64 redeemerPolicyId;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -114,7 +120,8 @@ interface IPolicyRegistry {
         address indexed creator,
         uint64 senderPolicyId,
         uint64 recipientPolicyId,
-        uint64 mintRecipientPolicyId
+        uint64 mintRecipientPolicyId,
+        uint64 redeemerPolicyId
     );
 
     /// @notice Emitted when a policy's admin is updated (including initial
@@ -149,19 +156,22 @@ interface IPolicyRegistry {
         external
         returns (uint64 newPolicyId);
 
-    /// @notice Creates a new compound policy referencing three constituent
-    ///         simple policies. Compound policies are structurally
-    ///         immutable: the constituent IDs cannot be changed after
+    /// @notice Creates a new compound policy referencing four constituent
+    ///         simple policies, one per transfer role. Compound policies are
+    ///         structurally immutable: constituent IDs cannot be changed after
     ///         creation, and there is no admin. To rotate the configuration,
     ///         create a new compound policy and re-point the consuming
     ///         token's `transferPolicyId`.
-    /// @dev    Permissionless. Each constituent MUST exist and MUST be a
-    ///         simple policy (WHITELIST, BLACKLIST) OR a built-in (IDs 0
-    ///         or 1). Reverts with `PolicyNotFound` for unknown IDs and
-    ///         `PolicyNotSimple` if any constituent is itself COMPOUND.
-    function createCompoundPolicy(uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId)
-        external
-        returns (uint64 newPolicyId);
+    /// @dev    Permissionless. Each constituent MUST exist and MUST NOT be a
+    ///         COMPOUND policy. Built-in IDs (0 and 1) are always valid
+    ///         constituents. Reverts with `PolicyNotFound` for unknown IDs
+    ///         and `PolicyNotSimple` if any constituent is itself COMPOUND.
+    function createCompoundPolicy(
+        uint64 senderPolicyId,
+        uint64 recipientPolicyId,
+        uint64 mintRecipientPolicyId,
+        uint64 redeemerPolicyId
+    ) external returns (uint64 newPolicyId);
 
     /*//////////////////////////////////////////////////////////////
                           POLICY ADMINISTRATION
@@ -212,6 +222,11 @@ interface IPolicyRegistry {
     ///         the same result as `isAuthorizedRecipient`.
     function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool);
 
+    /// @notice Whether `user` is authorized as a redeemer under `policyId`.
+    ///         For compound policies, delegates to the policy's `redeemerPolicyId`.
+    ///         For simple policies, equivalent to `isAuthorizedRecipient`.
+    function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool);
+
     /*//////////////////////////////////////////////////////////////
                             POLICY QUERIES
     //////////////////////////////////////////////////////////////*/
@@ -240,5 +255,10 @@ interface IPolicyRegistry {
     function compoundPolicyData(uint64 policyId)
         external
         view
-        returns (uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId);
+        returns (
+            uint64 senderPolicyId,
+            uint64 recipientPolicyId,
+            uint64 mintRecipientPolicyId,
+            uint64 redeemerPolicyId
+        );
 }

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -48,9 +48,11 @@ interface IPolicyRegistry {
     ///                  references three simple policies and delegates the
     ///                  per-role check.
     enum PolicyType {
-        WHITELIST,
-        BLACKLIST,
-        COMPOUND
+        WHITELIST,     // 0: address-set membership; authorized if in set
+        BLACKLIST,     // 1: address-set membership; authorized if NOT in set
+        COMPOUND,      // 2: per-role slots delegating to constituent policies
+        ALWAYS_REJECT, // 3: built-in; all authorization queries return false
+        ALWAYS_ALLOW   // 4: built-in; all authorization queries return true
     }
 
     /// @notice Top-level data for any policy (simple or compound).
@@ -239,11 +241,9 @@ interface IPolicyRegistry {
     ///         exist; custom IDs (>=2) exist iff they have been created.
     function policyExists(uint64 policyId) external view returns (bool);
 
-    /// @notice Returns the type and admin of `policyId`.
-    /// @dev    For COMPOUND policies, `admin` is `address(0)`. For built-in
-    ///         policies, `admin` is `address(0)` and `policyType` is
-    ///         implementation-defined (the built-ins are not categorized as
-    ///         WHITELIST or BLACKLIST since they have no member set).
+    /// @notice Returns the type and admin of `policyId`. For COMPOUND policies,
+    ///         `admin` is `address(0)`. For built-in IDs, `admin` is `address(0)`
+    ///         and `policyType` is `ALWAYS_REJECT` (ID 0) or `ALWAYS_ALLOW` (ID 1).
     ///         Reverts with `PolicyNotFound` for unknown policy IDs.
     function policyData(uint64 policyId) external view returns (PolicyType policyType, address admin);
 

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -88,10 +88,10 @@ interface IPolicyRegistry {
     /// @notice The referenced policy ID does not exist (and is not built-in).
     error PolicyNotFound();
 
-    /// @notice A compound policy attempted to reference another compound
-    ///         policy as a constituent. Only simple policies (WHITELIST,
-    ///         BLACKLIST) and the built-in IDs (0, 1) are valid constituents.
-    error PolicyNotSimple();
+    /// @notice A compound policy attempted to reference another compound policy
+    ///         as a constituent. Only WHITELIST, BLACKLIST, and built-in IDs
+    ///         (0, 1) are valid constituents.
+    error ConstituentIsCompound();
 
     /// @notice The operation is incompatible with the policy's type. For
     ///         example, calling `modifyPolicyWhitelist` on a BLACKLIST
@@ -110,8 +110,8 @@ interface IPolicyRegistry {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a new simple (WHITELIST or BLACKLIST) policy is
-    ///         created. For compound policies, see `CompoundPolicyCreated`.
+    /// @notice Emitted when a new WHITELIST or BLACKLIST policy is created.
+    ///         For compound policies, see `CompoundPolicyCreated`.
     event PolicyCreated(uint64 indexed policyId, address indexed creator, PolicyType policyType);
 
     /// @notice Emitted when a new compound policy is created.
@@ -140,10 +140,10 @@ interface IPolicyRegistry {
                             POLICY CREATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a new simple (WHITELIST or BLACKLIST) policy.
-    /// @dev    Permissionless. Reverts with `InvalidPolicyType` if
-    ///         `policyType` is `COMPOUND` (use `createCompoundPolicy`),
-    ///         and with `ZeroAddress` if `admin` is `address(0)`.
+    /// @notice Creates a new WHITELIST or BLACKLIST policy.
+    /// @dev    Permissionless. Reverts with `InvalidPolicyType` if `policyType`
+    ///         is `COMPOUND` (use `createCompoundPolicy`), and with `ZeroAddress`
+    ///         if `admin` is `address(0)`.
     /// @param admin       The address authorized to modify this policy.
     /// @param policyType  WHITELIST or BLACKLIST.
     /// @return newPolicyId The newly assigned policy ID.
@@ -156,16 +156,15 @@ interface IPolicyRegistry {
         external
         returns (uint64 newPolicyId);
 
-    /// @notice Creates a new compound policy referencing four constituent
-    ///         simple policies, one per transfer role. Compound policies are
-    ///         structurally immutable: constituent IDs cannot be changed after
-    ///         creation, and there is no admin. To rotate the configuration,
-    ///         create a new compound policy and re-point the consuming
+    /// @notice Creates a new compound policy referencing four child policy IDs,
+    ///         one per transfer role. Compound policies are immutable: child IDs
+    ///         cannot be changed after creation, and there is no admin. To rotate
+    ///         the configuration, create a new compound policy and re-point the
     ///         token's `transferPolicyId`.
-    /// @dev    Permissionless. Each constituent MUST exist and MUST NOT be a
-    ///         COMPOUND policy. Built-in IDs (0 and 1) are always valid
-    ///         constituents. Reverts with `PolicyNotFound` for unknown IDs
-    ///         and `PolicyNotSimple` if any constituent is itself COMPOUND.
+    /// @dev    Permissionless. Each child MUST exist and MUST NOT be COMPOUND.
+    ///         Built-in IDs (0 and 1) are always valid. Reverts with
+    ///         `PolicyNotFound` for unknown IDs and `ConstituentIsCompound` if
+    ///         any child is itself COMPOUND.
     function createCompoundPolicy(
         uint64 senderPolicyId,
         uint64 recipientPolicyId,
@@ -177,9 +176,9 @@ interface IPolicyRegistry {
                           POLICY ADMINISTRATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Transfers admin rights for a simple policy. Caller must be
-    ///         the current admin. Reverts on COMPOUND policies (they have
-    ///         no admin).
+    /// @notice Transfers admin rights for a WHITELIST or BLACKLIST policy.
+    ///         Caller must be the current admin. Reverts on COMPOUND policies
+    ///         (they have no admin).
     function setPolicyAdmin(uint64 policyId, address newAdmin) external;
 
     /// @notice Adds or removes an account from a WHITELIST policy. Caller
@@ -205,9 +204,9 @@ interface IPolicyRegistry {
     function isAuthorized(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a transfer sender under
-    ///         `policyId`. For simple policies this is equivalent to a
-    ///         single membership check; for compound policies it delegates
-    ///         to the policy's `senderPolicyId`.
+    ///         `policyId`. For WHITELIST/BLACKLIST policies this is a single
+    ///         membership check; for compound policies it delegates to the
+    ///         policy's `senderPolicyId`.
     function isAuthorizedSender(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a transfer recipient under
@@ -216,15 +215,15 @@ interface IPolicyRegistry {
     function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a mint recipient under
-    ///         `policyId`. Distinct from `isAuthorizedRecipient` for
-    ///         compound policies, which carry separate sender / recipient
-    ///         / mint-recipient slots. For simple policies this returns
-    ///         the same result as `isAuthorizedRecipient`.
+    ///         `policyId`. Distinct from `isAuthorizedRecipient` for compound
+    ///         policies, which carry separate per-role slots. For WHITELIST/
+    ///         BLACKLIST policies this returns the same result as
+    ///         `isAuthorizedRecipient`.
     function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool);
 
     /// @notice Whether `user` is authorized as a redeemer under `policyId`.
     ///         For compound policies, delegates to the policy's `redeemerPolicyId`.
-    ///         For simple policies, equivalent to `isAuthorizedRecipient`.
+    ///         For WHITELIST/BLACKLIST policies, equivalent to `isAuthorizedRecipient`.
     function isAuthorizedRedeemer(uint64 policyId, address user) external view returns (bool);
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -103,6 +103,17 @@ interface IPolicyRegistry {
     ///         creating one more policy would overflow that bound.
     error PolicyIdOverflow();
 
+    /// @notice The caller is not the pending admin for this policy.
+    error NotPendingAdmin();
+
+    /// @notice There is no admin transfer in progress for this policy.
+    error NoTransferPending();
+
+    /// @notice The policy has been permanently frozen and can no longer be
+    ///         modified (no membership changes, no admin transfers, no further
+    ///         freezing). This is a one-way state set by `freezePolicy`.
+    error PolicyFrozen();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -122,8 +133,25 @@ interface IPolicyRegistry {
     );
 
     /// @notice Emitted when a policy's admin is updated (including initial
-    ///         assignment at creation).
+    ///         assignment at creation and on `acceptPolicyAdminTransfer`).
     event PolicyAdminUpdated(uint64 indexed policyId, address indexed updater, address indexed admin);
+
+    /// @notice Emitted when the current admin nominates a new admin via
+    ///         `beginPolicyAdminTransfer`. The transfer does not take effect until
+    ///         `pendingAdmin` calls `acceptPolicyAdminTransfer`.
+    event PolicyAdminTransferBegun(
+        uint64 indexed policyId, address indexed currentAdmin, address indexed pendingAdmin
+    );
+
+    /// @notice Emitted when an in-flight admin transfer is cancelled by the current
+    ///         admin (clearing the pending admin without changing the active admin).
+    event PolicyAdminTransferCancelled(
+        uint64 indexed policyId, address indexed currentAdmin, address indexed cancelledPendingAdmin
+    );
+
+    /// @notice Emitted when a policy is permanently frozen. After this event, the
+    ///         policy's membership and admin can no longer be modified.
+    event PolicyFrozenEvent(uint64 indexed policyId, address indexed frozenBy);
 
     /// @notice Emitted when an account's whitelist status is updated for a
     ///         WHITELIST policy.
@@ -173,21 +201,46 @@ interface IPolicyRegistry {
                           POLICY ADMINISTRATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Transfers admin rights for a simple policy. Caller must be
-    ///         the current admin. Reverts on COMPOUND policies (they have
-    ///         no admin).
-    function setPolicyAdmin(uint64 policyId, address newAdmin) external;
+    /// @notice Nominates a new admin for a simple policy. The transfer is two-step:
+    ///         this call records `newAdmin` as the pending admin without changing the
+    ///         active admin. The nominee must then call `acceptPolicyAdminTransfer`.
+    /// @dev    Caller must be the current admin. Reverts on COMPOUND policies (they
+    ///         have no admin) and on frozen policies. Calling this again overwrites
+    ///         any previously pending admin for this policy. Pass `address(0)` to
+    ///         clear a previously nominated pending admin (equivalent to
+    ///         `cancelPolicyAdminTransfer`).
+    function beginPolicyAdminTransfer(uint64 policyId, address newAdmin) external;
+
+    /// @notice Completes a two-step admin transfer. Caller must be the address
+    ///         previously nominated via `beginPolicyAdminTransfer`. On success,
+    ///         the caller becomes the new admin and the pending admin slot is
+    ///         cleared.
+    function acceptPolicyAdminTransfer(uint64 policyId) external;
+
+    /// @notice Cancels a pending admin transfer without changing the active admin.
+    ///         Caller must be the current admin.
+    function cancelPolicyAdminTransfer(uint64 policyId) external;
+
+    /// @notice Permanently freezes a policy: after this call, the policy's
+    ///         membership cannot be modified, its admin cannot be transferred,
+    ///         and it cannot be unfrozen. Compound policies that reference this
+    ///         policy as a constituent continue to work; only this policy's own
+    ///         membership state is locked.
+    /// @dev    Caller must be the current admin. Reverts on COMPOUND policies and
+    ///         on already-frozen policies. Any in-flight admin transfer is
+    ///         cleared as a side effect.
+    function freezePolicy(uint64 policyId) external;
 
     /// @notice Adds or removes an account from a WHITELIST policy. Caller
     ///         must be the policy admin.
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not
-    ///         WHITELIST.
+    ///         WHITELIST, and with `PolicyFrozen` if the policy has been frozen.
     function modifyPolicyWhitelist(uint64 policyId, address account, bool allowed) external;
 
     /// @notice Adds or removes an account from a BLACKLIST policy. Caller
     ///         must be the policy admin.
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not
-    ///         BLACKLIST.
+    ///         BLACKLIST, and with `PolicyFrozen` if the policy has been frozen.
     function modifyPolicyBlacklist(uint64 policyId, address account, bool restricted) external;
 
     /*//////////////////////////////////////////////////////////////
@@ -241,6 +294,15 @@ interface IPolicyRegistry {
     ///         and `policyType` is `ALWAYS_REJECT` (ID 0) or `ALWAYS_ALLOW` (ID 1).
     ///         Reverts with `PolicyNotFound` for unknown policy IDs.
     function policyData(uint64 policyId) external view returns (PolicyType policyType, address admin);
+
+    /// @notice The pending admin nominated via `beginPolicyAdminTransfer`, or
+    ///         `address(0)` if no transfer is in flight. Always `address(0)`
+    ///         for compound and built-in policies.
+    function pendingPolicyAdmin(uint64 policyId) external view returns (address);
+
+    /// @notice Whether `policyId` has been permanently frozen via `freezePolicy`.
+    ///         Always false for compound and built-in policies.
+    function isPolicyFrozen(uint64 policyId) external view returns (bool);
 
     /// @notice Returns the constituent policy IDs of a compound policy.
     /// @dev    Reverts with `IncompatiblePolicyType` if the policy is not


### PR DESCRIPTION
## Motivation

Implements `PolicyRegistry.sol` (TIP-403 + TIP-1015 parity) with a fourth compound slot for redeem policy specification. Bit-packing logic is isolated in `PolicySlot.sol`.

## Interface changes

- Added `redeemerPolicyId` as a fourth slot on `CompoundPolicyData`
- Updated `createCompoundPolicy` and `compoundPolicyData` signatures
- Added `isAuthorizedRedeemer` query
- Added `ALWAYS_REJECT` and `ALWAYS_ALLOW` to the `PolicyType` enum for built-in IDs

## Design decisions

**Single-slot storage.** Every policy fits in one `uint256`. Low 8 bits are always the type tag; remaining bits depend on type:
- WHITELIST/BLACKLIST: `[type(8b) | admin(160b)]` — 88 bits spare
- COMPOUND: `[type(8b) | sender(62b) | recipient(62b) | mintRecipient(62b) | redeemer(62b)]` — exactly 256 bits

Any authorization check costs at most 2 SLOADs: one for the compound slot, one for the constituent's member set.

**62-bit constituent IDs.** Four 64-bit IDs plus an 8-bit type tag would be 264 bits. Trimming 2 bits per ID makes it fit exactly. The interface keeps `uint64` throughout; truncation requires ~4.6e18 policies, which is not realistic.

**No recursion.** Constituents are validated as non-COMPOUND at creation time. The evaluation graph is always one level deep — no cycle detection or depth cap needed.

**Built-in IDs.** IDs 0 (always-reject) and 1 (always-allow) are handled as constants with no storage access. `ALWAYS_REJECT` and `ALWAYS_ALLOW` are added to the `PolicyType` enum so `policyData()` returns a meaningful type for built-ins rather than a misleading placeholder.