### PR TITLE
feat(interfaces): rename token interfaces to IB20 naming scheme

### DIFF
--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -44,7 +44,7 @@ This leaves headroom in each range for v2 / v3 additions.
 
 #### Default IS Core (variant inheritance, no separate ICoreToken)
 
-`IStablecoin` and `ISecurityToken` both extend `IDefaultToken` directly
+`IB20Stablecoin` and `IB20Security` both extend `IB20` directly
 as siblings. There is no separate `ICoreToken` interface. The Default
 token IS the canonical "ERC-20 + memos + roles + permits + policy + pause
 + URI + supply cap" surface that every variant inherits.
@@ -109,7 +109,7 @@ those as illustrative, not gas-optimal.
 
 #### MINT_ROLE and BURN_ROLE are separate
 
-`IDefaultToken` exposes `MINT_ROLE` and `BURN_ROLE` as distinct role
+`IB20` exposes `MINT_ROLE` and `BURN_ROLE` as distinct role
 identifiers. Originally combined as `ISSUER_ROLE` (TIP-20 convention),
 we split them after reading CDP Custom Stablecoin (CCS), which has
 them separate.
@@ -380,7 +380,7 @@ Items below need your input. Status legend:
 - ✅ **RESOLVED**: confirmed and reflected in current code; kept for context
 - 🔴 **VERIFY**: ambiguity in source docs; resolved one way but worth confirming
 
-### IDefaultToken
+### IB20
 
 #### 🟡 OPEN: Should there be a `MEMOS_REQUIRED` capability bit?
 
@@ -429,7 +429,7 @@ Preset values:
 Worth verifying these match what real issuers (CCS, Tangor, Coinbase
 Wrapped Assets) would actually want.
 
-### IStablecoin
+### IB20Stablecoin
 
 #### ✅ RESOLVED: Per-minter rate limiting added
 
@@ -453,7 +453,7 @@ For yield-bearing stablecoins like Base USD's planned design. Mechanics
 are complex (rebase storage, snapshot timing, indexer compatibility).
 Defer to dedicated design pass; not added.
 
-### ISecurityToken
+### IB20Security
 
 #### ✅ RESOLVED: `redeemPolicyId` separate from `transferPolicyId`
 
@@ -595,7 +595,7 @@ items needing your input:
 1. `MEMOS_REQUIRED` capability bit — add now or defer? (My lean: add)
 2. Preset contents (`STANDARD_STABLECOIN`, `STANDARD_EQUITY`,
    `FIXED_SUPPLY`) — confirm reasonable defaults?
-3. Reserve attestation accessor on IStablecoin — add or defer to
+3. Reserve attestation accessor on IB20Stablecoin — add or defer to
    off-chain JSON?
 4. Indexed `bytes32 idHash` on `Announcement` event — add for
    filterability?

