### PR TITLE
fix: correct NatSpec inconsistencies across interface files

### DIFF
--- a/src/interfaces/IDefaultToken.sol
+++ b/src/interfaces/IDefaultToken.sol
@@ -220,9 +220,9 @@ interface IDefaultToken {
     ///         here; this is intentional alignment.
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
 
-    /// @notice Emitted by `pause`. `vectors` is the bitmask added to the
-    ///         current paused state (the result of `current | vectors`,
-    ///         not the argument). `updater` is the caller.
+    /// @notice Emitted by `pause`. `vectors` is the bitmask argument passed to
+    ///         `pause` (not the resulting accumulated state). Emitted even when
+    ///         a vector was already set. `updater` is the caller.
     event Paused(address indexed updater, uint256 vectors);
 
     /// @notice Emitted by `unpause`. All paused vectors are cleared.

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -145,6 +145,10 @@ interface IPolicyRegistry {
     /// @notice Same as `createPolicy`, but additionally seeds the policy's
     ///         member set with `accounts`. Convenience for one-shot
     ///         creation flows that don't need an empty initial state.
+    /// @param  admin       The address granted admin role on the new policy.
+    /// @param  policyType  The policy type to create.
+    /// @param  accounts    Initial members to add to the policy's set.
+    /// @return newPolicyId The ID of the newly created policy.
     function createPolicyWithAccounts(address admin, PolicyType policyType, address[] calldata accounts)
         external
         returns (uint64 newPolicyId);

--- a/src/interfaces/ISecurityToken.sol
+++ b/src/interfaces/ISecurityToken.sol
@@ -296,11 +296,9 @@ interface ISecurityToken is IDefaultToken {
 
     /// @notice Updates the token's name (e.g. corporate rebrand).
     ///         Reads via the inherited `name()` accessor reflect the
-    ///         new value immediately. Affects EIP-712 domain separator
-    ///         computation (used by `permit`); callers signing permits
-    ///         should re-read the relevant domain fields immediately
-    ///         before signing. Emits the inherited `NameUpdated` event
-    ///         from `IDefaultToken`.
+    ///         new value immediately. Does not affect the EIP-712 domain
+    ///         separator, which only includes (chainId, verifyingContract).
+    ///         Emits the inherited `NameUpdated` event from `IDefaultToken`.
     /// @dev    Requires `DEFAULT_ADMIN_ROLE` and an
     ///         `Announcement(id, ...)` emitted earlier in the same
     ///         transaction with the same id.

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -244,6 +244,7 @@ interface ITokenFactory {
     ///         `params.initialSupplyRecipient` atomically (same bootstrap
     ///         policy bypass as `createDefault`). Sets the immutable
     ///         `currency` field.
+    /// @return token The address of the newly created token.
     function createStablecoin(CreateStablecoinParams calldata params) external returns (address token);
 
     /// @notice Creates a Security-variant token at a deterministic
@@ -252,6 +253,7 @@ interface ITokenFactory {
     ///         (rate-limited compliant issuance) or `adminMint`
     ///         (cold-path batch with announcement coupling) for issuance
     ///         after deployment.
+    /// @return token The address of the newly created token.
     function createSecurity(CreateSecurityTokenParams calldata params) external returns (address token);
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Four self-contained NatSpec fixes across token and policy interface files. Each is a doc-only correction — no semantic changes.

## Changes

### 1. `IDefaultToken.sol` — `Paused` event doc contradicts `pause` function doc

Lines 223–225 vs 577–579 give opposite instructions on what value is emitted in `vectors`:

- Event doc said: "the bitmask added to the current paused state (the result of `current | vectors`, not the argument)"
- Function doc says: "Pausing a vector that is already set is a no-op for the bitmask but still emits `Paused(updater, vectors)` with the argument as supplied"

The function's "argument as-supplied" semantics are more useful for indexers (they can reconstruct the accumulated state themselves) and are what an implementer would naturally write.

```diff
- /// @notice Emitted by `pause`. `vectors` is the bitmask added to the
- ///         current paused state (the result of `current | vectors`,
- ///         not the argument). `updater` is the caller.
+ /// @notice Emitted by `pause`. `vectors` is the bitmask argument passed to
+ ///         `pause` (not the resulting accumulated state). Emitted even when
+ ///         a vector was already set. `updater` is the caller.
```

### 2. `ISecurityToken.sol` — `updateName` falsely warns it breaks permit signatures

Lines 299–305 warn that `updateName` affects the EIP-712 domain separator. But `IDefaultToken.sol:53–55` explicitly states:

> "EIP-712 domain is (chainId, verifyingContract) only, with name and version empty."

And `eip712Domain()` docs (lines 657–659) confirm name is empty. Since name is intentionally excluded from the domain, `updateName` has zero effect on the separator. The current warning could mislead integrators into needlessly re-signing permits or building flows that break.

```diff
- ///         new value immediately. Affects EIP-712 domain separator
- ///         computation (used by `permit`); callers signing permits
- ///         should re-read the relevant domain fields immediately
- ///         before signing.
+ ///         new value immediately. Does not affect the EIP-712 domain
+ ///         separator, which only includes (chainId, verifyingContract).
```

### 3. `IPolicyRegistry.sol` — `createPolicyWithAccounts` missing all `@param`/`@return` tags

`createPolicy` directly above (lines 136–143) documents all three params. `createPolicyWithAccounts` has three params and a return but documents none of them. The `accounts` parameter especially needs documentation since it's the entire point of using this variant.

Added matching `@param admin`, `@param policyType`, `@param accounts`, `@return newPolicyId` tags.

### 4. `ITokenFactory.sol` — `createStablecoin` and `createSecurity` missing `@return` tags

`createDefault` (line 238) documents its return: `/// @return token The address of the newly created token.`

`createStablecoin` (line 247) and `createSecurity` (line 254) return the same type but have no `@return` tag. ABI-documentation tools and IDE hover hints will show a blank return for two of the three creation methods.

Added matching `@return token` tags to both.

## Verification

- ✅ All four changes verified locally
- ✅ Only the 4 interface files touched
- ✅ All edits match the existing NatSpec formatting style in each file
- ✅ No semantic changes — doc-only