### PR TITLE
IB20 + ITokenFactory: renounceLastAdmin, initCalls semantics, stablecoin natspec cleanup

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -4,8 +4,7 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IB20
 /// @notice The base Solidity surface every Base-native token (B-20) implements.
 ///         Variants (Stablecoin, Security, ...) extend this interface; nothing
-///         on this surface is variant-specific. A token created at the Default
-///         variant address presents exactly this interface.
+///         on this surface is variant-specific.
 ///
 /// @dev    Backward-compatible with ERC-20 at the function-selector level:
 ///         `transfer`, `transferFrom`, `approve`, `balanceOf`, `allowance`,
@@ -18,10 +17,19 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         six named roles (`DEFAULT_ADMIN_ROLE`, `MINT_ROLE`, `BURN_ROLE`,
 ///         `BURN_BLOCKED_ROLE`, `PAUSE_ROLE`, `UNPAUSE_ROLE`) plus arbitrary
 ///         user-defined roles. `grantRole`, `revokeRole`, `renounceRole`, and
-///         `setRoleAdmin` work uniformly across all roles. The only
-///         protocol-level constraint is that the LAST holder of
-///         `DEFAULT_ADMIN_ROLE` cannot renounce: the token must always have
-///         at least one admin.
+///         `setRoleAdmin` work uniformly across all roles, with one
+///         protocol-level constraint: the LAST holder of
+///         `DEFAULT_ADMIN_ROLE` cannot renounce via `renounceRole` (this
+///         guards against accidentally bricking the token's admin
+///         surface). Tokens that DO want to permanently shed admin
+///         control (e.g. memecoins finalizing a fair launch, immutable
+///         tokens locking in their configuration) use the dedicated
+///         `renounceLastAdmin()` function, whose distinct name and
+///         existence is the explicit intent signal. After
+///         `renounceLastAdmin()` the token has zero admins forever: no
+///         further `grantRole(DEFAULT_ADMIN_ROLE, ...)`, no policy
+///         updates, no supply-cap changes, no name/symbol changes, no
+///         further admin operations of any kind.
 ///
 ///         **Pause model.** Pause is granular: `pause(PausableFeature[])`
 ///         halts a set of operation classes (transfer, mint, burn, ...)
@@ -58,11 +66,9 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         Asymmetric per-role configuration is expressed by pointing
 ///         different slots at different policies — for example, a
 ///         sanctions BLOCKLIST on `TRANSFER_SENDER` and an unrestricted
-///         always-allow on `MINT_RECEIVER`. The registry stays flat;
-///         all composition happens at the token layer.
-///
-///         `approve` is NOT gated by any policy (only the act of MOVING
-///         balance is gated).
+///         always-allow on `TRANSFER_RECEIVER`. The registry stays flat;
+///         all composition happens at the token layer. `approve` is NOT
+///         gated by any policy (only the act of MOVING balance is gated).
 ///
 ///         **Permit.** EIP-2612 permit, EOA signatures only. ERC-1271
 ///         contract signatures are NOT supported on the default surface
@@ -189,9 +195,20 @@ interface IB20 {
     error InvalidSigner(address signer, address owner);
 
     /// @notice `renounceRole(DEFAULT_ADMIN_ROLE, ...)` was called when the
-    ///         caller is the last admin. Tokens MUST always have at least
-    ///         one admin; rotate to a new admin first via `grantRole`.
+    ///         caller is the last admin. `renounceRole` is the routine
+    ///         "give up MY hold on this role" path and guards against
+    ///         accidentally leaving the token with zero admins; callers
+    ///         that intentionally want a permanently adminless token must
+    ///         use the dedicated `renounceLastAdmin()` function instead.
     error LastAdminCannotRenounce();
+
+    /// @notice `renounceLastAdmin()` was called by an account that is not
+    ///         the sole remaining holder of `DEFAULT_ADMIN_ROLE`. The
+    ///         function exists exclusively to transition the token from
+    ///         single-admin to zero-admin atomically; revoking other
+    ///         admins to reach single-admin state first is the caller's
+    ///         responsibility.
+    error NotSoleAdmin();
 
     /// @notice The `callerConfirmation` argument to `renounceRole` was not
     ///         `msg.sender`. This guard prevents accidental renunciation
@@ -250,6 +267,17 @@ interface IB20 {
     ///         `setRoleAdmin`.
     /// @dev    Matches OZ AccessControl's `RoleAdminChanged` event exactly.
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /// @notice Emitted by `renounceLastAdmin` in addition to the
+    ///         standard `RoleRevoked(DEFAULT_ADMIN_ROLE, previousAdmin,
+    ///         previousAdmin)` event. Signals the irreversible
+    ///         transition of the token to a permanently adminless
+    ///         state: no `grantRole`, `revokeRole`, `setRoleAdmin`,
+    ///         `updatePolicy`, `setSupplyCap`, `setContractURI`,
+    ///         `setName`, or `setSymbol` call can ever succeed again.
+    ///         Indexers should treat this event as a one-way state
+    ///         transition.
+    event LastAdminRenounced(address indexed previousAdmin);
 
     /// @notice Emitted by `pause`. `features` is the argument to the
     ///         call (not the resulting paused state). `updater` is the
@@ -536,18 +564,48 @@ interface IB20 {
     function revokeRole(bytes32 role, address account) external;
 
     /// @notice Caller renounces `role` for themselves. Always permitted
-    ///         (no admin authorization needed).
+    ///         (no admin authorization needed), EXCEPT that
+    ///         `renounceRole(DEFAULT_ADMIN_ROLE, msg.sender)` reverts
+    ///         with `LastAdminCannotRenounce` when the caller is the
+    ///         sole remaining admin. Callers that intentionally want to
+    ///         transition the token to a permanently adminless state
+    ///         must use `renounceLastAdmin()` instead; the dedicated
+    ///         function name is the explicit intent signal that
+    ///         distinguishes "I'm giving up my hold on this role" from
+    ///         "the token should have zero admins forever."
     /// @dev    `callerConfirmation` MUST equal `msg.sender`; otherwise
     ///         reverts with `AccessControlBadConfirmation`. This guard
     ///         prevents a fat-fingered call from accidentally renouncing
     ///         for a different account.
-    ///
-    ///         Reverts with `LastAdminCannotRenounce` if `role` is
-    ///         `DEFAULT_ADMIN_ROLE` and `msg.sender` is the only current
-    ///         admin: the token must always have at least one admin.
-    ///         Rotate to a new admin first via `grantRole`, then
-    ///         renounce.
     function renounceRole(bytes32 role, address callerConfirmation) external;
+
+    /// @notice Permanently transitions the token to a zero-admin state.
+    ///         Revokes `DEFAULT_ADMIN_ROLE` from `msg.sender` and emits
+    ///         `LastAdminRenounced(msg.sender)` (in addition to the
+    ///         standard `RoleRevoked(DEFAULT_ADMIN_ROLE, msg.sender,
+    ///         msg.sender)`). After this call, the token has no admin
+    ///         and no holder of `DEFAULT_ADMIN_ROLE` can ever be
+    ///         reinstated: `grantRole(DEFAULT_ADMIN_ROLE, ...)` would
+    ///         require an admin caller and there is none. All
+    ///         admin-gated operations (`updatePolicy`, `setSupplyCap`,
+    ///         `setContractURI`, `setName`, `setSymbol`, and any
+    ///         `grantRole` / `revokeRole` / `setRoleAdmin` for other
+    ///         roles) become permanently uncallable.
+    /// @dev    Caller MUST be the sole remaining holder of
+    ///         `DEFAULT_ADMIN_ROLE`; otherwise reverts with
+    ///         `NotSoleAdmin` (when there are additional admins) or
+    ///         `AccessControlUnauthorizedAccount` (when `msg.sender`
+    ///         holds no admin role at all). To reach the single-admin
+    ///         state from a multi-admin starting point, the existing
+    ///         admin(s) must revoke or renounce other admins first via
+    ///         `revokeRole` / `renounceRole`, leaving exactly one.
+    ///
+    ///         No `callerConfirmation` argument: the dedicated function
+    ///         name is the intent signal. This mirrors the
+    ///         `renounceAdmin` pattern on `IPolicyRegistry`, which also
+    ///         has no confirmation argument and relies on its distinct
+    ///         name for accidental-misuse protection.
+    function renounceLastAdmin() external;
 
     /// @notice Sets the admin role for `role`. Caller MUST hold the
     ///         current admin role for `role`. Useful for delegating role

--- a/src/interfaces/IB20Stablecoin.sol
+++ b/src/interfaces/IB20Stablecoin.sol
@@ -9,33 +9,6 @@ import {IB20} from "./IB20.sol";
 ///         immutable `currency()` identifier for routing, categorization,
 ///         and wallet display.
 ///
-/// @dev    Per the team PRD, stablecoin-specific features that earlier
-///         drafts attempted to enshrine here have been moved out of the
-///         protocol surface entirely:
-///
-///         - **Per-minter rate limiting** lives in EVM periphery
-///           contracts (a stablecoin issuer's own controller / wrapper
-///           contract that holds `MINT_ROLE` and enforces per-caller
-///           quotas before invoking `mint` on the precompile). The
-///           Bridge `TIP20Controller` pattern and the CDP Custom
-///           Stablecoin pattern are both expressible this way.
-///         - **ERC-3009 transfer-with-authorization** is not on the
-///           default surface. Stablecoin issuers that need gasless
-///           payment flows can layer it via periphery contracts (or
-///           rely on EIP-2612 permit, which IS on the default surface,
-///           plus call-batching on the wallet side).
-///         - **Sanctions seizure** ("force-burn from blocked addresses")
-///           is not on the default surface either. CCS uses the
-///           "freeze, never seize" philosophy and never burns;
-///           stablecoin issuers that need seizure flows do them via
-///           periphery contracts that hold roles for the underlying
-///           operations.
-///
-///         Compliance (sanctions, jurisdiction restrictions, KYC) is
-///         delegated to the policy engine via `IB20.transferPolicyId`.
-///         Issuers point their stablecoin at a compound policy with the
-///         appropriate sender, recipient, mint-recipient, and redeemer
-///         slots configured per their compliance regime.
 interface IB20Stablecoin is IB20 {
     /*//////////////////////////////////////////////////////////////
                           CURRENCY IDENTIFIER

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -39,10 +39,22 @@ pragma solidity >=0.8.20 <0.9.0;
 ///
 ///         **`initCalls`.** After the token is deployed and the bootstrap
 ///         state is set, each entry in `initCalls` is invoked on the new
-///         token with `msg.sender == factory` and the factory acting as
-///         if it held `DEFAULT_ADMIN_ROLE`. This is how callers configure
-///         optional post-creation state (initial mints, supply caps,
-///         policy slot assignments, contract URI, initial pause state, etc.)
+///         token with `msg.sender == factory`. These calls are entirely
+///         privileged: every authorization gate the token would normally
+///         enforce against the caller (role checks, transfer-policy
+///         checks, capability gates) is bypassed for calls originating
+///         from the factory during the bootstrap window. The window
+///         closes the moment `createToken` returns; from that point
+///         forward every call is subject to the standard role and policy
+///         checks. The factory is NOT added to any role on the token;
+///         "privileged" means authorization is skipped for the bootstrap
+///         caller, not that the factory has been granted authority that
+///         persists. Invariants intrinsic to token correctness
+///         (supply-cap math, balance accounting, etc.) are still enforced.
+///
+///         This is the supported path for configuring optional
+///         post-creation state (initial mints, supply caps, policy slot
+///         assignments, contract URI, initial pause state, etc.)
 ///         atomically in the same transaction as creation. The factory
 ///         does not interpret the call data; any revert in an init call
 ///         reverts the whole creation.
@@ -76,10 +88,13 @@ interface ITokenFactory {
     /// @param name          ERC-20 token name.
     /// @param symbol        ERC-20 token symbol.
     /// @param initialAdmin  Initial holder of `DEFAULT_ADMIN_ROLE`. All
-    ///                      post-creation admin operations (including any
-    ///                      ranout through `initCalls`) ultimately
-    ///                      authorize against this account once the
-    ///                      bootstrap init returns.
+    ///                      post-creation admin operations authorize
+    ///                      against this account (and any additional
+    ///                      admins it later grants). The bootstrap
+    ///                      `initCalls` are NOT subject to this check:
+    ///                      they execute with full privilege regardless
+    ///                      of role state, and the privileged window
+    ///                      closes the moment `createToken` returns.
     /// @param decimals      ERC-20 decimals. MUST be in `[2, 18]`.
     ///                      Encoded into address byte `[11]` for
     ///                      stateless retrieval.
@@ -205,12 +220,20 @@ interface ITokenFactory {
     ///         After the token is constructed and its identity state
     ///         (name, symbol, decimals, admin, variant-specific fields)
     ///         is sealed, the factory invokes each entry in `initCalls`
-    ///         on the new token, acting as if it held the token's
-    ///         `DEFAULT_ADMIN_ROLE`. This is the supported path for
-    ///         configuring all optional post-creation state atomically:
-    ///         initial mints, supply caps, policy slot assignments,
-    ///         initial pause state, contract URI, etc. Any init-call revert
-    ///         reverts the entire creation.
+    ///         on the new token. These calls are entirely privileged:
+    ///         all authorization gates the token would normally enforce
+    ///         against the caller (role checks, transfer-policy checks,
+    ///         capability gates) are bypassed for calls from the factory
+    ///         during this bootstrap window. The factory is not added to
+    ///         any role; the bypass is bound to the call site, not to
+    ///         RBAC state. Once `createToken` returns, every subsequent
+    ///         call on the token is subject to the standard checks.
+    ///
+    ///         This is the supported path for configuring all optional
+    ///         post-creation state atomically: initial mints, supply
+    ///         caps, policy slot assignments, initial pause state,
+    ///         contract URI, etc. Any init-call revert reverts the
+    ///         entire creation.
     ///
     ///         Emits `TokenCreated` once the token's identity is sealed
     ///         and before any `initCalls` are dispatched, so init-call
@@ -221,8 +244,11 @@ interface ITokenFactory {
     ///                   derivation.
     /// @param params     ABI-encoded variant-specific creation struct,
     ///                   leading with the version byte.
-    /// @param initCalls  Optional admin-context bootstrap calls invoked
-    ///                   on the new token after identity is sealed.
+    /// @param initCalls  Optional bootstrap calls invoked on the new
+    ///                   token after identity is sealed. Executed as
+    ///                   fully privileged calls from the factory: all
+    ///                   token-side authorization checks are bypassed
+    ///                   for this window only.
     /// @return token     The address of the newly created token.
     function createToken(
         TokenVariant variant,


### PR DESCRIPTION
## Summary

Three independent natspec / interface refinements on `main`. Build
clean throughout. Each commit is independently reviewable; no
implementation work, just interface contract changes.

## Commits

### 1. Add `renounceLastAdmin()` for explicit transition to adminless tokens (`e5aa545`)

The PRD anticipates \"no owner\" tokens (memecoins finalizing fair
launches, immutable tokens locking their configuration, DAO handoffs)
but the current interface has no path to get there from a token that
was born with an admin:

- `renounceRole(DEFAULT_ADMIN_ROLE, msg.sender)` reverts with
  `LastAdminCannotRenounce` when called by the sole remaining admin (a
  deliberate guard against bricking the admin surface accidentally).
- `revokeRole` always leaves at least one admin (the caller).
- Factory-time `initialAdmin = address(0)` is at best a single-shot
  workaround and doesn't cover \"configure then renounce.\"

Adds `renounceLastAdmin()` as the dedicated explicit path. Single-step,
no two-step ceremony: the distinct function name (separate from the
routine `renounceRole` flow) is the intent signal, mirroring the
pattern established for `IPolicyRegistry.renounceAdmin`. Naming
divergence from the registry only in qualification: where the registry
has at most one admin per policy, `IB20` supports multiple admin
holders, so the function is named `renounceLastAdmin` to make the
sole-admin precondition self-documenting.

**Surface additions:**
- `function renounceLastAdmin() external`
- `error NotSoleAdmin()` — caller is admin but not the only one
- `event LastAdminRenounced(address indexed previousAdmin)` — distinct
  from generic `RoleRevoked` because the state transition is
  significant: `updatePolicy`, `setSupplyCap`, `setContractURI`,
  `setName`, `setSymbol`, and any `grantRole` / `revokeRole` /
  `setRoleAdmin` for any role all become permanently uncallable.
  Indexers can detect this transition cheaply via the dedicated event
  instead of walking role membership.

**Natspec updates:**
- Contract docstring now documents the `renounceLastAdmin` escape
  hatch alongside the existing `renounceRole` guard.
- `renounceRole` and `LastAdminCannotRenounce` natspec both point at
  `renounceLastAdmin` as the explicit alternative for intentional
  adminless transitions.

No `callerConfirmation` argument: mirrors
`IPolicyRegistry.renounceAdmin` (also no confirmation, distinct name
is the intent signal).

### 2. Drop stale `@dev` block from `IB20Stablecoin` natspec (`5667830`)

The deleted block (27 lines of contract-level `@dev`) referenced two
concepts that no longer exist in the interface:

- `IB20.transferPolicyId` — replaced by the generic
  `policyId(bytes32)` / `updatePolicy(bytes32, uint64)` mapping with
  five standard policy-type constants.
- Compound policies — removed from `IPolicyRegistry` entirely;
  per-role asymmetric authorization is now expressed token-side via
  separate policy IDs in distinct slots.

The block was load-bearing context when stablecoin-specific features
(per-minter rate limiting, ERC-3009, sanctions seizure) were being
actively cut from the surface; with the cuts long since landed and
the surrounding architecture rewritten, it now misleads more than it
informs. The `currency` identifier remains the entire
stablecoin-specific surface.

### 3. Clarify `initCalls` semantics as entirely privileged (`f3a278d`)

Previous natspec described `initCalls` as the factory \"acting as if it
held `DEFAULT_ADMIN_ROLE`.\" This conflated two different models:

1. **Admin-via-RBAC**: factory temporarily granted `DEFAULT_ADMIN_ROLE`,
   calls go through normal role checks. NOT the design intent.
2. **Privileged-via-call-site**: factory call frames recognized as
   privileged at the auth-check layer; no role grant happens. The
   actual design intent, per team alignment.

The distinction matters because admin-via-RBAC can only do what an
admin can do, which is strictly less than what the factory needs at
bootstrap (e.g. initial mints to addresses not yet on a configured
`MINT_RECEIVER` allowlist, or supply-cap configuration that interacts
with policy slots before they're set). Entirely-privileged execution
lets the factory configure any state the token exposes without
ordering constraints.

Updates four natspec sites for consistency:
- Contract-level `@dev` block (the canonical `initCalls` explainer)
- `B20CreateParams.initialAdmin` field (had a `ranout` typo plus the
  stale \"authorize through `initCalls`\" wording)
- `createToken` function natspec around `initCalls` behavior
- `initCalls` `@param` description

All four now describe the same model:

- `msg.sender == factory` for the duration of `initCalls`
- All token-side authorization gates (role checks, transfer-policy
  checks, capability gates) bypassed for factory-originated calls
- Bootstrap window closes the moment `createToken` returns
- Factory is **NOT** granted any role on the token (privileged-via-call-site,
  not via RBAC)
- Token invariants (supply-cap math, balance accounting) still enforced
  throughout

## Out of scope

- Implementation work for any of the above. Interface contract only.
- Other natspec touch-ups beyond the targeted three areas.
- Tests.