### PR TITLE
Add IActivationRegistry interface and StdPrecompiles binding

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
+import {IActivationRegistry} from "./interfaces/IActivationRegistry.sol";
 import {IPolicyRegistry} from "./interfaces/IPolicyRegistry.sol";
 import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
 
@@ -11,7 +12,9 @@ import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
 library StdPrecompiles {
     address internal constant TOKEN_FACTORY_ADDRESS = 0xB20000000000000000000000000000000000000f;
     address internal constant POLICY_REGISTRY_ADDRESS = 0xb000000000000000000000000000000000000001;
+    address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x84530000000000000000000000000000000000ff;
 
     ITokenFactory internal constant TOKEN_FACTORY = ITokenFactory(TOKEN_FACTORY_ADDRESS);
     IPolicyRegistry internal constant POLICY_REGISTRY = IPolicyRegistry(POLICY_REGISTRY_ADDRESS);
+    IActivationRegistry internal constant ACTIVATION_REGISTRY = IActivationRegistry(ACTIVATION_REGISTRY_ADDRESS);
 }

--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -9,8 +9,9 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         downstream contracts) consult `isActivated` to gate behavior.
 ///
 ///         The activation admin is the only address authorized to call
-///         `activate` and `deactivate`; all other callers revert with
-///         `Unauthorized`.
+///         `activate`; all other callers revert with `Unauthorized`.
+///         Activation is one-way: once a feature is activated it cannot
+///         be deactivated.
 ///
 /// @dev    The precompile enforces two call-context invariants that are
 ///         surfaced as reverts but cannot originate from normal Solidity
@@ -19,8 +20,8 @@ pragma solidity >=0.8.20 <0.9.0;
 ///           via `CALL` (not `DELEGATECALL` or `CALLCODE`), so the admin
 ///           identity is bound to `msg.sender` rather than the calling
 ///           contract's storage context.
-///         - `StaticCallNotAllowed`: `activate` and `deactivate` mutate
-///           state and cannot be invoked from a `STATICCALL` frame.
+///         - `StaticCallNotAllowed`: `activate` mutates state and cannot
+///           be invoked from a `STATICCALL` frame.
 ///
 ///         Feature ids are opaque to the registry: it does not interpret
 ///         them, and any `bytes32` is a valid id. By convention the
