### PR TITLE
docs: add maintenance note about STANDARD_EQUITY mirroring ALL

### DIFF
--- a/src/interfaces/Capabilities.sol
+++ b/src/interfaces/Capabilities.sol
@@ -129,6 +129,11 @@ library Capabilities {
     ///         governance.
     uint256 internal constant FIXED_SUPPLY = PAUSABLE;
 
+    // NOTE: STANDARD_EQUITY currently resolves to the same bitmask as ALL
+    // because no stablecoin-specific bits (24..31) are assigned yet. The
+    // moment any such bit is added, ALL must include it but STANDARD_EQUITY
+    // must not — security tokens must never silently inherit stablecoin
+    // capabilities.
     /// @notice Standard equity-style security token: supports compliant
     ///         issuance via `create`, user redemption via `redeem`,
     ///         share-ratio updates (for splits), all metadata updates, and


### PR DESCRIPTION
## Summary

Adds a 5-line maintenance comment above `STANDARD_EQUITY` in `Capabilities.sol` to warn future contributors about a silent invariant the two constants must maintain.

## Background

Currently, `ALL` and `STANDARD_EQUITY` resolve to bit-for-bit identical bitmasks:

```solidity
uint256 internal constant ALL = PAUSABLE | CAP_MUTABLE | SECURITY_CREATABLE | SECURITY_REDEEMABLE
    | SHARE_RATIO_MUTABLE | SECURITY_METADATA_MUTABLE | SECURITY_ADMIN_BATCH;

uint256 internal constant STANDARD_EQUITY = PAUSABLE | CAP_MUTABLE | SECURITY_CREATABLE | SECURITY_REDEEMABLE
    | SHARE_RATIO_MUTABLE | SECURITY_METADATA_MUTABLE | SECURITY_ADMIN_BATCH;
```

This is coincidental — bits 24..31 are reserved for stablecoin-specific capabilities, and none have been defined yet. The comment on `ALL` says "all currently-defined optional features enabled." The comment on `STANDARD_EQUITY` says it's a "standard equity-style security token."

## The risk

The moment any stablecoin bit is added:
- `ALL` should include it (it's the union of everything)
- `STANDARD_EQUITY` must NOT include it (equity ≠ stablecoin)

But a future contributor adding bit 24 to `ALL` will see that `STANDARD_EQUITY` happens to use the same expression and might assume they're meant to stay in sync — silently granting security tokens a stablecoin capability they should not have.

## The fix

A 5-line comment above `STANDARD_EQUITY` documenting:
1. That the two are currently identical
2. Why (bits 24..31 unassigned)
3. The invariant: when stablecoin bits ARE defined, `ALL` must include them but `STANDARD_EQUITY` must not

## Verification

- ✅ Comment-only change
- ✅ No constants modified
- ✅ Matches the existing `//` comment style in the file