### PR TITLE
Add StdPrecompiles library for singleton precompile handles

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+import {IPolicyRegistry} from "./interfaces/IPolicyRegistry.sol";
+import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
+
+/// @title Standard Precompiles Library for Base
+/// @notice Address constants for Base's singleton precompiles, paired
+///         with interface-typed handles so callers can interact with
+///         them directly (e.g. `StdPrecompiles.TOKEN_FACTORY.createToken(...)`).
+library StdPrecompiles {
+    address internal constant TOKEN_FACTORY_ADDRESS = 0xB20000000000000000000000000000000000000f;
+    address internal constant POLICY_REGISTRY_ADDRESS = 0xb000000000000000000000000000000000000001;
+
+    ITokenFactory internal constant TOKEN_FACTORY = ITokenFactory(TOKEN_FACTORY_ADDRESS);
+    IPolicyRegistry internal constant POLICY_REGISTRY = IPolicyRegistry(POLICY_REGISTRY_ADDRESS);
+}


### PR DESCRIPTION
## Summary

- New `src/StdPrecompiles.sol` library exposing Base's two singleton precompiles as named address constants paired with interface-typed handles.
- `TOKEN_FACTORY` → `ITokenFactory(0xB20...000F)` (matches the address documented in `ITokenFactory.sol`).
- `POLICY_REGISTRY` → `IPolicyRegistry(0xb00...001)`.
- Callers can invoke directly: `StdPrecompiles.TOKEN_FACTORY.createToken(...)` / `StdPrecompiles.POLICY_REGISTRY.isAuthorized(...)`.
- Pattern mirrors Tempo's `StdPrecompiles` library.

## Test plan

- [ ] `forge build` succeeds (verified locally)
- [ ] Confirm `POLICY_REGISTRY_ADDRESS = 0xb000000000000000000000000000000000000001` matches the eventual chain assignment
- [ ] Confirm no other singleton precompiles need to be added to the library at this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)