### PR TITLE
Document policy ID type-encoding scheme and per-type counters

### DIFF
--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -40,17 +40,54 @@ pragma solidity >=0.8.20 <0.9.0;
 ///                  `REDEEMER_SENDER` at this sentinel), or as a "kill
 ///                  switch" independent of token-level pause.
 ///
-///         Custom policy IDs start at `1` and are assigned monotonically
-///         by `nextPolicyId`.
+///         **Policy ID encoding.** Custom policy IDs encode the policy's
+///         type directly into the top byte of the ID, so `policyType(id)`
+///         resolves via pure bit extraction with no SLOAD. Since every
+///         B-20 transfer / mint / redeem consults the registry, removing
+///         a per-call storage read from the type lookup is a material
+///         protocol-wide saving.
+///
+///         Encoding layout for custom IDs:
+///         ```
+///         [63:56]  uint8 type discriminator = uint8(PolicyType)
+///         [55:0]   uint56 local ID within that type's space (max ~7.2e16)
+///         ```
+///         Discriminators currently in use:
+///         - `0x00` — ALLOWLIST
+///         - `0x01` — BLOCKLIST
+///         - `0x02` .. `0xFE` — reserved for future PolicyType enum values
+///         - `0xFF` — reserved (`type(uint64).max` is the always-reject
+///                    built-in; the entire 0xFF discriminator slot is
+///                    reserved to keep that sentinel unambiguous)
+///
+///         The two built-in IDs (`0` and `type(uint64).max`) are
+///         special-cased BEFORE the encoding is consulted: implementations
+///         short-circuit on those exact ID values, so the fact that ID `0`
+///         numerically appears in the ALLOWLIST discriminator's local-ID
+///         space (and `type(uint64).max` appears in the reserved 0xFF
+///         space) does not create ambiguity at evaluation time. The
+///         per-type local-ID counter for ALLOWLIST skips local-ID `0` so
+///         no custom ALLOWLIST policy is ever assigned the encoded ID `0`.
+///
+///         This encoding gives `isAuthorized(policyId, account)` a
+///         best-case hot path of 1 SLOAD (the member set), compared to 2
+///         SLOADs if the type required a separate storage lookup. The
+///         built-in IDs cost 0 SLOADs (short-circuited).
+///
+///         Custom policy IDs are assigned by per-type monotonic counters;
+///         see `nextPolicyId(PolicyType)` to predict the next ID for a
+///         given type.
 ///
 ///         **Future extensions** (not in v1 scope, intended path):
 ///         - Union / intersect policies: compose two same-typed policies
 ///           into a derived membership check. Would be added as new enum
 ///           values (`UNION_ALLOWLIST`, `INTERSECT_ALLOWLIST`, and
 ///           blocklist counterparts) with sibling `createUnionPolicy` /