--- a/src/interfaces/Capabilities.sol
+++ b/src/interfaces/Capabilities.sol
@@ -100,7 +100,7 @@ library Capabilities {
     // Earlier drafts defined STABLECOIN_MINT_RATE_LIMITED (per-minter
     // rate limiting) and STABLECOIN_AUTHORIZATIONS (ERC-3009). Both
     // were removed when the corresponding surface moved out of
-    // `IStablecoin` to EVM periphery contracts. See `IStablecoin` for
+    // `IB20Stablecoin` to EVM periphery contracts. See `IB20Stablecoin` for
     // the rationale.
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
-/// @title IDefaultToken
+/// @title IB20
 /// @notice The base Solidity surface every Base-native token (B-20) implements.
 ///         Variants (Stablecoin, Security, ...) extend this interface; nothing
 ///         on this surface is variant-specific. A token created at the Default
@@ -54,7 +54,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         `(chainId, verifyingContract)` only, with `name` and `version`
 ///         empty. ERC-5267 `eip712Domain()` is exposed for domain
 ///         introspection by integrators.
-interface IDefaultToken {
+interface IB20 {
     /*//////////////////////////////////////////////////////////////
                                 ERRORS
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
-import {IDefaultToken} from "./IDefaultToken.sol";
+import {IB20} from "./IB20.sol";
 
-/// @title ISecurityToken
+/// @title IB20Security
 /// @notice A B-20 token variant for tokenized securities (equities, ETFs,
-///         commodities, etc.). Extends `IDefaultToken` with primitives
+///         commodities, etc.). Extends `IB20` with primitives
 ///         specific to securities: holder-impacting announcements,
 ///         split-safe share-ratio accounting, security-identifier
 ///         metadata, compliant issuance via `create`, and cold-path
 ///         admin batch mint / burn for unusual corporate actions.
 ///
-/// @dev    **Inherited surface.** `IDefaultToken` already provides the
+/// @dev    **Inherited surface.** `IB20` already provides the
 ///         pieces that are shared with stablecoins and other variants:
 ///         ERC-20 surface, mint / burn (gated by `MINT_ROLE` / `BURN_ROLE`),
 ///         redeem / redeemWithMemo / minimumRedeemable / setMinimumRedeemable
@@ -44,7 +44,7 @@ import {IDefaultToken} from "./IDefaultToken.sol";
 ///            paths that take an announcement ID. These are the
 ///            canonical name/symbol update functions for security
 ///            tokens; the inherited `setName` / `setSymbol` from
-///            `IDefaultToken` are present in the interface but
+///            `IB20` are present in the interface but
 ///            implementations typically revert them on security tokens
 ///            so that name/symbol changes always carry an announcement.
 ///         7. `securityIdentifier` / `updateSecurityIdentifier` for
@@ -58,7 +58,7 @@ import {IDefaultToken} from "./IDefaultToken.sol";
 ///         Capability bits relevant to securities live in the
 ///         `Capabilities` library bits 16..23 (e.g. `SECURITY_CREATABLE`,
 ///         `SHARE_RATIO_MUTABLE`).
-interface ISecurityToken is IDefaultToken {
+interface IB20Security is IB20 {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -127,7 +127,7 @@ interface ISecurityToken is IDefaultToken {
 
     // NOTE on `NameUpdated` / `SymbolUpdated` / `Redeemed` /
     // `MinimumRedeemableUpdated`: all four are inherited from
-    // `IDefaultToken` and are not redeclared here. Security
+    // `IB20` and are not redeclared here. Security
     // implementations of `updateName` / `updateSymbol` emit the
     // inherited `NameUpdated` / `SymbolUpdated` event after the matching
     // `Announcement(id, ...)` has been emitted earlier in the
@@ -300,12 +300,12 @@ interface ISecurityToken is IDefaultToken {
     ///         computation (used by `permit`); callers signing permits
     ///         should re-read the relevant domain fields immediately
     ///         before signing. Emits the inherited `NameUpdated` event
-    ///         from `IDefaultToken`.
+    ///         from `IB20`.
     /// @dev    Requires `DEFAULT_ADMIN_ROLE` and an
     ///         `Announcement(id, ...)` emitted earlier in the same
     ///         transaction with the same id.
     ///
-    ///         Note: `IDefaultToken.setName(newName)` is also in this
+    ///         Note: `IB20.setName(newName)` is also in this
     ///         interface (inherited) but security-token implementations
     ///         typically revert it so that all name changes carry an
     ///         announcement. Use `updateName` here for the canonical
@@ -315,7 +315,7 @@ interface ISecurityToken is IDefaultToken {
     /// @notice Updates the token's symbol (e.g. ticker change). Reads
     ///         via the inherited `symbol()` accessor reflect the new
     ///         value immediately. Emits the inherited `SymbolUpdated`
-    ///         event from `IDefaultToken`.
+    ///         event from `IB20`.
     /// @dev    Requires `DEFAULT_ADMIN_ROLE` and an
     ///         `Announcement(id, ...)` emitted earlier in the same
     ///         transaction with the same id.

--- a/src/interfaces/IB20Stablecoin.sol
+++ b/src/interfaces/IB20Stablecoin.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
-import {IDefaultToken} from "./IDefaultToken.sol";
+import {IB20} from "./IB20.sol";
 
-/// @title IStablecoin
+/// @title IB20Stablecoin
 /// @notice A B-20 token variant for value-pegged tokens (USD, EUR, XAU, etc.).
-///         Inherits the full `IDefaultToken` surface and adds a single
+///         Inherits the full `IB20` surface and adds a single
 ///         immutable `currency()` identifier for routing, categorization,
 ///         and wallet display.
 ///
@@ -32,11 +32,11 @@ import {IDefaultToken} from "./IDefaultToken.sol";
 ///           operations.
 ///
 ///         Compliance (sanctions, jurisdiction restrictions, KYC) is
-///         delegated to the policy engine via `IDefaultToken.transferPolicyId`.
+///         delegated to the policy engine via `IB20.transferPolicyId`.
 ///         Issuers point their stablecoin at a compound policy with the
 ///         appropriate sender, recipient, mint-recipient, and redeemer
 ///         slots configured per their compliance regime.
-interface IStablecoin is IDefaultToken {
+interface IB20Stablecoin is IB20 {
     /*//////////////////////////////////////////////////////////////
                           CURRENCY IDENTIFIER
     //////////////////////////////////////////////////////////////*/

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -17,7 +17,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///
 ///         The factory is a precompile and has no admin or governance.
 ///         Each created token has its own independent admin and operates
-///         per the inherited `IDefaultToken` (and variant) surface.
+///         per the inherited `IB20` (and variant) surface.
 interface ITokenFactory {
     /*//////////////////////////////////////////////////////////////
                                   TYPES
@@ -87,7 +87,7 @@ interface ITokenFactory {
     /// @notice Creation parameters for a Stablecoin-variant token.
     /// @param currency               Immutable currency identifier (e.g.
     ///                               "USD", "EUR", "XAU"). See
-    ///                               `IStablecoin.currency` for the
+    ///                               `IB20Stablecoin.currency` for the
     ///                               convention.
     /// @dev    All other fields have the same semantics as the Default
     ///         params struct.

--- a/src/interfaces/PauseVectors.sol
+++ b/src/interfaces/PauseVectors.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.20 <0.9.0;
 
 /// @title PauseVectors
 /// @notice Bit positions for the granular pause bitfield used by `pause`
-///         and `paused` on `IDefaultToken` and its variants.
+///         and `paused` on `IB20` and its variants.
 ///
 ///         A token's `pause(uint256 vectors)` function accepts a bitmask
 ///         of vectors to pause; multiple calls are additive (each call


### PR DESCRIPTION
## Summary

- `IDefaultToken` → `IB20`
- `ISecurityToken` → `IB20Security`
- `IStablecoin` → `IB20Stablecoin`

Updates all imports, inheritance declarations, and natspec/comment references across `Capabilities.sol`, `PauseVectors.sol`, `ITokenFactory.sol`, and `DESIGN_NOTES.md`. No functional changes.

## Test plan

- [ ] Verify `forge build` compiles cleanly with updated imports
- [ ] Confirm no remaining references to the old names (`grep -r IDefaultToken\|ISecurityToken\|IStablecoin src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)