@@ -33,16 +34,12 @@ interface IActivationRegistry {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice `caller` is not the activation admin and is therefore
-    ///         not authorized to call `activate` or `deactivate`.
+    ///         not authorized to call `activate`.
     error Unauthorized(address caller);
 
     /// @notice `activate` was called on a feature that is already
     ///         activated.
     error AlreadyActivated(bytes32 feature);
-
-    /// @notice `deactivate` was called on a feature that is not
-    ///         currently activated.
-    error AlreadyDeactivated(bytes32 feature);
 
     /// @notice `feature` is not activated. Returned by precompiles that
     ///         consult the registry as a hard gate (the chain node
@@ -54,8 +51,8 @@ interface IActivationRegistry {
     ///         `CALLCODE`. All entry points require a direct `CALL`.
     error DelegateCallNotAllowed();
 
-    /// @notice A state-mutating entry point (`activate` / `deactivate`)
-    ///         was invoked from a `STATICCALL` frame.
+    /// @notice A state-mutating entry point (`activate`) was invoked
+    ///         from a `STATICCALL` frame.
     error StaticCallNotAllowed();
 
     /*//////////////////////////////////////////////////////////////
@@ -66,21 +63,16 @@ interface IActivationRegistry {
     ///         activated. `caller` is the activation admin.
     event FeatureActivated(bytes32 indexed feature, address indexed caller);
 
-    /// @notice Emitted when `feature` transitions from activated to
-    ///         inactive. `caller` is the activation admin.
-    event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
-
     /*//////////////////////////////////////////////////////////////
                             ACTIVATION QUERIES
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Whether `feature` is currently activated. Returns
-    ///         `false` for any feature id that has never been activated
-    ///         (the default state) or that has been deactivated.
+    ///         `false` for any feature id that has never been
+    ///         activated (the default state).
     function isActivated(bytes32 feature) external view returns (bool);
 
-    /// @notice The address authorized to call `activate` and
-    ///         `deactivate`.
+    /// @notice The address authorized to call `activate`.
     function admin() external view returns (address);
 
     /*//////////////////////////////////////////////////////////////
@@ -91,13 +83,7 @@ interface IActivationRegistry {
     ///         `Unauthorized`). Reverts with `AlreadyActivated` if the
     ///         feature is already activated; reverts with
     ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
-    ///         Emits `FeatureActivated` on success.
+    ///         Emits `FeatureActivated` on success. Activation is
+    ///         one-way: there is no `deactivate` counterpart.
     function activate(bytes32 feature) external;
-
-    /// @notice Deactivates `feature`. Caller MUST equal `admin()` (else
-    ///         `Unauthorized`). Reverts with `AlreadyDeactivated` if
-    ///         the feature is not currently activated; reverts with
-    ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
-    ///         Emits `FeatureDeactivated` on success.
-    function deactivate(bytes32 feature) external;
 }

--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20 <0.9.0;
+
+/// @title IActivationRegistry
+/// @notice Singleton precompile that gates Base-native features behind
+///         an activation admin. Each feature is identified by an opaque
+///         `bytes32` feature id and is either enabled or disabled;
+///         disabled features cannot be activated by anyone other than
+///         the activation admin, and once enabled they remain enabled.
+///
+///         Consumers (typically other Base precompiles or the system
+///         configuration) consult `isEnabled` to gate behavior. The
+///         activation admin is the only address authorized to call
+///         `enable`; all other callers revert with `Unauthorized`.
+///
+/// @dev    The precompile enforces two call-context invariants that are
+///         surfaced as reverts but cannot originate from normal Solidity
+///         consumers:
+///         - `DelegateCallNotAllowed`: the precompile MUST be invoked
+///           via `CALL` (not `DELEGATECALL` or `CALLCODE`), so the admin
+///           identity is bound to `msg.sender` rather than the calling
+///           contract's storage context.
+///         - `StaticCallNotAllowed`: `enable` mutates state and cannot
+///           be invoked from a `STATICCALL` frame.
+///
+///         Feature ids are opaque to the registry: it does not interpret
+///         them, and any `bytes32` is a valid id. By convention the
+///         producing component picks a stable id derived from a
+///         human-readable feature name (the chain-node source uses
+///         32-byte digests for this purpose).
+interface IActivationRegistry {
+    /*//////////////////////////////////////////////////////////////
+                                 ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice `caller` is not the activation admin and is therefore
+    ///         not authorized to call `enable`.
+    error Unauthorized(address caller);
+
+    /// @notice `feature` is already enabled. `enable` is idempotent in
+    ///         intent but reverts to signal that the caller's expected
+    ///         state transition (disabled -> enabled) did not occur.
+    error AlreadyEnabled(bytes32 feature);
+
+    /// @notice `feature` is not enabled. Returned by precompiles that
+    ///         consult the registry as a hard gate (see `assertEnabled`-
+    ///         style flows in the chain node); not raised by `isEnabled`,
+    ///         which returns `false` instead.
+    error FeatureNotEnabled(bytes32 feature);
+
+    /// @notice The precompile was invoked via `DELEGATECALL` or
+    ///         `CALLCODE`. All entry points require a direct `CALL`.
+    error DelegateCallNotAllowed();
+
+    /// @notice A state-mutating entry point (`enable`) was invoked from
+    ///         a `STATICCALL` frame.
+    error StaticCallNotAllowed();
+
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when `feature` transitions from disabled to
+    ///         enabled. `caller` is the activation admin (the only
+    ///         address authorized to flip the bit).
+    event FeatureEnabled(bytes32 indexed feature, address indexed caller);
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTIVATION QUERIES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Whether `feature` is currently enabled. Returns `false`
+    ///         for any feature id that has never been enabled (the
+    ///         default state).
+    function isEnabled(bytes32 feature) external view returns (bool);
+
+    /// @notice The address authorized to call `enable`.
+    function activationAdmin() external view returns (address);
+
+    /*//////////////////////////////////////////////////////////////
+                            ACTIVATION CONTROL
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Enables `feature`. Caller MUST equal `activationAdmin()`
+    ///         (else `Unauthorized`). Reverts with `AlreadyEnabled` if
+    ///         the feature is already enabled; reverts with
+    ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
+    ///         Emits `FeatureEnabled` on success. Once enabled, a
+    ///         feature cannot be disabled.
+    function enable(bytes32 feature) external;
+}

--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -4,14 +4,13 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IActivationRegistry
 /// @notice Singleton precompile that gates Base-native features behind
 ///         an activation admin. Each feature is identified by an opaque
-///         `bytes32` feature id and is either enabled or disabled;
-///         disabled features cannot be activated by anyone other than
-///         the activation admin, and once enabled they remain enabled.
+///         `bytes32` feature id and is either activated or not;
+///         consumers (other precompiles, system configuration, or
+///         downstream contracts) consult `isActivated` to gate behavior.
 ///
-///         Consumers (typically other Base precompiles or the system
-///         configuration) consult `isEnabled` to gate behavior. The
-///         activation admin is the only address authorized to call
-///         `enable`; all other callers revert with `Unauthorized`.
+///         The activation admin is the only address authorized to call
+///         `activate` and `deactivate`; all other callers revert with
+///         `Unauthorized`.
 ///
 /// @dev    The precompile enforces two call-context invariants that are
 ///         surfaced as reverts but cannot originate from normal Solidity
@@ -20,8 +19,8 @@ pragma solidity >=0.8.20 <0.9.0;
 ///           via `CALL` (not `DELEGATECALL` or `CALLCODE`), so the admin
 ///           identity is bound to `msg.sender` rather than the calling
 ///           contract's storage context.
-///         - `StaticCallNotAllowed`: `enable` mutates state and cannot
-///           be invoked from a `STATICCALL` frame.
+///         - `StaticCallNotAllowed`: `activate` and `deactivate` mutate
+///           state and cannot be invoked from a `STATICCALL` frame.
 ///
 ///         Feature ids are opaque to the registry: it does not interpret
 ///         them, and any `bytes32` is a valid id. By convention the
@@ -34,58 +33,71 @@ interface IActivationRegistry {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice `caller` is not the activation admin and is therefore
-    ///         not authorized to call `enable`.
+    ///         not authorized to call `activate` or `deactivate`.
     error Unauthorized(address caller);
 
-    /// @notice `feature` is already enabled. `enable` is idempotent in
-    ///         intent but reverts to signal that the caller's expected
-    ///         state transition (disabled -> enabled) did not occur.
-    error AlreadyEnabled(bytes32 feature);
+    /// @notice `activate` was called on a feature that is already
+    ///         activated.
+    error AlreadyActivated(bytes32 feature);
 
-    /// @notice `feature` is not enabled. Returned by precompiles that
-    ///         consult the registry as a hard gate (see `assertEnabled`-
-    ///         style flows in the chain node); not raised by `isEnabled`,
-    ///         which returns `false` instead.
-    error FeatureNotEnabled(bytes32 feature);
+    /// @notice `deactivate` was called on a feature that is not
+    ///         currently activated.
+    error AlreadyDeactivated(bytes32 feature);
+
+    /// @notice `feature` is not activated. Returned by precompiles that
+    ///         consult the registry as a hard gate (the chain node
+    ///         uses an `assertActivated`-style flow for this); not
+    ///         raised by `isActivated`, which returns `false` instead.
+    error FeatureNotActivated(bytes32 feature);
 
     /// @notice The precompile was invoked via `DELEGATECALL` or
     ///         `CALLCODE`. All entry points require a direct `CALL`.
     error DelegateCallNotAllowed();
 
-    /// @notice A state-mutating entry point (`enable`) was invoked from
-    ///         a `STATICCALL` frame.
+    /// @notice A state-mutating entry point (`activate` / `deactivate`)
+    ///         was invoked from a `STATICCALL` frame.
     error StaticCallNotAllowed();
 
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when `feature` transitions from disabled to
-    ///         enabled. `caller` is the activation admin (the only
-    ///         address authorized to flip the bit).
-    event FeatureEnabled(bytes32 indexed feature, address indexed caller);
+    /// @notice Emitted when `feature` transitions from inactive to
+    ///         activated. `caller` is the activation admin.
+    event FeatureActivated(bytes32 indexed feature, address indexed caller);
+
+    /// @notice Emitted when `feature` transitions from activated to
+    ///         inactive. `caller` is the activation admin.
+    event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
 
     /*//////////////////////////////////////////////////////////////
                             ACTIVATION QUERIES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Whether `feature` is currently enabled. Returns `false`
-    ///         for any feature id that has never been enabled (the
-    ///         default state).
-    function isEnabled(bytes32 feature) external view returns (bool);
+    /// @notice Whether `feature` is currently activated. Returns
+    ///         `false` for any feature id that has never been activated
+    ///         (the default state) or that has been deactivated.
+    function isActivated(bytes32 feature) external view returns (bool);
 
-    /// @notice The address authorized to call `enable`.
-    function activationAdmin() external view returns (address);
+    /// @notice The address authorized to call `activate` and
+    ///         `deactivate`.
+    function admin() external view returns (address);
 
     /*//////////////////////////////////////////////////////////////
                             ACTIVATION CONTROL
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Enables `feature`. Caller MUST equal `activationAdmin()`
-    ///         (else `Unauthorized`). Reverts with `AlreadyEnabled` if
-    ///         the feature is already enabled; reverts with
+    /// @notice Activates `feature`. Caller MUST equal `admin()` (else
+    ///         `Unauthorized`). Reverts with `AlreadyActivated` if the
+    ///         feature is already activated; reverts with
     ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
-    ///         Emits `FeatureEnabled` on success. Once enabled, a
-    ///         feature cannot be disabled.
-    function enable(bytes32 feature) external;
+    ///         Emits `FeatureActivated` on success.
+    function activate(bytes32 feature) external;
+
+    /// @notice Deactivates `feature`. Caller MUST equal `admin()` (else
+    ///         `Unauthorized`). Reverts with `AlreadyDeactivated` if
+    ///         the feature is not currently activated; reverts with
+    ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
+    ///         Emits `FeatureDeactivated` on success.
+    function deactivate(bytes32 feature) external;
 }


### PR DESCRIPTION
## Summary

- New `src/interfaces/IActivationRegistry.sol` adapts the ActivationRegistry precompile proposed in [base/base#2733](https://github.com/base/base/pull/2733) into a Solidity interface.
- Wire `ACTIVATION_REGISTRY` (`0x8453…00ff`) into `src/StdPrecompiles.sol` so callers can use `StdPrecompiles.ACTIVATION_REGISTRY.isActivated(...)` and `…activate(...)` directly.

## Interface surface

```solidity
interface IActivationRegistry {
    event FeatureActivated(bytes32 indexed feature, address indexed caller);

    error Unauthorized(address caller);
    error AlreadyActivated(bytes32 feature);
    error FeatureNotActivated(bytes32 feature);
    error DelegateCallNotAllowed();
    error StaticCallNotAllowed();

    function isActivated(bytes32 feature) external view returns (bool);
    function admin() external view returns (address);
    function activate(bytes32 feature) external;
}
```

## Deliberate divergence from base/base#2733

The Solidity surface differs from the upstream Rust ABI in two ways. The upstream chain code will need matching changes for the interface to compile against the real precompile:

1. **Consistent verb.** All `enable` / `isEnabled` / `FeatureEnabled` / `AlreadyEnabled` / `FeatureNotEnabled` names are renamed to use `activate` / `isActivated` / `FeatureActivated` / `AlreadyActivated` / `FeatureNotActivated` so the surface uses one verb matching the registry's name.
2. **`activationAdmin()` → `admin()`.** Shorter and unambiguous given the surrounding `IActivationRegistry` namespacing.

Activation remains one-way (no `deactivate` counterpart), matching upstream.

## Notes

- `DelegateCallNotAllowed` and `StaticCallNotAllowed` are kept on the interface for ABI completeness even though normal Solidity consumers can't trip them directly — the precompile reverts with these so callers parsing revert data benefit from having them in the ABI.
- The chain-node source also defines a `SECURITIES_TOKEN_CREATION` feature id constant. I left it out of this PR since the registry treats feature ids as opaque; a separate `ActivationFeatures` library can hold canonical ids once there's more than one known feature.
- The chain-node source flags the activation admin (`0xcb00…0000`) as **temporary**, to be replaced before deployment. The interface just returns whatever is configured at runtime, so no follow-up here.

## Test plan

- [x] `forge build` succeeds locally
- [ ] Sync the two deliberate divergences (rename, admin shorthand) with the base/base#2733 author before either side merges
- [ ] Decide whether to add a `SECURITIES_TOKEN_CREATION` constant in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)