-///           `createIntersectPolicy` creators. Enum extension is
-///           backward-compatible; existing policies and consumers stay
-///           valid. Defer to a future hardfork.
+///           `createIntersectPolicy` creators. New types get new top-byte
+///           discriminators automatically (the encoding already reserves
+///           253 future type slots), so the storage shape does not need
+///           to change. Enum extension is backward-compatible; existing
+///           policies and consumers stay valid. Defer to a future hardfork.
 interface IPolicyRegistry {
     /*//////////////////////////////////////////////////////////////
                                   TYPES
@@ -219,16 +256,24 @@ interface IPolicyRegistry {
                             POLICY QUERIES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The next policy ID that will be assigned by the next call
-    ///         to `createPolicy` / `createPolicyWithAccounts`. Starts at
-    ///         `1` (ID `0` is reserved for the always-allow built-in;
-    ///         `type(uint64).max` is reserved for the always-reject
-    ///         built-in but is never assigned by the monotonic counter).
-    function nextPolicyId() external view returns (uint64);
+    /// @notice The next fully-encoded policy ID that will be assigned by
+    ///         the next `createPolicy(_, policyType)` /
+    ///         `createPolicyWithAccounts(_, policyType, _)` call for the
+    ///         given type. Each `PolicyType` has its own monotonic local
+    ///         counter; the returned value is the local counter combined
+    ///         with the type's top-byte discriminator (see the contract
+    ///         docstring "Policy ID encoding" section for the layout).
+    /// @dev    For ALLOWLIST the per-type counter starts at local-ID `1`
+    ///         (skipping the encoded ID `0`, which is the always-allow
+    ///         built-in). For all other current and future types the
+    ///         per-type counter starts at local-ID `0`.
+    function nextPolicyId(PolicyType policyType) external view returns (uint64);
 
     /// @notice Whether `policyId` exists. The built-in IDs (`0` and
-    ///         `type(uint64).max`) always exist; custom IDs in
-    ///         `[1, nextPolicyId)` exist iff they have been created.
+    ///         `type(uint64).max`) always exist; custom IDs exist iff they
+    ///         have been created. Custom IDs are recognizable by their
+    ///         top-byte discriminator falling within the active type
+    ///         range and their local-ID falling below the per-type counter.
     function policyExists(uint64 policyId) external view returns (bool);
 
     /// @notice The type of `policyId`. Reverts with `PolicyNotFound` for
@@ -236,6 +281,11 @@ interface IPolicyRegistry {
     ///         implementation-defined (the built-ins have no member set
     ///         and are not categorized as ALLOWLIST or BLOCKLIST);
     ///         callers should treat the built-ins as a separate case.
+    /// @dev    Per the policy-ID encoding scheme (see contract docstring),
+    ///         conforming implementations resolve this view via pure bit
+    ///         extraction from the top byte of `policyId` rather than via
+    ///         a storage read — except for the two built-in IDs, which are
+    ///         special-cased.
     function policyType(uint64 policyId) external view returns (PolicyType);
 
     /// @notice The current admin of `policyId`. Returns `address(0)` for


### PR DESCRIPTION
## Summary

Adds a missing piece of the `IPolicyRegistry` design: the policy ID
encoding scheme. The intent was that custom policy IDs encode their
type in the top byte so `policyType(id)` resolves via pure bit
extraction (no SLOAD), giving `isAuthorized` a 1-SLOAD hot path
instead of 2. The contract docstring on `main` describes neither the
encoding nor the per-type counter implication, so callers and
implementers have no way to know it's the intended protocol contract.

This PR fixes that with documentation + one signature change forced by
the per-type counter semantics. Interface-only. Build clean.

## What this does

### 1. Adds a \"Policy ID encoding\" section to the `IPolicyRegistry` docstring

Custom policy IDs are laid out as:

```
[63:56]  uint8 type discriminator = uint8(PolicyType)
[55:0]   uint56 local ID within that type's space (max ~7.2e16)
```

Discriminator allocation:
- `0x00` — ALLOWLIST
- `0x01` — BLOCKLIST
- `0x02 .. 0xFE` — reserved for future PolicyType enum values (253 slots)
- `0xFF` — reserved (the always-reject built-in `type(uint64).max` lives in this discriminator's slot; entire `0xFF` discriminator stays reserved to keep that sentinel unambiguous)

The two built-in IDs (`0` and `type(uint64).max`) are special-cased BEFORE
encoding extraction, so the fact that ID `0` numerically lies inside the
ALLOWLIST discriminator's local-ID space does not create ambiguity. The
ALLOWLIST per-type counter skips local-ID `0` to avoid assigning the
encoded ID `0` to any custom policy.

### 2. Changes `nextPolicyId()` → `nextPolicyId(PolicyType policyType)`

With per-type local-ID counters, \"the next policy ID\" only makes sense
relative to a type. The new signature returns the fully-encoded ID that
the next `createPolicy(_, policyType)` call would assign, so callers
can compare directly with IDs returned by `createPolicy` without
encoding or decoding themselves.

### 3. Tightens `policyType(uint64)` natspec

Documents that conforming implementations resolve this view via pure
bit extraction from the top byte rather than via a storage read,
except for the two built-in IDs (special-cased). The interface cannot
enforce purity; the encoding scheme is the protocol contract that
makes purity achievable.

## Why it matters

`isAuthorized(policyId, account)` is called by every B-20 token on
every transfer, mint, and redeem. Saving one SLOAD per call across
the entire B-20 ecosystem is a real protocol-wide gain. Without the
encoding scheme documented as part of the interface contract, a
conforming implementation cannot know to derive the type from the ID
bits rather than store it separately — and downstream tooling (block
explorers, indexers) cannot know to decode IDs without an RPC call.