### PR TITLE
Sync test scaffolding with latest main (nextPolicyId encoding + renounceLastAdmin)

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -4,8 +4,7 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IB20
 /// @notice The base Solidity surface every Base-native token (B-20) implements.
 ///         Variants (Stablecoin, Security, ...) extend this interface; nothing
-///         on this surface is variant-specific. A token created at the Default
-///         variant address presents exactly this interface.
+///         on this surface is variant-specific.
 ///
 /// @dev    Backward-compatible with ERC-20 at the function-selector level:
 ///         `transfer`, `transferFrom`, `approve`, `balanceOf`, `allowance`,
@@ -18,10 +17,19 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         six named roles (`DEFAULT_ADMIN_ROLE`, `MINT_ROLE`, `BURN_ROLE`,
 ///         `BURN_BLOCKED_ROLE`, `PAUSE_ROLE`, `UNPAUSE_ROLE`) plus arbitrary
 ///         user-defined roles. `grantRole`, `revokeRole`, `renounceRole`, and
-///         `setRoleAdmin` work uniformly across all roles. The only
-///         protocol-level constraint is that the LAST holder of
-///         `DEFAULT_ADMIN_ROLE` cannot renounce: the token must always have
-///         at least one admin.
+///         `setRoleAdmin` work uniformly across all roles, with one
+///         protocol-level constraint: the LAST holder of
+///         `DEFAULT_ADMIN_ROLE` cannot renounce via `renounceRole` (this
+///         guards against accidentally bricking the token's admin
+///         surface). Tokens that DO want to permanently shed admin
+///         control (e.g. memecoins finalizing a fair launch, immutable
+///         tokens locking in their configuration) use the dedicated
+///         `renounceLastAdmin()` function, whose distinct name and
+///         existence is the explicit intent signal. After
+///         `renounceLastAdmin()` the token has zero admins forever: no
+///         further `grantRole(DEFAULT_ADMIN_ROLE, ...)`, no policy
+///         updates, no supply-cap changes, no name/symbol changes, no
+///         further admin operations of any kind.
 ///
 ///         **Pause model.** Pause is granular: `pause(PausableFeature[])`
 ///         halts a set of operation classes (transfer, mint, burn, ...)
@@ -58,11 +66,9 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         Asymmetric per-role configuration is expressed by pointing
 ///         different slots at different policies — for example, a
 ///         sanctions BLOCKLIST on `TRANSFER_SENDER` and an unrestricted
-///         always-allow on `MINT_RECEIVER`. The registry stays flat;
-///         all composition happens at the token layer.
-///
-///         `approve` is NOT gated by any policy (only the act of MOVING
-///         balance is gated).
+///         always-allow on `TRANSFER_RECEIVER`. The registry stays flat;
+///         all composition happens at the token layer. `approve` is NOT
+///         gated by any policy (only the act of MOVING balance is gated).
 ///
 ///         **Permit.** EIP-2612 permit, EOA signatures only. ERC-1271
 ///         contract signatures are NOT supported on the default surface
@@ -189,9 +195,20 @@ interface IB20 {
     error InvalidSigner(address signer, address owner);
 
     /// @notice `renounceRole(DEFAULT_ADMIN_ROLE, ...)` was called when the
-    ///         caller is the last admin. Tokens MUST always have at least
-    ///         one admin; rotate to a new admin first via `grantRole`.
+    ///         caller is the last admin. `renounceRole` is the routine
+    ///         "give up MY hold on this role" path and guards against
+    ///         accidentally leaving the token with zero admins; callers
+    ///         that intentionally want a permanently adminless token must
+    ///         use the dedicated `renounceLastAdmin()` function instead.
     error LastAdminCannotRenounce();
+
+    /// @notice `renounceLastAdmin()` was called by an account that is not
+    ///         the sole remaining holder of `DEFAULT_ADMIN_ROLE`. The
+    ///         function exists exclusively to transition the token from
+    ///         single-admin to zero-admin atomically; revoking other
+    ///         admins to reach single-admin state first is the caller's
+    ///         responsibility.
+    error NotSoleAdmin();
 
     /// @notice The `callerConfirmation` argument to `renounceRole` was not
     ///         `msg.sender`. This guard prevents accidental renunciation
@@ -250,6 +267,17 @@ interface IB20 {
     ///         `setRoleAdmin`.
     /// @dev    Matches OZ AccessControl's `RoleAdminChanged` event exactly.
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /// @notice Emitted by `renounceLastAdmin` in addition to the
+    ///         standard `RoleRevoked(DEFAULT_ADMIN_ROLE, previousAdmin,
+    ///         previousAdmin)` event. Signals the irreversible
+    ///         transition of the token to a permanently adminless
+    ///         state: no `grantRole`, `revokeRole`, `setRoleAdmin`,
+    ///         `updatePolicy`, `setSupplyCap`, `setContractURI`,
+    ///         `setName`, or `setSymbol` call can ever succeed again.
+    ///         Indexers should treat this event as a one-way state
+    ///         transition.
+    event LastAdminRenounced(address indexed previousAdmin);
 
     /// @notice Emitted by `pause`. `features` is the argument to the
     ///         call (not the resulting paused state). `updater` is the
@@ -536,18 +564,48 @@ interface IB20 {
     function revokeRole(bytes32 role, address account) external;
 
     /// @notice Caller renounces `role` for themselves. Always permitted
-    ///         (no admin authorization needed).
+    ///         (no admin authorization needed), EXCEPT that
+    ///         `renounceRole(DEFAULT_ADMIN_ROLE, msg.sender)` reverts
+    ///         with `LastAdminCannotRenounce` when the caller is the
+    ///         sole remaining admin. Callers that intentionally want to
+    ///         transition the token to a permanently adminless state
+    ///         must use `renounceLastAdmin()` instead; the dedicated
+    ///         function name is the explicit intent signal that
+    ///         distinguishes "I'm giving up my hold on this role" from
+    ///         "the token should have zero admins forever."
     /// @dev    `callerConfirmation` MUST equal `msg.sender`; otherwise
     ///         reverts with `AccessControlBadConfirmation`. This guard
     ///         prevents a fat-fingered call from accidentally renouncing
     ///         for a different account.
-    ///
-    ///         Reverts with `LastAdminCannotRenounce` if `role` is
-    ///         `DEFAULT_ADMIN_ROLE` and `msg.sender` is the only current
-    ///         admin: the token must always have at least one admin.
-    ///         Rotate to a new admin first via `grantRole`, then
-    ///         renounce.
     function renounceRole(bytes32 role, address callerConfirmation) external;
+
+    /// @notice Permanently transitions the token to a zero-admin state.
+    ///         Revokes `DEFAULT_ADMIN_ROLE` from `msg.sender` and emits
+    ///         `LastAdminRenounced(msg.sender)` (in addition to the
+    ///         standard `RoleRevoked(DEFAULT_ADMIN_ROLE, msg.sender,
+    ///         msg.sender)`). After this call, the token has no admin
+    ///         and no holder of `DEFAULT_ADMIN_ROLE` can ever be
+    ///         reinstated: `grantRole(DEFAULT_ADMIN_ROLE, ...)` would
+    ///         require an admin caller and there is none. All
+    ///         admin-gated operations (`updatePolicy`, `setSupplyCap`,
+    ///         `setContractURI`, `setName`, `setSymbol`, and any
+    ///         `grantRole` / `revokeRole` / `setRoleAdmin` for other
+    ///         roles) become permanently uncallable.
+    /// @dev    Caller MUST be the sole remaining holder of
+    ///         `DEFAULT_ADMIN_ROLE`; otherwise reverts with
+    ///         `NotSoleAdmin` (when there are additional admins) or
+    ///         `AccessControlUnauthorizedAccount` (when `msg.sender`
+    ///         holds no admin role at all). To reach the single-admin
+    ///         state from a multi-admin starting point, the existing
+    ///         admin(s) must revoke or renounce other admins first via
+    ///         `revokeRole` / `renounceRole`, leaving exactly one.
+    ///
+    ///         No `callerConfirmation` argument: the dedicated function
+    ///         name is the intent signal. This mirrors the
+    ///         `renounceAdmin` pattern on `IPolicyRegistry`, which also
+    ///         has no confirmation argument and relies on its distinct
+    ///         name for accidental-misuse protection.
+    function renounceLastAdmin() external;
 
     /// @notice Sets the admin role for `role`. Caller MUST hold the
     ///         current admin role for `role`. Useful for delegating role

--- a/src/interfaces/IB20Stablecoin.sol
+++ b/src/interfaces/IB20Stablecoin.sol
@@ -9,33 +9,6 @@ import {IB20} from "./IB20.sol";
 ///         immutable `currency()` identifier for routing, categorization,
 ///         and wallet display.
 ///
-/// @dev    Per the team PRD, stablecoin-specific features that earlier
-///         drafts attempted to enshrine here have been moved out of the
-///         protocol surface entirely:
-///
-///         - **Per-minter rate limiting** lives in EVM periphery
-///           contracts (a stablecoin issuer's own controller / wrapper
-///           contract that holds `MINT_ROLE` and enforces per-caller
-///           quotas before invoking `mint` on the precompile). The
-///           Bridge `TIP20Controller` pattern and the CDP Custom
-///           Stablecoin pattern are both expressible this way.
-///         - **ERC-3009 transfer-with-authorization** is not on the
-///           default surface. Stablecoin issuers that need gasless
-///           payment flows can layer it via periphery contracts (or
-///           rely on EIP-2612 permit, which IS on the default surface,
-///           plus call-batching on the wallet side).
-///         - **Sanctions seizure** ("force-burn from blocked addresses")
-///           is not on the default surface either. CCS uses the
-///           "freeze, never seize" philosophy and never burns;
-///           stablecoin issuers that need seizure flows do them via
-///           periphery contracts that hold roles for the underlying
-///           operations.
-///
-///         Compliance (sanctions, jurisdiction restrictions, KYC) is
-///         delegated to the policy engine via `IB20.transferPolicyId`.
-///         Issuers point their stablecoin at a compound policy with the
-///         appropriate sender, recipient, mint-recipient, and redeemer
-///         slots configured per their compliance regime.
 interface IB20Stablecoin is IB20 {
     /*//////////////////////////////////////////////////////////////
                           CURRENCY IDENTIFIER

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -40,17 +40,54 @@ pragma solidity >=0.8.20 <0.9.0;
 ///                  `REDEEMER_SENDER` at this sentinel), or as a "kill
 ///                  switch" independent of token-level pause.
 ///
-///         Custom policy IDs start at `1` and are assigned monotonically
-///         by `nextPolicyId`.
+///         **Policy ID encoding.** Custom policy IDs encode the policy's
+///         type directly into the top byte of the ID, so `policyType(id)`
+///         resolves via pure bit extraction with no SLOAD. Since every
+///         B-20 transfer / mint / redeem consults the registry, removing
+///         a per-call storage read from the type lookup is a material
+///         protocol-wide saving.
+///
+///         Encoding layout for custom IDs:
+///         ```
+///         [63:56]  uint8 type discriminator = uint8(PolicyType)
+///         [55:0]   uint56 local ID within that type's space (max ~7.2e16)
+///         ```
+///         Discriminators currently in use:
+///         - `0x00` — ALLOWLIST
+///         - `0x01` — BLOCKLIST
+///         - `0x02` .. `0xFE` — reserved for future PolicyType enum values
+///         - `0xFF` — reserved (`type(uint64).max` is the always-reject
+///                    built-in; the entire 0xFF discriminator slot is
+///                    reserved to keep that sentinel unambiguous)
+///
+///         The two built-in IDs (`0` and `type(uint64).max`) are
+///         special-cased BEFORE the encoding is consulted: implementations
+///         short-circuit on those exact ID values, so the fact that ID `0`
+///         numerically appears in the ALLOWLIST discriminator's local-ID
+///         space (and `type(uint64).max` appears in the reserved 0xFF
+///         space) does not create ambiguity at evaluation time. The
+///         per-type local-ID counter for ALLOWLIST skips local-ID `0` so
+///         no custom ALLOWLIST policy is ever assigned the encoded ID `0`.
+///
+///         This encoding gives `isAuthorized(policyId, account)` a
+///         best-case hot path of 1 SLOAD (the member set), compared to 2
+///         SLOADs if the type required a separate storage lookup. The
+///         built-in IDs cost 0 SLOADs (short-circuited).
+///
+///         Custom policy IDs are assigned by per-type monotonic counters;
+///         see `nextPolicyId(PolicyType)` to predict the next ID for a
+///         given type.
 ///
 ///         **Future extensions** (not in v1 scope, intended path):
 ///         - Union / intersect policies: compose two same-typed policies
 ///           into a derived membership check. Would be added as new enum
 ///           values (`UNION_ALLOWLIST`, `INTERSECT_ALLOWLIST`, and
 ///           blocklist counterparts) with sibling `createUnionPolicy` /
-///           `createIntersectPolicy` creators. Enum extension is
-///           backward-compatible; existing policies and consumers stay
-///           valid. Defer to a future hardfork.
+///           `createIntersectPolicy` creators. New types get new top-byte
+///           discriminators automatically (the encoding already reserves
+///           253 future type slots), so the storage shape does not need
+///           to change. Enum extension is backward-compatible; existing
+///           policies and consumers stay valid. Defer to a future hardfork.
 interface IPolicyRegistry {
     /*//////////////////////////////////////////////////////////////
                                   TYPES
@@ -219,16 +256,24 @@ interface IPolicyRegistry {
                             POLICY QUERIES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The next policy ID that will be assigned by the next call
-    ///         to `createPolicy` / `createPolicyWithAccounts`. Starts at
-    ///         `1` (ID `0` is reserved for the always-allow built-in;
-    ///         `type(uint64).max` is reserved for the always-reject
-    ///         built-in but is never assigned by the monotonic counter).
-    function nextPolicyId() external view returns (uint64);
+    /// @notice The next fully-encoded policy ID that will be assigned by
+    ///         the next `createPolicy(_, policyType)` /
+    ///         `createPolicyWithAccounts(_, policyType, _)` call for the
+    ///         given type. Each `PolicyType` has its own monotonic local
+    ///         counter; the returned value is the local counter combined
+    ///         with the type's top-byte discriminator (see the contract
+    ///         docstring "Policy ID encoding" section for the layout).
+    /// @dev    For ALLOWLIST the per-type counter starts at local-ID `1`
+    ///         (skipping the encoded ID `0`, which is the always-allow
+    ///         built-in). For all other current and future types the
+    ///         per-type counter starts at local-ID `0`.
+    function nextPolicyId(PolicyType policyType) external view returns (uint64);
 
     /// @notice Whether `policyId` exists. The built-in IDs (`0` and
-    ///         `type(uint64).max`) always exist; custom IDs in
-    ///         `[1, nextPolicyId)` exist iff they have been created.
+    ///         `type(uint64).max`) always exist; custom IDs exist iff they
+    ///         have been created. Custom IDs are recognizable by their
+    ///         top-byte discriminator falling within the active type
+    ///         range and their local-ID falling below the per-type counter.
     function policyExists(uint64 policyId) external view returns (bool);
 
     /// @notice The type of `policyId`. Reverts with `PolicyNotFound` for
@@ -236,6 +281,11 @@ interface IPolicyRegistry {
     ///         implementation-defined (the built-ins have no member set
     ///         and are not categorized as ALLOWLIST or BLOCKLIST);
     ///         callers should treat the built-ins as a separate case.
+    /// @dev    Per the policy-ID encoding scheme (see contract docstring),
+    ///         conforming implementations resolve this view via pure bit
+    ///         extraction from the top byte of `policyId` rather than via
+    ///         a storage read — except for the two built-in IDs, which are
+    ///         special-cased.
     function policyType(uint64 policyId) external view returns (PolicyType);
 
     /// @notice The current admin of `policyId`. Returns `address(0)` for

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -39,10 +39,22 @@ pragma solidity >=0.8.20 <0.9.0;
 ///
 ///         **`initCalls`.** After the token is deployed and the bootstrap
 ///         state is set, each entry in `initCalls` is invoked on the new
-///         token with `msg.sender == factory` and the factory acting as
-///         if it held `DEFAULT_ADMIN_ROLE`. This is how callers configure
-///         optional post-creation state (initial mints, supply caps,
-///         policy slot assignments, contract URI, initial pause state, etc.)
+///         token with `msg.sender == factory`. These calls are entirely
+///         privileged: every authorization gate the token would normally
+///         enforce against the caller (role checks, transfer-policy
+///         checks, capability gates) is bypassed for calls originating
+///         from the factory during the bootstrap window. The window
+///         closes the moment `createToken` returns; from that point
+///         forward every call is subject to the standard role and policy
+///         checks. The factory is NOT added to any role on the token;
+///         "privileged" means authorization is skipped for the bootstrap
+///         caller, not that the factory has been granted authority that
+///         persists. Invariants intrinsic to token correctness
+///         (supply-cap math, balance accounting, etc.) are still enforced.
+///
+///         This is the supported path for configuring optional
+///         post-creation state (initial mints, supply caps, policy slot
+///         assignments, contract URI, initial pause state, etc.)
 ///         atomically in the same transaction as creation. The factory
 ///         does not interpret the call data; any revert in an init call
 ///         reverts the whole creation.
@@ -76,10 +88,13 @@ interface ITokenFactory {
     /// @param name          ERC-20 token name.
     /// @param symbol        ERC-20 token symbol.
     /// @param initialAdmin  Initial holder of `DEFAULT_ADMIN_ROLE`. All
-    ///                      post-creation admin operations (including any
-    ///                      ranout through `initCalls`) ultimately
-    ///                      authorize against this account once the
-    ///                      bootstrap init returns.
+    ///                      post-creation admin operations authorize
+    ///                      against this account (and any additional
+    ///                      admins it later grants). The bootstrap
+    ///                      `initCalls` are NOT subject to this check:
+    ///                      they execute with full privilege regardless
+    ///                      of role state, and the privileged window
+    ///                      closes the moment `createToken` returns.
     /// @param decimals      ERC-20 decimals. MUST be in `[2, 18]`.
     ///                      Encoded into address byte `[11]` for
     ///                      stateless retrieval.
@@ -205,12 +220,20 @@ interface ITokenFactory {
     ///         After the token is constructed and its identity state
     ///         (name, symbol, decimals, admin, variant-specific fields)
     ///         is sealed, the factory invokes each entry in `initCalls`
-    ///         on the new token, acting as if it held the token's
-    ///         `DEFAULT_ADMIN_ROLE`. This is the supported path for
-    ///         configuring all optional post-creation state atomically:
-    ///         initial mints, supply caps, policy slot assignments,
-    ///         initial pause state, contract URI, etc. Any init-call revert
-    ///         reverts the entire creation.
+    ///         on the new token. These calls are entirely privileged:
+    ///         all authorization gates the token would normally enforce
+    ///         against the caller (role checks, transfer-policy checks,
+    ///         capability gates) are bypassed for calls from the factory
+    ///         during this bootstrap window. The factory is not added to
+    ///         any role; the bypass is bound to the call site, not to
+    ///         RBAC state. Once `createToken` returns, every subsequent
+    ///         call on the token is subject to the standard checks.
+    ///
+    ///         This is the supported path for configuring all optional
+    ///         post-creation state atomically: initial mints, supply
+    ///         caps, policy slot assignments, initial pause state,
+    ///         contract URI, etc. Any init-call revert reverts the
+    ///         entire creation.
     ///
     ///         Emits `TokenCreated` once the token's identity is sealed
     ///         and before any `initCalls` are dispatched, so init-call
@@ -221,8 +244,11 @@ interface ITokenFactory {
     ///                   derivation.
     /// @param params     ABI-encoded variant-specific creation struct,
     ///                   leading with the version byte.
-    /// @param initCalls  Optional admin-context bootstrap calls invoked
-    ///                   on the new token after identity is sealed.
+    /// @param initCalls  Optional bootstrap calls invoked on the new
+    ///                   token after identity is sealed. Executed as
+    ///                   fully privileged calls from the factory: all
+    ///                   token-side authorization checks are bypassed
+    ///                   for this window only.
     /// @return token     The address of the newly created token.
     function createToken(
         TokenVariant variant,

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -56,7 +56,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
         revert("MockPolicyRegistry: not implemented");
     }
 
-    function nextPolicyId() external pure returns (uint64) {
+    function nextPolicyId(PolicyType) external pure returns (uint64) {
         revert("MockPolicyRegistry: not implemented");
     }
 

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {B20Test} from "test/lib/B20Test.sol";
+
+contract B20RenounceLastAdminTest is B20Test {
+    /// @notice Verifies renounceLastAdmin reverts when caller does not hold DEFAULT_ADMIN_ROLE
+    /// @dev    Distinct from NotSoleAdmin: the caller isn't an admin at all,
+    ///         so authorization fails before the "are you the only one?" check.
+    ///         Checks AccessControlUnauthorizedAccount(caller, DEFAULT_ADMIN_ROLE).
+    function test_renounceLastAdmin_revert_callerNotAdmin(address caller) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies renounceLastAdmin reverts when caller is an admin but additional admins exist
+    /// @dev    The function exists exclusively to transition single-admin → zero-admin.
+    ///         Callers that want to step away while leaving the token administered should
+    ///         use renounceRole (which only allows non-last admins to renounce themselves).
+    ///         Checks NotSoleAdmin() error.
+    function test_renounceLastAdmin_revert_multipleAdmins(address otherAdmin) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies renounceLastAdmin clears DEFAULT_ADMIN_ROLE from the caller
+    /// @dev    Read-after-write: hasRole(DEFAULT_ADMIN_ROLE, msg.sender) is false post-call.
+    function test_renounceLastAdmin_success_clearsAdminRole() public {
+        // unimplemented
+    }
+
+    /// @notice Verifies admin-gated operations revert after renounceLastAdmin
+    /// @dev    Permanent-immutability invariant. updatePolicy is the canonical example;
+    ///         the same mechanism (no admin holder → AccessControlUnauthorizedAccount on
+    ///         any DEFAULT_ADMIN_ROLE-gated call) covers setSupplyCap, setContractURI,
+    ///         setName, setSymbol, grantRole / revokeRole / setRoleAdmin for any role.
+    ///         No test should be able to reinstate an admin after this transition.
+    function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyType, uint64 newPolicyId) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies grantRole(DEFAULT_ADMIN_ROLE, ...) cannot succeed post-renunciation
+    /// @dev    Explicit test of the "no path back to admin" property. grantRole requires
+    ///         the caller to hold the admin role for the target role; with zero admins,
+    ///         every grant call (from any caller, for any account) reverts.
+    function test_renounceLastAdmin_success_noPathToReinstateAdmin(address wouldBeNewAdmin, address caller) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)
+    /// @dev    Canonical emission test for LastAdminRenounced. The standard
+    ///         RoleRevoked(DEFAULT_ADMIN_ROLE, caller, caller) is also emitted, but its
+    ///         canonical emission test lives in revokeRole.t.sol; this stub asserts
+    ///         only the dedicated event.
+    function test_renounceLastAdmin_success_emitsLastAdminRenounced() public {
+        // unimplemented
+    }
+}

--- a/test/unit/PolicyRegistry/nextPolicyId.t.sol
+++ b/test/unit/PolicyRegistry/nextPolicyId.t.sol
@@ -3,16 +3,42 @@ pragma solidity ^0.8.20;
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
 contract PolicyRegistryNextPolicyIdTest is PolicyRegistryTest {
-    /// @notice Verifies nextPolicyId starts at 1 (id 0 reserved for the always-allow built-in)
-    /// @dev Initial state check before any policy creations
-    function test_nextPolicyId_success_startsAtOne() public {
+    /// @notice Verifies nextPolicyId(ALLOWLIST) returns the first ALLOWLIST-encoded id
+    ///         the next createPolicy(_, ALLOWLIST) would assign
+    /// @dev Per the policy ID encoding scheme (top byte = type discriminator,
+    ///      ALLOWLIST counter skips local-id 0 to avoid colliding with the
+    ///      always-allow built-in at encoded id 0), the first allowlist id is
+    ///      `(uint64(uint8(PolicyType.ALLOWLIST)) << 56) | 1`
+    function test_nextPolicyId_success_allowlistInitialEncoded() public {
         // unimplemented
     }
 
-    /// @notice Verifies nextPolicyId advances by one per successful createPolicy call
-    /// @dev Monotonic counter; checks the returned id equals the prior nextPolicyId value
-    function test_nextPolicyId_success_advancesPerCreate(uint8 count) public {
+    /// @notice Verifies nextPolicyId(BLOCKLIST) returns the first BLOCKLIST-encoded id
+    ///         the next createPolicy(_, BLOCKLIST) would assign
+    /// @dev Per the policy ID encoding scheme, the first blocklist id is
+    ///      `(uint64(uint8(PolicyType.BLOCKLIST)) << 56) | 0` — no skip on
+    ///      non-ALLOWLIST counters (only ALLOWLIST collides with built-in 0)
+    function test_nextPolicyId_success_blocklistInitialEncoded() public {
+        // unimplemented
+    }
+
+    /// @notice Verifies nextPolicyId(type) advances by one (local-id) per
+    ///         successful createPolicy(_, type) call
+    /// @dev Per-type monotonic counter; check returned id equals the prior
+    ///      nextPolicyId(type) value and that the top-byte discriminator stays
+    ///      stable across the sequence
+    function test_nextPolicyId_success_advancesPerCreate(IPolicyRegistry.PolicyType policyType, uint8 count) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies nextPolicyId(ALLOWLIST) and nextPolicyId(BLOCKLIST)
+    ///         advance independently
+    /// @dev Per-type counters do not share state; creating an allowlist must
+    ///      not affect the next-blocklist-id value and vice versa
+    function test_nextPolicyId_success_perTypeCountersIndependent(uint8 allowCount, uint8 blockCount) public {
         // unimplemented
     }
 }


### PR DESCRIPTION
## Summary

Brings `conner/test-spec-phase` (PR #19) up to date with the two
interface PRs that have landed on `main` since the test scaffolding
was written. Merges `main` cleanly (no manual conflict resolution
needed in `src/` — interface changes don't physically overlap with
the new `test/` tree), then patches three files for the two
behavioral interface deltas.

Goal: get the scaffolding mergeable to `main` so the next-phase
mock-implementation work can branch off a clean baseline.

Build clean throughout.

## Changes

### Picked up from `main` via merge

- **PR #21** — `IPolicyRegistry.nextPolicyId()` →
  `nextPolicyId(PolicyType)`, with the policy-ID encoding scheme
  documented (top-byte type discriminator, per-type local counters).
- **PR #22** — `IB20.renounceLastAdmin()` + `NotSoleAdmin` error +
  `LastAdminRenounced` event, `IB20Stablecoin` natspec cleanup,
  `ITokenFactory.initCalls` semantics clarified (entirely
  privileged, not admin-roled).

### Patched in this PR

Three files needed updates because the test scaffolding referenced
the pre-merge interfaces:

1. **`test/lib/mocks/MockPolicyRegistry.sol`** — `nextPolicyId`
   signature updated from `()` to `(PolicyType)`. Still reverts as
   `\"MockPolicyRegistry: not implemented\"`; the full mock pass lives
   in a later PR.

2. **`test/unit/PolicyRegistry/nextPolicyId.t.sol`** — rewrote the
   two old stubs (which assumed a single global counter starting at
   1) into four encoding-aware ones:
   - `allowlistInitialEncoded` — first ALLOWLIST id is
     `(uint8(PolicyType.ALLOWLIST) << 56) | 1` (the counter skips
     local-id 0 to avoid colliding with the always-allow built-in
     at encoded id 0)
   - `blocklistInitialEncoded` — first BLOCKLIST id is
     `(uint8(PolicyType.BLOCKLIST) << 56) | 0` (no skip; non-allowlist
     counters don't collide with built-ins)
   - `advancesPerCreate` — fuzzed over `PolicyType` and count, asserts
     the local-id portion advances by 1 per create call and the
     top-byte discriminator stays stable
   - `perTypeCountersIndependent` — creating an allowlist must not
     advance the next-blocklist-id and vice versa

3. **`test/unit/B20/roles/renounceLastAdmin.t.sol`** (new file) —
   six stubs following the existing convention (reverts first in
   source-execution order, happy paths after, single canonical event
   emission test):
   - `callerNotAdmin` revert (`AccessControlUnauthorizedAccount`)
   - `multipleAdmins` revert (`NotSoleAdmin`)
   - `clearsAdminRole` success (read-after-write)
   - `subsequentAdminCallsRevert` success (permanent-immutability
     invariant; uses `updatePolicy` as the canonical example since
     the same \"no admin holder → AccessControlUnauthorizedAccount on
     any DEFAULT_ADMIN_ROLE-gated call\" mechanism covers
     `setSupplyCap`, `setContractURI`, `setName`, `setSymbol`,
     `grantRole`, `revokeRole`, `setRoleAdmin`)
   - `noPathToReinstateAdmin` success (explicit test of the \"no path
     back to admin\" property; `grantRole(DEFAULT_ADMIN_ROLE, ...)`
     cannot succeed from any caller post-renunciation)
   - `emitsLastAdminRenounced` success (canonical for the dedicated
     event; standard `RoleRevoked` emission stays in
     `revokeRole.t.sol`)

### Not touched

- `ITokenFactory` initCalls natspec change (PR #22) — docs-only, no
  test-stub impact.
- `IB20Stablecoin` natspec cleanup (PR #22) — docs-only, no
  test-stub impact.

## Out of scope

- Stub bodies. Still unimplemented per the spec-then-implement
  discipline this PR series follows.
- Full mock implementations. Lands in the next phase off a clean
  `main` baseline once this PR is merged into your branch and yours
  is merged into `main`.