### PR TITLE
Collapse factory surface and flip policy built-in IDs per PRD

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -50,10 +50,11 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         variant-side additions are pure interface additions with no
 ///         change to the storage shape.
 ///
-///         Each policy slot defaults to built-in ID `0` (always-reject) so
-///         newly minted tokens cannot move balance until the admin
-///         configures their compliance regime. ID `1` (always-allow) is
-///         the explicit opt-out for a given role.
+///         Each policy slot defaults to built-in ID `0` (always-allow) so
+///         newly created tokens are unrestricted until the admin
+///         configures their compliance regime. ID `type(uint64).max`
+///         (always-reject) is the explicit hard-deny for a given role
+///         (e.g. disabling redemption on a non-redeemable token).
 ///
 ///         Asymmetric per-role configuration is expressed by pointing
 ///         different slots at different policies — for example, a
@@ -596,7 +597,7 @@ interface IB20 {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice The current policy ID configured for `policyType`. Returns
-    ///         `0` (always-reject built-in) for any policy slot that has
+    ///         `0` (always-allow built-in) for any policy slot that has
     ///         never been assigned. Standard policy types are exposed as
     ///         the role-identifier constants `TRANSFER_SENDER()`,
     ///         `TRANSFER_RECEIVER()`, `TRANSFER_EXECUTOR()`, and
@@ -605,18 +606,20 @@ interface IB20 {
     ///         `IB20Security`). User-defined policy types are also
     ///         supported and may be used by periphery contracts that
     ///         layer additional gating on top.
-    /// @dev    All slots default to `0` (always-reject) at token creation:
-    ///         newly minted tokens cannot move balance until the admin
-    ///         configures their policy slots. To explicitly opt out of a
-    ///         given slot's enforcement, point it at `1` (always-allow).
+    /// @dev    All slots default to `0` (always-allow) at token creation:
+    ///         newly created tokens are unrestricted until the admin
+    ///         points each slot at a concrete policy. To explicitly
+    ///         hard-deny a slot (e.g. disabling redemption on a
+    ///         non-redeemable token), point it at `type(uint64).max`
+    ///         (always-reject).
     function policyId(bytes32 policyType) external view returns (uint64);
 
     /// @notice Updates the policy ID assigned to `policyType`. Requires
     ///         `DEFAULT_ADMIN_ROLE`. The target policy MUST exist in the
-    ///         registry (or be one of the built-in IDs `0` or `1`);
-    ///         otherwise reverts with `PolicyNotFound`. Takes effect
-    ///         immediately for the next operation that consults this
-    ///         slot. Emits `PolicyUpdated`.
+    ///         registry (or be one of the built-in IDs `0` or
+    ///         `type(uint64).max`); otherwise reverts with
+    ///         `PolicyNotFound`. Takes effect immediately for the next
+    ///         operation that consults this slot. Emits `PolicyUpdated`.
     function updatePolicy(bytes32 policyType, uint64 newPolicyId) external;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -209,8 +209,8 @@ interface IB20Security is IB20 {
     ///         operation on the caller's own balance, gated entirely by
     ///         the `REDEEMER_SENDER` policy slot. Tokens that do not
     ///         offer redemption configure the `REDEEMER_SENDER` slot to
-    ///         policy ID `0` (always-reject); calls to `redeem` then
-    ///         revert with `PolicyForbids` for every caller.
+    ///         policy ID `type(uint64).max` (always-reject); calls to
+    ///         `redeem` then revert with `PolicyForbids` for every caller.
     ///
     ///         Distinct from `burn` (which requires `BURN_ROLE` and
     ///         carries no off-chain settlement implication) and

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -29,15 +29,18 @@ pragma solidity >=0.8.20 <0.9.0;
 ///
 ///         **Built-in policy IDs** (always present, never need to be
 ///         created):
-///         - `0` — always-reject. `isAuthorized(0, any)` returns false.
-///                  Useful as the safe default for newly created tokens
-///                  that should not transfer until compliance is configured,
-///                  and as a "kill switch" independent of token-level pause.
-///         - `1` — always-allow. `isAuthorized(1, any)` returns true.
-///                  Useful for tokens that opt out of policy gating for a
-///                  given role slot.
+///         - `0` — always-allow. `isAuthorized(0, any)` returns true.
+///                  Semantic: "there is no policy on this slot." This is
+///                  the default state of every unassigned policy slot on
+///                  a newly created token, matching the principle that
+///                  absence of a configured policy means no restriction.
+///         - `type(uint64).max` — always-reject. `isAuthorized(max, any)`
+///                  returns false. Useful as an explicit hard-deny on a
+///                  policy slot (e.g. disabling redemption by pointing
+///                  `REDEEMER_SENDER` at this sentinel), or as a "kill
+///                  switch" independent of token-level pause.
 ///
-///         Custom policy IDs start at `2` and are assigned monotonically
+///         Custom policy IDs start at `1` and are assigned monotonically
 ///         by `nextPolicyId`.
 ///
 ///         **Future extensions** (not in v1 scope, intended path):
@@ -205,8 +208,9 @@ interface IPolicyRegistry {
     ///           policy's member set.
     ///         - For BLOCKLIST: returns true iff `account` is NOT on the
     ///           policy's member set.
-    ///         - For built-in ID `0` (always-reject): always returns false.
-    ///         - For built-in ID `1` (always-allow): always returns true.
+    ///         - For built-in ID `0` (always-allow): always returns true.
+    ///         - For built-in ID `type(uint64).max` (always-reject):
+    ///           always returns false.
     /// @dev    Reverts with `PolicyNotFound` if `policyId` is neither a
     ///         built-in nor a previously-created policy.
     function isAuthorized(uint64 policyId, address account) external view returns (bool);
@@ -217,11 +221,14 @@ interface IPolicyRegistry {
 
     /// @notice The next policy ID that will be assigned by the next call
     ///         to `createPolicy` / `createPolicyWithAccounts`. Starts at
-    ///         `2` (IDs 0 and 1 are reserved for the built-ins).
+    ///         `1` (ID `0` is reserved for the always-allow built-in;
+    ///         `type(uint64).max` is reserved for the always-reject
+    ///         built-in but is never assigned by the monotonic counter).
     function nextPolicyId() external view returns (uint64);
 
-    /// @notice Whether `policyId` exists. The built-in IDs (0, 1) always
-    ///         exist; custom IDs (>= 2) exist iff they have been created.
+    /// @notice Whether `policyId` exists. The built-in IDs (`0` and
+    ///         `type(uint64).max`) always exist; custom IDs in
+    ///         `[1, nextPolicyId)` exist iff they have been created.
     function policyExists(uint64 policyId) external view returns (bool);
 
     /// @notice The type of `policyId`. Reverts with `PolicyNotFound` for

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -57,7 +57,7 @@ interface ITokenFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Variant of a B-20 token. Encoded in address byte `[10]`,
-    ///         so `variantOf` is a pure address-prefix read with no
+    ///         so `getTokenVariant` is a pure address-prefix read with no
     ///         storage lookup. `NONE` indicates the address is not a
     ///         B-20 token created by this factory.
     enum TokenVariant {
@@ -254,5 +254,5 @@ interface ITokenFactory {
     /// @notice Returns the variant of `token`. Returns `NONE` if `token`
     ///         is not a factory-created B-20. Recovered from address
     ///         byte `[10]`; no storage read.
-    function variantOf(address token) external view returns (TokenVariant);
+    function getTokenVariant(address token) external view returns (TokenVariant);
 }

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -2,30 +2,64 @@
 pragma solidity >=0.8.20 <0.9.0;
 
 /// @title ITokenFactory
-/// @notice Singleton factory for creating B-20 tokens of any variant.
-///         A single precompile at a fixed address exposes three creation
-///         methods (`createDefault`, `createStablecoin`, `createSecurity`).
-///         Creation is permissionless: anyone may create a token of any
-///         variant, and the creator picks the initial admin.
+/// @notice Singleton factory precompile for creating B-20 tokens of any
+///         variant. A single entry point `createToken` dispatches on a
+///         `TokenVariant` discriminator; per-variant creation arguments
+///         are ABI-encoded into `params` and prefixed with a `version`
+///         byte so the encoding can evolve without breaking the factory's
+///         immutable surface. Creation is permissionless; the caller picks
+///         the initial admin.
 ///
-/// @dev    Each token is deployed at a deterministic address derived from
-///         `(variant, creator, salt)`. The variant is encoded in the
-///         address prefix, so the variant of any address is recoverable
-///         via `variantOf` without a storage lookup. Address prediction
-///         functions (`predict*Address`) let callers compute the address
-///         off-chain or pre-fund the address before deployment.
+/// @dev    **Factory address.** The factory lives at the fixed address
+///         `0xB20...000F`.
 ///
-///         The factory is a precompile and has no admin or governance.
-///         Each created token has its own independent admin and operates
-///         per the inherited `IB20` (and variant) surface.
+///         **Token address schema (20 bytes).**
+///         - `[0:10]`  — `bytes10(0xB20...000)` shared prefix identifying a
+///                       factory-created B-20.
+///         - `[10]`    — `bytes1(variant)` (matches `TokenVariant`).
+///         - `[11]`    — `bytes1(decimals)` — encoded in the address so
+///                       `decimals()` is recoverable statelessly from the
+///                       token address alone, avoiding a storage read on
+///                       hot integration paths (AMMs, lending markets,
+///                       wallets). For variants that hardcode decimals
+///                       (Stablecoin, Security: 6), this byte is fixed
+///                       at `0x06`.
+///         - `[12:20]` — `bytes8(keccak256(abi.encode(msg.sender, salt)))`.
+///
+///         **Variant evolution.** Adding new required fields to an
+///         existing variant after launch is NOT supported: the factory is
+///         an immutable precompile, and downstream protocols (e.g.
+///         Clanker-style launchers) depend on the surface. Schemas evolve
+///         in two ways:
+///         1. Bumping the `version` byte at the head of a variant's
+///            params struct and ABI-decoding accordingly. Old versions
+///            remain valid forever.
+///         2. Customizing per-token configuration via `initCalls` (see
+///            below) instead of growing the params struct.
+///
+///         **`initCalls`.** After the token is deployed and the bootstrap
+///         state is set, each entry in `initCalls` is invoked on the new
+///         token with `msg.sender == factory` and the factory acting as
+///         if it held `DEFAULT_ADMIN_ROLE`. This is how callers configure
+///         optional post-creation state (initial mints, supply caps,
+///         policy slot assignments, contract URI, capability bitfields,
+///         pause vectors, etc.) atomically in the same transaction as
+///         creation. The factory does not interpret the call data; any
+///         revert in an init call reverts the whole creation.
+///
+///         **Per-variant validation.** Variant-specific required-field
+///         checks (e.g. stablecoins must specify a non-empty `currency`)
+///         are applied at the end of the variant decode, after the
+///         common version check, so each variant owns its own invariants.
 interface ITokenFactory {
     /*//////////////////////////////////////////////////////////////
                                   TYPES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Variant of a B-20 token. Recoverable from the token's
-    ///         address prefix; `NONE` indicates the address is not a B-20
-    ///         token created by this factory.
+    /// @notice Variant of a B-20 token. Encoded in address byte `[10]`,
+    ///         so `variantOf` is a pure address-prefix read with no
+    ///         storage lookup. `NONE` indicates the address is not a
+    ///         B-20 token created by this factory.
     enum TokenVariant {
         NONE,
         DEFAULT,
@@ -33,118 +67,74 @@ interface ITokenFactory {
         SECURITY
     }
 
-    /// @notice Creation parameters for a Default-variant token.
-    /// @param name                   ERC-20 token name. Mutable post-creation
-    ///                               via `setName` (admin-only).
-    /// @param symbol                 ERC-20 token symbol. Mutable
-    ///                               post-creation via `setSymbol`
-    ///                               (admin-only).
-    /// @param decimals               ERC-20 token decimals (issuer choice).
-    ///                               Immutable after creation.
-    /// @param admin                  Initial holder of `DEFAULT_ADMIN_ROLE`.
-    /// @param capabilities           Immutable capability bitfield. See
-    ///                               `Capabilities` for the bit definitions.
-    /// @param initialSupply          Amount minted atomically at creation.
-    ///                               Bypasses the transfer-policy check
-    ///                               (this is the bootstrap mint, not a
-    ///                               normal mint operation; the policy
-    ///                               may not be configured at creation
-    ///                               time).
-    /// @param initialSupplyRecipient Address that receives `initialSupply`.
-    ///                               Ignored when `initialSupply == 0`.
-    /// @param transferPolicyId       Initial value of `transferPolicyId`.
-    ///                               Must reference an existing policy in
-    ///                               the policy registry.
-    /// @param supplyCap              Initial value of `supplyCap`. Use
-    ///                               `type(uint256).max` for no cap. To
-    ///                               make the token permanently fixed-supply,
-    ///                               set this equal to `initialSupply` and
-    ///                               leave the `CAP_MUTABLE` capability
-    ///                               unset.
-    /// @param minimumRedeemable      Initial value of `minimumRedeemable`.
-    ///                               Use `0` to allow any non-zero amount
-    ///                               (the typical setting for tokens
-    ///                               without a redemption product). Mutable
-    ///                               post-creation via `setMinimumRedeemable`.
-    /// @param contractURI            Initial ERC-7572 contract URI.
-    /// @param salt                   Caller-chosen salt for deterministic
-    ///                               address derivation.
-    struct CreateDefaultTokenParams {
+    /// @notice Creation parameters for a Default-variant B-20 token.
+    ///         ABI-encoded into the `params` argument of `createToken`.
+    /// @param version       Encoding version. Currently `1`. Future
+    ///                      hardforks may introduce additional versions
+    ///                      with different field layouts; the leading
+    ///                      byte selects the decoder.
+    /// @param name          ERC-20 token name.
+    /// @param symbol        ERC-20 token symbol.
+    /// @param initialAdmin  Initial holder of `DEFAULT_ADMIN_ROLE`. All
+    ///                      post-creation admin operations (including any
+    ///                      ranout through `initCalls`) ultimately
+    ///                      authorize against this account once the
+    ///                      bootstrap init returns.
+    /// @param decimals      ERC-20 decimals. MUST be in `[2, 18]`.
+    ///                      Encoded into address byte `[11]` for
+    ///                      stateless retrieval.
+    struct B20CreateParams {
+        uint8 version;
         string name;
         string symbol;
+        address initialAdmin;
         uint8 decimals;
-        address admin;
-        uint256 capabilities;
-        uint256 initialSupply;
-        address initialSupplyRecipient;
-        uint64 transferPolicyId;
-        uint256 supplyCap;
-        uint256 minimumRedeemable;
-        string contractURI;
-        bytes32 salt;
     }
 
-    /// @notice Creation parameters for a Stablecoin-variant token.
-    /// @param currency               Immutable currency identifier (e.g.
-    ///                               "USD", "EUR", "XAU"). See
-    ///                               `IB20Stablecoin.currency` for the
-    ///                               convention.
-    /// @dev    All other fields have the same semantics as the Default
-    ///         params struct.
-    struct CreateStablecoinParams {
+    /// @notice Creation parameters for a Stablecoin-variant B-20 token.
+    /// @param version       Encoding version. Currently `1`.
+    /// @param name          ERC-20 token name.
+    /// @param symbol        ERC-20 token symbol.
+    /// @param initialAdmin  Initial holder of `DEFAULT_ADMIN_ROLE`.
+    /// @param currency      Immutable currency identifier (e.g. "USD",
+    ///                      "EUR", "XAU"). Required: empty string
+    ///                      reverts. See `IB20Stablecoin.currency` for
+    ///                      the convention.
+    /// @dev    Decimals are fixed at `6` (the SPL stablecoin convention)
+    ///         and encoded as `0x06` in address byte `[11]`. There is no
+    ///         decimals field on this struct.
+    struct B20StablecoinCreateParams {
+        uint8 version;
         string name;
         string symbol;
-        uint8 decimals;
-        address admin;
-        uint256 capabilities;
-        uint256 initialSupply;
-        address initialSupplyRecipient;
-        uint64 transferPolicyId;
-        uint256 supplyCap;
-        uint256 minimumRedeemable;
-        string contractURI;
+        address initialAdmin;
         string currency;
-        bytes32 salt;
     }
 
-    /// @notice Creation parameters for a Security-variant token.
-    /// @param shareRatioNumerator     Initial share-ratio numerator. Must
-    ///                                be non-zero. Use `1` for 1:1 unless
-    ///                                the issuer wants headroom for
-    ///                                fractional ratio updates.
-    /// @param shareRatioDenominator   Initial share-ratio denominator.
-    ///                                Must be non-zero.
-    /// @param securityIdentifiers     Initial `[type, value]` pairs (e.g.
-    ///                                `[["isin", "US..."], ["cusip", "..."]]`).
-    ///                                May be empty; identifiers can be
-    ///                                added later via
-    ///                                `updateSecurityIdentifier`.
-    /// @dev    Security tokens have NO `initialSupply` parameter. All
-    ///         issuance goes through `create` (rate-limited compliant
-    ///         path) or `adminMint` (cold-path batch with announcement
-    ///         coupling) after creation. The supply cap is set at
-    ///         creation; `transferPolicyId` must reference an existing
-    ///         compound policy in the registry whose redeemer slot
-    ///         encodes the brokerage allowlist (typically a
-    ///         Coinbase-managed whitelist of KYC'd, brokerage-connected
-    ///         accounts).
-    ///
-    ///         All other fields have the same semantics as the Default
-    ///         params struct.
-    struct CreateSecurityTokenParams {
+    /// @notice Creation parameters for a Security-variant B-20 token.
+    /// @param version            Encoding version. Currently `1`.
+    /// @param name               ERC-20 token name.
+    /// @param symbol             ERC-20 token symbol.
+    /// @param initialAdmin       Initial holder of `DEFAULT_ADMIN_ROLE`.
+    /// @param isin               International Securities Identification
+    ///                           Number. Required: empty string reverts.
+    ///                           Additional identifiers (CUSIP, FIGI,
+    ///                           SEDOL) can be attached post-creation
+    ///                           via `IB20Security.updateSecurityIdentifier`.
+    /// @param minimumRedeemable  Initial value of `minimumRedeemable`.
+    ///                           Use `0` to allow any non-zero redemption.
+    /// @dev    Decimals are fixed at `6` and encoded as `0x06` in address
+    ///         byte `[11]`. Security tokens have no `initialSupply`
+    ///         parameter: all issuance flows through `create`
+    ///         (rate-limited compliant path) or `adminMint` (cold-path
+    ///         batch with announcement coupling) after deployment.
+    struct B20SecurityCreateParams {
+        uint8 version;
         string name;
         string symbol;
-        uint8 decimals;
-        address admin;
-        uint256 capabilities;
-        uint64 transferPolicyId;
-        uint256 supplyCap;
+        address initialAdmin;
+        string isin;
         uint256 minimumRedeemable;
-        uint48 shareRatioNumerator;
-        uint48 shareRatioDenominator;
-        string[2][] securityIdentifiers;
-        string contractURI;
-        bytes32 salt;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -152,135 +142,117 @@ interface ITokenFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice A token already exists at the deterministic address
-    ///         derived from `(variant, msg.sender, salt)`. Caller must
-    ///         use a different salt.
+    ///         derived from `(variant, decimals, msg.sender, salt)`.
+    ///         Caller must use a different salt.
     error TokenAlreadyExists(address token);
 
-    /// @notice The provided policy ID does not exist in the policy
-    ///         registry.
-    error InvalidPolicyId(uint64 policyId);
+    /// @notice `variant` is not a recognized `TokenVariant` (or is
+    ///         `NONE`, which is invalid for creation).
+    error InvalidVariant();
 
-    /// @notice The provided share-ratio numerator or denominator is zero.
-    error InvalidShareRatio();
+    /// @notice The leading `version` byte in `params` does not match
+    ///         any known encoding for the requested variant.
+    error UnsupportedVersion(uint8 version);
 
-    /// @notice The provided decimals value is outside the allowed range
-    ///         (implementation-defined; typically 0..18 inclusive).
+    /// @notice The provided decimals value is outside the variant's
+    ///         allowed range. Default tokens require `[2, 18]`;
+    ///         Stablecoin and Security tokens hardcode `6` and do not
+    ///         accept a caller-supplied value.
     error InvalidDecimals(uint8 decimals);
 
     /// @notice A required address argument was the zero address.
     error ZeroAddress();
 
-    /// @notice The provided supply cap is below the configured initial
-    ///         supply, or is otherwise invalid.
-    error InvalidSupplyCap();
+    /// @notice A required string argument was the empty string (e.g.
+    ///         stablecoin `currency`, security `isin`).
+    error MissingRequiredField();
 
-    /// @notice A security identifier `type` was the empty string.
-    ///         Identifier types must be non-empty (typical values:
-    ///         "isin", "cusip", "figi", "sedol").
-    error EmptyIdentifierType();
+    /// @notice One of the `initCalls` reverted. The factory bubbles the
+    ///         underlying revert reason where the call returns one;
+    ///         this error wraps empty reverts.
+    error InitCallFailed(uint256 index);
 
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a Default-variant token is created.
-    event DefaultTokenCreated(
+    /// @notice Emitted once per `createToken` invocation. The common
+    ///         fields cover the universal token-identity surface; all
+    ///         variant-specific state changes (e.g. `currency`, `isin`,
+    ///         supply cap, policy slots) are observable via the
+    ///         token's own events as they're applied during the
+    ///         bootstrap and `initCalls`.
+    event TokenCreated(
         address indexed token,
-        address indexed creator,
-        address indexed admin,
+        TokenVariant indexed variant,
         string name,
         string symbol,
-        uint8 decimals,
-        uint256 capabilities,
-        uint256 initialSupply,
-        bytes32 salt
-    );
-
-    /// @notice Emitted when a Stablecoin-variant token is created.
-    event StablecoinCreated(
-        address indexed token,
-        address indexed creator,
-        address indexed admin,
-        string name,
-        string symbol,
-        uint8 decimals,
-        string currency,
-        uint256 capabilities,
-        uint256 initialSupply,
-        bytes32 salt
-    );
-
-    /// @notice Emitted when a Security-variant token is created.
-    event SecurityTokenCreated(
-        address indexed token,
-        address indexed creator,
-        address indexed admin,
-        string name,
-        string symbol,
-        uint8 decimals,
-        uint256 capabilities,
-        uint48 shareRatioNumerator,
-        uint48 shareRatioDenominator,
-        bytes32 salt
+        uint8 decimals
     );
 
     /*//////////////////////////////////////////////////////////////
-                            CREATION METHODS
+                                 CREATE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a Default-variant token at a deterministic address
-    ///         derived from `(DEFAULT, msg.sender, params.salt)`. Mints
-    ///         `params.initialSupply` to `params.initialSupplyRecipient`
-    ///         atomically. The bootstrap mint bypasses the policy check
-    ///         (the policy may not yet authorize the recipient at
-    ///         creation time); subsequent mints go through the normal
-    ///         policy hook.
-    /// @return token The address of the newly created token.
-    function createDefault(CreateDefaultTokenParams calldata params) external returns (address token);
-
-    /// @notice Creates a Stablecoin-variant token at a deterministic
-    ///         address derived from `(STABLECOIN, msg.sender, params.salt)`.
-    ///         Mints `params.initialSupply` to
-    ///         `params.initialSupplyRecipient` atomically (same bootstrap
-    ///         policy bypass as `createDefault`). Sets the immutable
-    ///         `currency` field.
-    function createStablecoin(CreateStablecoinParams calldata params) external returns (address token);
-
-    /// @notice Creates a Security-variant token at a deterministic
-    ///         address derived from `(SECURITY, msg.sender, params.salt)`.
-    ///         NO initial supply is minted; security tokens use `create`
-    ///         (rate-limited compliant issuance) or `adminMint`
-    ///         (cold-path batch with announcement coupling) for issuance
-    ///         after deployment.
-    function createSecurity(CreateSecurityTokenParams calldata params) external returns (address token);
+    /// @notice Creates a B-20 token of the given `variant` at the
+    ///         deterministic address derived from `(variant, decimals,
+    ///         msg.sender, salt)`. `params` MUST be the ABI-encoded
+    ///         variant-specific struct (`B20CreateParams`,
+    ///         `B20StablecoinCreateParams`, or `B20SecurityCreateParams`),
+    ///         leading with a `version` byte the factory uses to select
+    ///         the decoder.
+    ///
+    ///         After the token is constructed and its identity state
+    ///         (name, symbol, decimals, admin, variant-specific fields)
+    ///         is sealed, the factory invokes each entry in `initCalls`
+    ///         on the new token, acting as if it held the token's
+    ///         `DEFAULT_ADMIN_ROLE`. This is the supported path for
+    ///         configuring all optional post-creation state atomically:
+    ///         initial mints, supply caps, policy slot assignments,
+    ///         capabilities, pause vectors, contract URI, etc. Any
+    ///         init-call revert reverts the entire creation.
+    ///
+    ///         Emits `TokenCreated` once the token's identity is sealed
+    ///         and before any `initCalls` are dispatched, so init-call
+    ///         effects appear strictly after the creation event in the
+    ///         log order.
+    /// @param variant    Which variant struct `params` decodes as.
+    /// @param salt       Caller-chosen salt for deterministic address
+    ///                   derivation.
+    /// @param params     ABI-encoded variant-specific creation struct,
+    ///                   leading with the version byte.
+    /// @param initCalls  Optional admin-context bootstrap calls invoked
+    ///                   on the new token after identity is sealed.
+    /// @return token     The address of the newly created token.
+    function createToken(
+        TokenVariant variant,
+        bytes32 salt,
+        bytes calldata params,
+        bytes[] calldata initCalls
+    ) external returns (address token);
 
     /*//////////////////////////////////////////////////////////////
-                          ADDRESS PREDICTION
+                            ADDRESS QUERIES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Returns the deterministic address that `createDefault`
-    ///         would assign for the given `(creator, salt)`. The address
-    ///         depends only on the variant, creator, and salt; not on
-    ///         any of the other creation parameters. Stable across all
-    ///         parameter choices for a given `(creator, salt)`.
-    function predictDefaultAddress(address creator, bytes32 salt) external view returns (address);
+    /// @notice Returns the deterministic address `createToken` would
+    ///         assign for `(variant, decimals, sender, salt)`. Address
+    ///         derivation depends only on these four inputs; the
+    ///         remaining `params` fields do not affect the address.
+    /// @dev    `variant` and `decimals` are both required because both
+    ///         are encoded into the address (bytes `[10]` and `[11]`).
+    ///         For Stablecoin and Security variants, pass `decimals = 6`.
+    function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
+        external
+        view
+        returns (address);
 
-    /// @notice Same as `predictDefaultAddress`, for the Stablecoin
-    ///         variant.
-    function predictStablecoinAddress(address creator, bytes32 salt) external view returns (address);
-
-    /// @notice Same as `predictDefaultAddress`, for the Security variant.
-    function predictSecurityAddress(address creator, bytes32 salt) external view returns (address);
-
-    /*//////////////////////////////////////////////////////////////
-                         VARIANT INTROSPECTION
-    //////////////////////////////////////////////////////////////*/
+    /// @notice Whether `token` was created by this factory. Recovered
+    ///         from the address prefix (bytes `[0:10]`); no storage read.
+    function isB20(address token) external view returns (bool);
 
     /// @notice Returns the variant of `token`. Returns `NONE` if `token`
-    ///         is not a B-20 token created by this factory. Recovered
-    ///         from the address prefix; no storage read.
+    ///         is not a factory-created B-20. Recovered from address
+    ///         byte `[10]`; no storage read.
     function variantOf(address token) external view returns (TokenVariant);
-
-    /// @notice Convenience: `variantOf(token) != NONE`.
-    function isB20(address token) external view returns (bool);
 }


### PR DESCRIPTION
## Summary

Two PRD-driven interface reshapes:

**`ITokenFactory`** — full surface collapse.
- Replace three variant-specific creators (`createDefault` / `createStablecoin` / `createSecurity`) with a single `createToken(TokenVariant, bytes32 salt, bytes params, bytes[] initCalls)`.
- Replace three variant-specific events with a single `TokenCreated(token, variant, name, symbol, decimals)`.
- Replace three `predict*Address` views with a single `getTokenAddress(variant, decimals, sender, salt)` (expanded from the spec's 2-arg signature to include the encoding-determining fields).
- Strip non-essential fields from each `*CreateParams` struct (`capabilities`, `initialSupply`, `initialSupplyRecipient`, `transferPolicyId`, `supplyCap`, `contractURI`, `shareRatio*`, `securityIdentifiers[][]`). All optional post-creation state now flows through `initCalls`, applied in admin context.
- Each params struct leads with a `uint8 version` byte so per-variant encodings can evolve without breaking the immutable factory.
- Stablecoin and Security hardcode `decimals = 6` (no field on those structs); Default restricts to `[2, 18]`.
- Security takes a single `isin` field instead of the flexible identifier array (additional identifiers attach post-creation).
- Document the factory address (`0xB20...000F`) and the 20-byte token address schema: `[0:10]` shared prefix, `[10]` variant byte, `[11]` decimals byte (enables stateless `decimals()` lookup), `[12:20]` `keccak256(sender, salt)` collision-resistant hash.

**`IPolicyRegistry`** — built-in policy IDs flipped to spec.
- `0` now means **always-allow** (semantic: "no policy on this slot"). Was always-reject.
- `type(uint64).max` now means **always-reject**. New sentinel; ID `1` is no longer special and is the first assignable ID.
- `nextPolicyId()` starts at `1`.

**Cascading doc updates** in `IB20` and `IB20Security` so the "default policy slot = always-allow" semantics are consistent across the surface: newly created tokens are unrestricted until the admin configures policy slots, matching the spec's "absence of policy = no restriction" framing.

## Open items flagged in review

- `getTokenAddress` was expanded to 4 args (variant + decimals + sender + salt) because both variant and decimals are encoded into the deterministic address per the schema. Spec wrote a 2-arg signature; happy to revisit if a different shape was intended.
- Decimals-in-address is documented as committed per spec, though the spec itself flagged this as TODO pending chain-team confirmation.
- No implementation files exist in this repo today, so the changes are purely interface surface. Downstream periphery integrating the previous three-creator surface (e.g. Clanker-style launchers) will need a migration pass.

## Test plan

- [ ] `forge build` succeeds (verified locally)
- [ ] Review the new address schema doc against chain-team intent on decimals-in-address
- [ ] Confirm `getTokenAddress` signature shape (4-arg expansion vs spec's 2-arg)
- [ ] Confirm default-slot semantic flip is acceptable (newly created tokens now unrestricted by default rather than inert-until-configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)