### PR TITLE
Mock implementations and unit tests: `MockB20, `MockB20Stablecoin`, `MockTokenFactory`

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -10,7 +10,11 @@ import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
 ///         with interface-typed handles so callers can interact with
 ///         them directly (e.g. `StdPrecompiles.TOKEN_FACTORY.createToken(...)`).
 library StdPrecompiles {
-    address internal constant TOKEN_FACTORY_ADDRESS = 0xB20000000000000000000000000000000000000f;
+    /// @dev The `0xB20F` prefix mirrors the `0xB2` B-20 token prefix while staying
+    ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
+    ///      so `isB20(TOKEN_FACTORY_ADDRESS)` returns false unambiguously. The
+    ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
+    address internal constant TOKEN_FACTORY_ADDRESS = 0xb20F00000000000000000000000000000000000f;
     address internal constant POLICY_REGISTRY_ADDRESS = 0xb000000000000000000000000000000000000001;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x84530000000000000000000000000000000000ff;
 

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -11,11 +11,14 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         the initial admin.
 ///
 /// @dev    **Factory address.** The factory lives at the fixed address
-///         `0xB20...000F`.
+///         `0xB20F00000000000000000000000000000000000F`. The `0xB20F`
+///         prefix is deliberately distinct from the B-20 token prefix
+///         `0xB200` (byte `[1]` differs), so `isB20(factory)` returns
+///         false unambiguously.
 ///
 ///         **Token address schema (20 bytes).**
-///         - `[0:10]`  — `bytes10(0xB20...000)` shared prefix identifying a
-///                       factory-created B-20.
+///         - `[0:10]`  — `bytes10(0xB200000000000000000000)` shared
+///                       prefix identifying a factory-created B-20.
 ///         - `[10]`    — `bytes1(variant)` (matches `TokenVariant`).
 ///         - `[11]`    — `bytes1(decimals)` — encoded in the address so
 ///                       `decimals()` is recoverable statelessly from the
@@ -95,6 +98,15 @@ interface ITokenFactory {
     ///                      they execute with full privilege regardless
     ///                      of role state, and the privileged window
     ///                      closes the moment `createToken` returns.
+    ///                      May be `address(0)` for the "demonstrate no
+    ///                      owner" case (memecoins, credibly-neutral
+    ///                      tokens). When zero, no role is granted at
+    ///                      creation and the token has no admin: no
+    ///                      role grants, policy changes, or pauses are
+    ///                      ever possible post-creation. The
+    ///                      `renounceLastAdmin` path is the alternative
+    ///                      for tokens that need an admin during setup
+    ///                      and then want to evolve to admin-less.
     /// @param decimals      ERC-20 decimals. MUST be in `[2, 18]`.
     ///                      Encoded into address byte `[11]` for
     ///                      stateless retrieval.
@@ -175,9 +187,6 @@ interface ITokenFactory {
     ///         accept a caller-supplied value.
     error InvalidDecimals(uint8 decimals);
 
-    /// @notice A required address argument was the zero address.
-    error ZeroAddress();
-
     /// @notice A required string argument was the empty string (e.g.
     ///         stablecoin `currency`, security `isin`).
     error MissingRequiredField();
@@ -195,14 +204,21 @@ interface ITokenFactory {
     ///         fields cover the universal token-identity surface; all
     ///         variant-specific state changes (e.g. `currency`, `isin`,
     ///         supply cap, policy slots) are observable via the
-    ///         token's own events as they're applied during the
-    ///         bootstrap and `initCalls`.
+    ///         token's own events as they're applied during `initCalls`.
+    /// @dev    The factory writes the token's initial storage directly
+    ///         (no `bootstrap` call into the token), so the initial
+    ///         admin grant does not produce a separate `RoleGranted`
+    ///         event. This event is the canonical signal for both
+    ///         "token created" AND "initial admin set". A zero `admin`
+    ///         indicates the "demonstrate no owner" path. Post-creation
+    ///         role grants emit `RoleGranted` from the token as usual.
     event TokenCreated(
         address indexed token,
         TokenVariant indexed variant,
         string name,
         string symbol,
-        uint8 decimals
+        uint8 decimals,
+        address admin
     );
 
     /*//////////////////////////////////////////////////////////////

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -143,4 +143,42 @@ contract B20Test is TokenFactoryTest {
         vm.prank(pauser);
         token.pause(_singleFeature(feature));
     }
+
+    // -- Permit helpers --
+    /// @dev EIP-2612 permit type hash; matches MockB20's constant.
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    /// @notice Constructs and signs an EIP-2612 permit digest under the token's
+    ///         current DOMAIN_SEPARATOR, with `owner = vm.addr(privateKey)`.
+    /// @dev    Reads the current nonce for `owner` so the caller doesn't have to.
+    ///         Use `boundPrivateKey(uint256)` to derive a valid secp256k1 key
+    ///         from a fuzz seed.
+    function _signPermit(uint256 privateKey, address spender, uint256 value, uint256 deadline)
+        internal
+        view
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        return _signPermitAs(privateKey, vm.addr(privateKey), spender, value, deadline);
+    }
+
+    /// @notice Constructs and signs an EIP-2612 permit digest where the struct's
+    ///         `owner` field is `claimedOwner`, separate from the signing key.
+    /// @dev    Used by "wrong-owner" revert tests: the resulting signature is
+    ///         well-formed for the digest the contract recomputes (which is
+    ///         keyed on `claimedOwner`), so ecrecover deterministically returns
+    ///         `vm.addr(privateKey)` rather than garbage.
+    function _signPermitAs(
+        uint256 privateKey,
+        address claimedOwner,
+        address spender,
+        uint256 value,
+        uint256 deadline
+    ) internal view returns (uint8 v, bytes32 r, bytes32 s) {
+        uint256 nonce = token.nonces(claimedOwner);
+        bytes32 structHash =
+            keccak256(abi.encode(PERMIT_TYPEHASH, claimedOwner, spender, value, nonce, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", token.DOMAIN_SEPARATOR(), structHash));
+        (v, r, s) = vm.sign(privateKey, digest);
+    }
 }

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -20,6 +20,28 @@ import {IB20} from "src/interfaces/IB20.sol";
 /// `unpauser`, `burnBlocker`) so role-gated tests have explicit named
 /// accounts to grant roles to in setUp's initCalls.
 contract B20Test is TokenFactoryTest {
+    // -- Role identifiers (match MockB20's keccak256 derivations) --
+    // Inlined here so tests can avoid `token.MINT_ROLE()` calls during
+    // setup paths where the token may not yet exist (e.g. createToken
+    // tests). Verified against MockB20's constants by direct equality
+    // in the role-constants test suite.
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
+    bytes32 internal constant MINT_ROLE = keccak256("MINT_ROLE");
+    bytes32 internal constant BURN_ROLE = keccak256("BURN_ROLE");
+    bytes32 internal constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
+    bytes32 internal constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
+    bytes32 internal constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+
+    // -- Policy-type identifiers --
+    bytes32 internal constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
+    bytes32 internal constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
+    bytes32 internal constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
+    bytes32 internal constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
+
+    // -- Built-in policy sentinel IDs (MockPolicyRegistry-supported) --
+    uint64 internal constant ALWAYS_ALLOW = 0;
+    uint64 internal constant ALWAYS_REJECT = type(uint64).max;
+
     // -- Token-specific role-holder actors --
     address internal minter = makeAddr("minter");
     address internal burner = makeAddr("burner");
@@ -50,10 +72,11 @@ contract B20Test is TokenFactoryTest {
     ///         `B20StablecoinTest`) override to deploy their variant while
     ///         reusing every other piece of `B20Test`.
     /// @dev    `MockTokenFactory.createToken` etches `MockB20` runtime
-    ///         bytecode at the computed address, then runs the bootstrap +
-    ///         initCalls flow before returning. Calls against the returned
-    ///         `token` (transfer, mint, ...) execute against a live mock
-    ///         token with the initial admin granted by `bootstrap`.
+    ///         bytecode at the computed address, writes initial state
+    ///         directly via vm.store (no init function on the token),
+    ///         runs initCalls, then closes the bootstrap window. Calls
+    ///         against the returned `token` (transfer, mint, ...) execute
+    ///         against a live mock token with the initial admin granted.
     function _deployToken() internal virtual returns (IB20) {
         return IB20(_createDefault());
     }
@@ -68,5 +91,56 @@ contract B20Test is TokenFactoryTest {
     {
         features = new IB20.PausableFeature[](1);
         features[0] = feature;
+    }
+
+    /// @notice Filters out addresses that are unsafe to use as a fuzzed
+    ///         token-state actor (balance holder, allowance party, transfer
+    ///         counterparty).
+    ///
+    /// Extends `BaseTest._assumeValidCaller`'s precompile / VM / zero
+    /// filtering with the token's own address. Using the token as a
+    /// transfer recipient or balance holder is meaningless: the token
+    /// has no business holding its own balance, and the underlying
+    /// _transfer would still succeed (the policy slots default to
+    /// ALWAYS_ALLOW), producing confusing test state.
+    function _assumeValidActor(address account) internal view {
+        _assumeValidCaller(account);
+        vm.assume(account != address(token));
+    }
+
+    /// @notice Grants `role` to `account` as the admin actor.
+    /// @dev Pranks `admin` (initial holder of `DEFAULT_ADMIN_ROLE` from
+    ///      factory bootstrap), so this works even when the role has no
+    ///      explicit role-admin configured (defaults to `DEFAULT_ADMIN_ROLE`).
+    function _grantRole(bytes32 role, address account) internal {
+        vm.prank(admin);
+        token.grantRole(role, account);
+    }
+
+    /// @notice Mints `amount` to `to`, lazily granting `MINT_ROLE` to the
+    ///         `minter` actor on first call.
+    /// @dev Most balance-setup needs in tests reduce to "give this account some
+    ///      tokens"; this helper avoids re-asserting the role-grant boilerplate.
+    function _mint(address to, uint256 amount) internal {
+        if (!token.hasRole(MINT_ROLE, minter)) _grantRole(MINT_ROLE, minter);
+        vm.prank(minter);
+        token.mint(to, amount);
+    }
+
+    /// @notice Sets a policy slot on the token as the admin actor.
+    /// @dev Use `ALWAYS_ALLOW` (0) or `ALWAYS_REJECT` (type(uint64).max);
+    ///      these are the only two policy IDs `MockPolicyRegistry`
+    ///      supports today.
+    function _setPolicy(bytes32 policyType, uint64 policyId) internal {
+        vm.prank(admin);
+        token.updatePolicy(policyType, policyId);
+    }
+
+    /// @notice Pauses a single `PausableFeature`, lazily granting `PAUSE_ROLE`
+    ///         to the `pauser` actor on first call.
+    function _pause(IB20.PausableFeature feature) internal {
+        if (!token.hasRole(PAUSE_ROLE, pauser)) _grantRole(PAUSE_ROLE, pauser);
+        vm.prank(pauser);
+        token.pause(_singleFeature(feature));
     }
 }

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -49,12 +49,11 @@ contract B20Test is TokenFactoryTest {
     ///         token via the factory mock; variant-specific bases (e.g.
     ///         `B20StablecoinTest`) override to deploy their variant while
     ///         reusing every other piece of `B20Test`.
-    /// @dev    The current `MockTokenFactory` only computes and returns the
-    ///         deterministic token address — no token code is deployed
-    ///         there yet, so any call against `token` (transfer, mint, ...)
-    ///         will revert. The unit stubs in this spec PR have no-op
-    ///         bodies, so this is intentional. The next PR plants real
-    ///         token bytecode at the returned address.
+    /// @dev    `MockTokenFactory.createToken` etches `MockB20` runtime
+    ///         bytecode at the computed address, then runs the bootstrap +
+    ///         initCalls flow before returning. Calls against the returned
+    ///         `token` (transfer, mint, ...) execute against a live mock
+    ///         token with the initial admin granted by `bootstrap`.
     function _deployToken() internal virtual returns (IB20) {
         return IB20(_createDefault());
     }

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -37,8 +37,9 @@ import {StdPrecompiles} from "src/StdPrecompiles.sol";
 /// **Mock status.**
 ///   - `MockTokenFactory` is fully implemented: `createToken` decodes
 ///     params, etches the variant-appropriate runtime bytecode at the
-///     computed B-20 address, runs the bootstrap + initCalls flow, and
-///     closes the privileged window before returning.
+///     computed B-20 address, writes initial state directly via vm.store
+///     (no init function on the token), runs initCalls, and closes the
+///     privileged window before returning.
 ///   - `MockB20` / `MockB20Stablecoin` (planted by the factory at token
 ///     addresses) are fully implemented: every `IB20` / `IB20Stablecoin`
 ///     surface function is live, with the bootstrap-window auth bypass
@@ -80,5 +81,27 @@ abstract contract BaseTest is Test {
         if (StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS.code.length == 0) {
             vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
         }
+    }
+
+    /// @notice Filters out addresses that are unsafe to use as a fuzzed
+    ///         `msg.sender` in test bodies.
+    ///
+    /// Pranking these addresses produces meaningless or misleading test
+    /// outcomes:
+    ///   - `address(0)`: many functions revert specifically on zero
+    ///     sender (`InvalidSender`, `InvalidApprover`), masking the
+    ///     behavior under test.
+    ///   - The forge-std VM cheatcode address: pranking it disrupts
+    ///     subsequent cheatcode calls.
+    ///   - Any of the etched precompiles: they have a privileged
+    ///     auth-bypass path (e.g. `MockB20`'s factory bootstrap window),
+    ///     so calls "from" them go through a different code path than
+    ///     a user would.
+    function _assumeValidCaller(address caller) internal pure {
+        vm.assume(caller != address(0));
+        vm.assume(caller != address(vm));
+        vm.assume(caller != StdPrecompiles.TOKEN_FACTORY_ADDRESS);
+        vm.assume(caller != StdPrecompiles.POLICY_REGISTRY_ADDRESS);
+        vm.assume(caller != StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS);
     }
 }

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -34,16 +34,25 @@ import {StdPrecompiles} from "src/StdPrecompiles.sol";
 /// reason about which precompiles they "depend on" — they're all just
 /// available, the way the EVM has `SLOAD`.
 ///
-/// **Mock status.** The placeholder mocks etched here implement the
-/// minimum needed for `setUp` to succeed across every base:
-///   - `MockTokenFactory` implements the address-derivation schema so
-///     `_deployToken` calls return real-shaped addresses.
-///   - `MockPolicyRegistry` implements the two built-in sentinel IDs
-///     (`0` → always-allow, `type(uint64).max` → always-reject).
-///   - `MockActivationRegistry` implements `admin()` to return the
-///     hardcoded test admin.
-/// Every other method reverts with `"MockX: not implemented"`. Real
-/// behavior fills in alongside test implementations in the next PR.
+/// **Mock status.**
+///   - `MockTokenFactory` is fully implemented: `createToken` decodes
+///     params, etches the variant-appropriate runtime bytecode at the
+///     computed B-20 address, runs the bootstrap + initCalls flow, and
+///     closes the privileged window before returning.
+///   - `MockB20` / `MockB20Stablecoin` (planted by the factory at token
+///     addresses) are fully implemented: every `IB20` / `IB20Stablecoin`
+///     surface function is live, with the bootstrap-window auth bypass
+///     for factory-originated calls and the standard role / policy /
+///     pause / supply-cap checks otherwise.
+///   - `MockPolicyRegistry` is a SKELETON: implements only the two
+///     built-in sentinel IDs (`0` → always-allow,
+///     `type(uint64).max` → always-reject) so the most common B-20 tests
+///     can exercise both authorize and forbid paths without any custom
+///     policy state. Tests that need custom policies (create, update
+///     membership, rotate admin, etc.) will fail until the full mock
+///     lands in a follow-up PR.
+///   - `MockActivationRegistry` is a SKELETON: implements only `admin()`
+///     to return the hardcoded test admin.
 abstract contract BaseTest is Test {
     // -- Actors --
     address internal admin = makeAddr("admin");

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -18,33 +18,40 @@ import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
 ///
 ///         - All mutable state lives in `MockB20Storage.layout()` at a
 ///           single ERC-7201 namespaced root. The struct field order IS
-///           the slot layout the Rust impl mirrors.
+///           the slot layout the Rust impl mirrors; slot offsets are
+///           named constants on `MockB20Storage`.
 ///         - `decimals()` is decoded from address byte `[11]` — no
 ///           storage slot. The Rust impl does the same.
+///         - **No factory-only entrypoints exist on this contract.**
+///           Initial storage state (name, symbol, supply cap, admin
+///           role, `initialized` flag) is written directly by the
+///           factory via `vm.store` at the slots declared in
+///           `MockB20Storage`. The Rust impl writes the same slots
+///           the same way; the public surface this contract exposes
+///           is exactly `IB20`.
 ///         - The factory call-site bypass for the bootstrap window is an
 ///           explicit gate consulted at every authorization check:
-///           `msg.sender == FACTORY && !initialized`. Once
-///           `closeBootstrap()` flips `initialized = true`, the factory
-///           has no remaining special privilege. Token invariants
-///           (supply-cap math, balance accounting) are NOT bypassed
-///           during the window.
+///           `msg.sender == FACTORY && !initialized`. The factory
+///           writes `initialized = true` directly (also via `vm.store`)
+///           once `initCalls` have run, closing the privileged window.
+///           Token invariants (supply-cap math, balance accounting)
+///           are NOT bypassed during the window.
 ///         - Variant tokens (e.g. `MockB20Stablecoin`) extend by adding
-///           a disjoint storage namespace plus an override of
-///           `_bootstrapVariant`; the base never enumerates variants.
+///           a disjoint storage namespace; the factory writes the
+///           variant-specific slots directly, no virtual hook needed.
 ///
 ///         **What this mock is for:** local-tests-with-vm.etch and as a
 ///         readable spec artifact for auditors and Rust developers. It
 ///         lives under `test/` and is never deployed as production code.
 contract MockB20 is IB20 {
-    using MockB20Storage for MockB20Storage.Layout;
-
     // ============================================================
     //                          CONSTANTS
     // ============================================================
 
     /// @notice The factory precompile address. Calls from this address
-    ///         during the bootstrap window (before `closeBootstrap()`)
-    ///         bypass all token-side authorization gates.
+    ///         during the bootstrap window (before the factory writes
+    ///         `initialized = true` via vm.store) bypass all token-side
+    ///         authorization gates.
     address internal constant FACTORY = StdPrecompiles.TOKEN_FACTORY_ADDRESS;
 
     /// @notice The policy registry precompile address. Consulted on
@@ -70,55 +77,6 @@ contract MockB20 is IB20 {
     bytes32 public constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
     bytes32 public constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
     bytes32 public constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
-
-    // ============================================================
-    //                          BOOTSTRAP
-    // ============================================================
-    // Functions called only by the factory during the bootstrap window.
-    // Not part of the IB20 interface.
-
-    /// @notice Factory-only: writes initial identity state into storage.
-    ///         Called once per token, before any initCalls dispatch.
-    /// @dev    Variant-specific state is set via `_bootstrapVariant` so
-    ///         the base contract never enumerates variants.
-    function bootstrap(string calldata name_, string calldata symbol_, address admin, bytes calldata variantData)
-        external
-    {
-        MockB20Storage.Layout storage $ = MockB20Storage.layout();
-        require(msg.sender == FACTORY, "MockB20: only factory");
-        require(!$.initialized, "MockB20: already initialized");
-
-        $.name = name_;
-        $.symbol = symbol_;
-        $.supplyCap = type(uint256).max;
-
-        if (admin != address(0)) {
-            $.roles[DEFAULT_ADMIN_ROLE][admin] = true;
-            $.adminCount = 1;
-            emit RoleGranted(DEFAULT_ADMIN_ROLE, admin, msg.sender);
-        }
-
-        _bootstrapVariant(variantData);
-    }
-
-    /// @notice Factory-only: closes the bootstrap window. After this
-    ///         call `msg.sender == FACTORY` no longer triggers the
-    ///         authorization bypass; every subsequent call (factory or
-    ///         otherwise) goes through the standard checks.
-    function closeBootstrap() external {
-        MockB20Storage.Layout storage $ = MockB20Storage.layout();
-        require(msg.sender == FACTORY, "MockB20: only factory");
-        require(!$.initialized, "MockB20: already initialized");
-        $.initialized = true;
-    }
-
-    /// @notice Variant extension hook. Default-variant tokens ignore
-    ///         `variantData`; variants override to decode and apply
-    ///         their variant-specific initial state (e.g.
-    ///         `MockB20Stablecoin` decodes a currency string).
-    function _bootstrapVariant(bytes calldata variantData) internal virtual {
-        variantData; // unused on the base variant
-    }
 
     // ============================================================
     //                          ERC-20: VIEWS

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {StdPrecompiles} from "src/StdPrecompiles.sol";
+
+import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+
+/// @title MockB20
+/// @notice Reference implementation of the `IB20` default-token surface.
+///         Etched at every default-variant B-20 token's factory-derived
+///         address via `vm.etch` from `MockTokenFactory.createToken`.
+///
+/// @dev    Written as Solidity-as-if-Rust: the goal is unambiguous
+///         spec-correspondence with the production Rust precompile, not
+///         gas optimization or Solidity idiom adherence. Specifically:
+///
+///         - All mutable state lives in `MockB20Storage.layout()` at a
+///           single ERC-7201 namespaced root. The struct field order IS
+///           the slot layout the Rust impl mirrors.
+///         - `decimals()` is decoded from address byte `[11]` — no
+///           storage slot. The Rust impl does the same.
+///         - The factory call-site bypass for the bootstrap window is an
+///           explicit gate consulted at every authorization check:
+///           `msg.sender == FACTORY && !initialized`. Once
+///           `closeBootstrap()` flips `initialized = true`, the factory
+///           has no remaining special privilege. Token invariants
+///           (supply-cap math, balance accounting) are NOT bypassed
+///           during the window.
+///         - Variant tokens (e.g. `MockB20Stablecoin`) extend by adding
+///           a disjoint storage namespace plus an override of
+///           `_bootstrapVariant`; the base never enumerates variants.
+///
+///         **What this mock is for:** local-tests-with-vm.etch and as a
+///         readable spec artifact for auditors and Rust developers. It
+///         lives under `test/` and is never deployed as production code.
+contract MockB20 is IB20 {
+    using MockB20Storage for MockB20Storage.Layout;
+
+    // ============================================================
+    //                          CONSTANTS
+    // ============================================================
+
+    /// @notice The factory precompile address. Calls from this address
+    ///         during the bootstrap window (before `closeBootstrap()`)
+    ///         bypass all token-side authorization gates.
+    address internal constant FACTORY = StdPrecompiles.TOKEN_FACTORY_ADDRESS;
+
+    /// @notice The policy registry precompile address. Consulted on
+    ///         every transfer, mint, and `burnBlocked` to resolve the
+    ///         token's configured policy slots.
+    address internal constant POLICY_REGISTRY = StdPrecompiles.POLICY_REGISTRY_ADDRESS;
+
+    /// @notice Default top-level admin role. Equal to `bytes32(0)` per
+    ///         the OZ AccessControl convention.
+    bytes32 public constant DEFAULT_ADMIN_ROLE = bytes32(0);
+
+    /// @notice Role identifiers. Computed as `keccak256` of the role
+    ///         name per the OZ AccessControl convention, so the
+    ///         Rust impl can derive them identically.
+    bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
+    bytes32 public constant BURN_ROLE = keccak256("BURN_ROLE");
+    bytes32 public constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
+    bytes32 public constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
+    bytes32 public constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+
+    /// @notice Policy-type identifiers. Same `keccak256` convention.
+    bytes32 public constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
+    bytes32 public constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
+    bytes32 public constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
+    bytes32 public constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
+
+    // ============================================================
+    //                          BOOTSTRAP
+    // ============================================================
+    // Functions called only by the factory during the bootstrap window.
+    // Not part of the IB20 interface.
+
+    /// @notice Factory-only: writes initial identity state into storage.
+    ///         Called once per token, before any initCalls dispatch.
+    /// @dev    Variant-specific state is set via `_bootstrapVariant` so
+    ///         the base contract never enumerates variants.
+    function bootstrap(string calldata name_, string calldata symbol_, address admin, bytes calldata variantData)
+        external
+    {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        require(msg.sender == FACTORY, "MockB20: only factory");
+        require(!$.initialized, "MockB20: already initialized");
+
+        $.name = name_;
+        $.symbol = symbol_;
+        $.supplyCap = type(uint256).max;
+
+        if (admin != address(0)) {
+            $.roles[DEFAULT_ADMIN_ROLE][admin] = true;
+            $.adminCount = 1;
+            emit RoleGranted(DEFAULT_ADMIN_ROLE, admin, msg.sender);
+        }
+
+        _bootstrapVariant(variantData);
+    }
+
+    /// @notice Factory-only: closes the bootstrap window. After this
+    ///         call `msg.sender == FACTORY` no longer triggers the
+    ///         authorization bypass; every subsequent call (factory or
+    ///         otherwise) goes through the standard checks.
+    function closeBootstrap() external {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        require(msg.sender == FACTORY, "MockB20: only factory");
+        require(!$.initialized, "MockB20: already initialized");
+        $.initialized = true;
+    }
+
+    /// @notice Variant extension hook. Default-variant tokens ignore
+    ///         `variantData`; variants override to decode and apply
+    ///         their variant-specific initial state (e.g.
+    ///         `MockB20Stablecoin` decodes a currency string).
+    function _bootstrapVariant(bytes calldata variantData) internal virtual {
+        variantData; // unused on the base variant
+    }
+
+    // ============================================================
+    //                          ERC-20: VIEWS
+    // ============================================================
+
+    function name() external view returns (string memory) {
+        return MockB20Storage.layout().name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return MockB20Storage.layout().symbol;
+    }
+
+    /// @notice Decimals are encoded in address byte `[11]` by the
+    ///         factory. Stateless retrieval; no storage slot.
+    function decimals() external view returns (uint8) {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return uint8(uint160(address(this)) >> 64);
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return MockB20Storage.layout().totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return MockB20Storage.layout().balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return MockB20Storage.layout().allowances[owner][spender];
+    }
+
+    // ============================================================
+    //                       ERC-20: MUTATIONS
+    // ============================================================
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (!_isPrivileged() && msg.sender != from) {
+            _consumeAllowance(from, msg.sender, amount);
+            _checkPolicy(TRANSFER_EXECUTOR, msg.sender);
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        if (msg.sender == address(0)) revert InvalidApprover(msg.sender);
+        if (spender == address(0)) revert InvalidSpender(spender);
+        MockB20Storage.layout().allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    // ============================================================
+    //                       MEMO TRANSFER VARIANTS
+    // ============================================================
+
+    function transferWithMemo(address to, uint256 amount, bytes32 memo) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        emit Memo(memo);
+        return true;
+    }
+
+    function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool) {
+        if (!_isPrivileged() && msg.sender != from) {
+            _consumeAllowance(from, msg.sender, amount);
+            _checkPolicy(TRANSFER_EXECUTOR, msg.sender);
+        }
+        _transfer(from, to, amount);
+        emit Memo(memo);
+        return true;
+    }
+
+    // ============================================================
+    //                         METADATA UPDATES
+    // ============================================================
+
+    function setName(string calldata newName) external {
+        _requireAdmin();
+        MockB20Storage.layout().name = newName;
+        emit NameUpdated(msg.sender, newName);
+    }
+
+    function setSymbol(string calldata newSymbol) external {
+        _requireAdmin();
+        MockB20Storage.layout().symbol = newSymbol;
+        emit SymbolUpdated(msg.sender, newSymbol);
+    }
+
+    // ============================================================
+    //                          MINT / BURN
+    // ============================================================
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function mintWithMemo(address to, uint256 amount, bytes32 memo) external {
+        _mint(to, amount);
+        emit Memo(memo);
+    }
+
+    function burn(uint256 amount) external {
+        _burnSelf(msg.sender, amount);
+    }
+
+    function burnWithMemo(uint256 amount, bytes32 memo) external {
+        _burnSelf(msg.sender, amount);
+        emit Memo(memo);
+    }
+
+    function burnBlocked(address from, uint256 amount) external {
+        if (!_isPrivileged()) {
+            if (!hasRole(BURN_BLOCKED_ROLE, msg.sender)) {
+                revert AccessControlUnauthorizedAccount(msg.sender, BURN_BLOCKED_ROLE);
+            }
+            if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
+            // The point of burnBlocked is to seize from policy-blocked
+            // accounts. Calling it on an authorized account is rejected.
+            uint64 senderPolicyId = MockB20Storage.layout().policyIds[TRANSFER_SENDER];
+            if (_policyAuthorized(senderPolicyId, from)) revert AccountNotBlocked(from);
+        }
+        _burnRaw(from, amount);
+        emit BurnedBlocked(msg.sender, from, amount);
+    }
+
+    // ============================================================
+    //                            ROLES
+    // ============================================================
+
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return MockB20Storage.layout().roles[role][account];
+    }
+
+    function getRoleAdmin(bytes32 role) external view returns (bytes32) {
+        bytes32 adminRole = MockB20Storage.layout().roleAdmins[role];
+        // Default admin if not explicitly overridden via setRoleAdmin.
+        return adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE ? DEFAULT_ADMIN_ROLE : adminRole;
+    }
+
+    function grantRole(bytes32 role, address account) external {
+        if (!_isPrivileged()) _requireRoleAdmin(role);
+        _grantRole(role, account);
+    }
+
+    function revokeRole(bytes32 role, address account) external {
+        if (!_isPrivileged()) _requireRoleAdmin(role);
+        _revokeRole(role, account);
+    }
+
+    function renounceRole(bytes32 role, address callerConfirmation) external {
+        if (callerConfirmation != msg.sender) revert AccessControlBadConfirmation();
+        if (role == DEFAULT_ADMIN_ROLE && MockB20Storage.layout().adminCount == 1) {
+            // Sole admin must use the explicit renounceLastAdmin path.
+            revert LastAdminCannotRenounce();
+        }
+        _revokeRole(role, msg.sender);
+    }
+
+    function renounceLastAdmin() external {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        if (!$.roles[DEFAULT_ADMIN_ROLE][msg.sender]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);
+        }
+        if ($.adminCount != 1) revert NotSoleAdmin();
+        $.roles[DEFAULT_ADMIN_ROLE][msg.sender] = false;
+        $.adminCount = 0;
+        emit RoleRevoked(DEFAULT_ADMIN_ROLE, msg.sender, msg.sender);
+        emit LastAdminRenounced(msg.sender);
+    }
+
+    function setRoleAdmin(bytes32 role, bytes32 newAdminRole) external {
+        if (!_isPrivileged()) _requireRoleAdmin(role);
+        bytes32 previousAdminRole = MockB20Storage.layout().roleAdmins[role];
+        // Default admin if not explicitly set; expose it in the event.
+        if (previousAdminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) {
+            previousAdminRole = DEFAULT_ADMIN_ROLE;
+        }
+        MockB20Storage.layout().roleAdmins[role] = newAdminRole;
+        emit RoleAdminChanged(role, previousAdminRole, newAdminRole);
+    }
+
+    // ============================================================
+    //                            PAUSE
+    // ============================================================
+
+    function pausedFeatures() external view returns (PausableFeature[] memory) {
+        uint256 vectors = MockB20Storage.layout().pausedVectors;
+        uint256 count;
+        for (uint256 i = 0; i < 4; i++) {
+            if (((vectors >> i) & uint256(1)) == 1) count++;
+        }
+        PausableFeature[] memory result = new PausableFeature[](count);
+        uint256 idx;
+        for (uint256 i = 0; i < 4; i++) {
+            if (((vectors >> i) & uint256(1)) == 1) {
+                // forge-lint: disable-next-line(unsafe-typecast)
+                result[idx++] = PausableFeature(uint8(i));
+            }
+        }
+        return result;
+    }
+
+    function isPaused(PausableFeature feature) public view returns (bool) {
+        return _isPaused(feature);
+    }
+
+    function pause(PausableFeature[] calldata features) external {
+        if (!_isPrivileged()) {
+            if (!hasRole(PAUSE_ROLE, msg.sender)) {
+                revert AccessControlUnauthorizedAccount(msg.sender, PAUSE_ROLE);
+            }
+        }
+        if (features.length == 0) revert EmptyFeatureSet();
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        for (uint256 i = 0; i < features.length; i++) {
+            $.pausedVectors |= uint256(1) << uint8(features[i]);
+        }
+        emit Paused(msg.sender, features);
+    }
+
+    function unpause(PausableFeature[] calldata features) external {
+        if (!_isPrivileged()) {
+            if (!hasRole(UNPAUSE_ROLE, msg.sender)) {
+                revert AccessControlUnauthorizedAccount(msg.sender, UNPAUSE_ROLE);
+            }
+        }
+        if (features.length == 0) revert EmptyFeatureSet();
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        for (uint256 i = 0; i < features.length; i++) {
+            $.pausedVectors &= ~(uint256(1) << uint8(features[i]));
+        }
+        emit Unpaused(msg.sender, features);
+    }
+
+    // ============================================================
+    //                            POLICY
+    // ============================================================
+
+    function policyId(bytes32 policyType) external view returns (uint64) {
+        return MockB20Storage.layout().policyIds[policyType];
+    }
+
+    function updatePolicy(bytes32 policyType, uint64 newPolicyId) external {
+        _requireAdmin();
+        // Verify the target policy exists in the registry (or is built-in).
+        if (!IPolicyRegistry(POLICY_REGISTRY).policyExists(newPolicyId)) {
+            revert PolicyNotFound(newPolicyId);
+        }
+        uint64 oldPolicyId = MockB20Storage.layout().policyIds[policyType];
+        MockB20Storage.layout().policyIds[policyType] = newPolicyId;
+        emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
+    }
+
+    // ============================================================
+    //                          SUPPLY CAP
+    // ============================================================
+
+    function supplyCap() external view returns (uint256) {
+        return MockB20Storage.layout().supplyCap;
+    }
+
+    function setSupplyCap(uint256 newSupplyCap) external {
+        _requireAdmin();
+        uint256 currentSupply = MockB20Storage.layout().totalSupply;
+        if (newSupplyCap < currentSupply) revert InvalidSupplyCap(currentSupply, newSupplyCap);
+        uint256 oldSupplyCap = MockB20Storage.layout().supplyCap;
+        MockB20Storage.layout().supplyCap = newSupplyCap;
+        emit SupplyCapUpdated(msg.sender, oldSupplyCap, newSupplyCap);
+    }
+
+    // ============================================================
+    //                  PERMIT (EIP-2612 + ERC-5267)
+    // ============================================================
+
+    /// @dev Domain content per IB20 spec: chainId and verifyingContract
+    ///      only. No name, no version. Type hash is the bare EIP712Domain
+    ///      with those two fields.
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+
+    /// @dev EIP-2612 permit type hash.
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
+    }
+
+    function nonces(address owner) external view returns (uint256) {
+        return MockB20Storage.layout().nonces[owner];
+    }
+
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+    {
+        if (block.timestamp > deadline) revert ExpiredSignature(deadline);
+
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        uint256 nonce = $.nonces[owner];
+
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+
+        address recovered = ecrecover(digest, v, r, s);
+        if (recovered == address(0) || recovered != owner) {
+            revert InvalidSigner(recovered, owner);
+        }
+
+        unchecked {
+            $.nonces[owner] = nonce + 1;
+        }
+        $.allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function eip712Domain()
+        external
+        view
+        returns (
+            bytes1 fields,
+            string memory name_,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        // Bits 2 and 3 set: chainId and verifyingContract are populated.
+        // name, version, salt, extensions are all empty/zero.
+        fields = hex"0c";
+        name_ = "";
+        version = "";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
+
+    // ============================================================
+    //                      CONTRACT URI (ERC-7572)
+    // ============================================================
+
+    function contractURI() external view returns (string memory) {
+        return MockB20Storage.layout().contractURI;
+    }
+
+    function setContractURI(string calldata newURI) external {
+        _requireAdmin();
+        MockB20Storage.layout().contractURI = newURI;
+        emit ContractURIUpdated();
+    }
+
+    // ============================================================
+    //                       INTERNAL HELPERS
+    // ============================================================
+
+    /// @dev True iff the caller is the factory in the bootstrap window.
+    ///      Every authorization gate consults this first; if true, the
+    ///      gate is skipped. Token invariants (supply-cap math, balance
+    ///      accounting) are NOT gated and are always enforced.
+    function _isPrivileged() internal view returns (bool) {
+        return msg.sender == FACTORY && !MockB20Storage.layout().initialized;
+    }
+
+    function _requireAdmin() internal view {
+        if (_isPrivileged()) return;
+        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
+            revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);
+        }
+    }
+
+    function _requireRoleAdmin(bytes32 role) internal view {
+        bytes32 adminRole = MockB20Storage.layout().roleAdmins[role];
+        if (adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) adminRole = DEFAULT_ADMIN_ROLE;
+        if (!hasRole(adminRole, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, adminRole);
+    }
+
+    function _isPaused(PausableFeature feature) internal view returns (bool) {
+        return ((MockB20Storage.layout().pausedVectors >> uint8(feature)) & uint256(1)) == 1;
+    }
+
+    /// @dev Resolves an authorization check against the policy registry.
+    ///      Reverts with `PolicyForbids` propagated from the caller, not
+    ///      raised here, so callers can include the right policyType.
+    function _policyAuthorized(uint64 _policyId, address account) internal view returns (bool) {
+        return IPolicyRegistry(POLICY_REGISTRY).isAuthorized(_policyId, account);
+    }
+
+    function _checkPolicy(bytes32 policyType, address account) internal view {
+        uint64 _policyId = MockB20Storage.layout().policyIds[policyType];
+        if (!_policyAuthorized(_policyId, account)) revert PolicyForbids(policyType, _policyId);
+    }
+
+    function _grantRole(bytes32 role, address account) internal {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        if (!$.roles[role][account]) {
+            $.roles[role][account] = true;
+            if (role == DEFAULT_ADMIN_ROLE) $.adminCount += 1;
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) internal {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        if ($.roles[role][account]) {
+            $.roles[role][account] = false;
+            if (role == DEFAULT_ADMIN_ROLE) $.adminCount -= 1;
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+
+    function _consumeAllowance(address owner, address spender, uint256 amount) internal {
+        uint256 current = MockB20Storage.layout().allowances[owner][spender];
+        if (current != type(uint256).max) {
+            if (current < amount) revert InsufficientAllowance(spender, current, amount);
+            unchecked {
+                MockB20Storage.layout().allowances[owner][spender] = current - amount;
+            }
+        }
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        if (to == address(0)) revert InvalidReceiver(to);
+        if (from == address(0)) revert InvalidSender(from);
+
+        if (!_isPrivileged()) {
+            if (_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);
+            _checkPolicy(TRANSFER_SENDER, from);
+            _checkPolicy(TRANSFER_RECEIVER, to);
+        }
+
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        uint256 fromBalance = $.balances[from];
+        if (fromBalance < amount) revert InsufficientBalance(from, fromBalance, amount);
+        unchecked {
+            $.balances[from] = fromBalance - amount;
+            $.balances[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
+        if (to == address(0)) revert InvalidReceiver(to);
+
+        if (!_isPrivileged()) {
+            if (!hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);
+            if (_isPaused(PausableFeature.MINT)) revert ContractPaused(PausableFeature.MINT);
+            _checkPolicy(MINT_RECEIVER, to);
+        }
+
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        uint256 newSupply = $.totalSupply + amount;
+        if (newSupply > $.supplyCap) revert SupplyCapExceeded($.supplyCap, newSupply);
+        $.totalSupply = newSupply;
+        unchecked {
+            $.balances[to] += amount;
+        }
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _burnSelf(address from, uint256 amount) internal {
+        if (!_isPrivileged()) {
+            if (!hasRole(BURN_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, BURN_ROLE);
+            if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
+        }
+        _burnRaw(from, amount);
+    }
+
+    function _burnRaw(address from, uint256 amount) internal {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        uint256 fromBalance = $.balances[from];
+        if (fromBalance < amount) revert InsufficientBalance(from, fromBalance, amount);
+        unchecked {
+            $.balances[from] = fromBalance - amount;
+            $.totalSupply -= amount;
+        }
+        emit Transfer(from, address(0), amount);
+    }
+}

--- a/test/lib/mocks/MockB20Stablecoin.sol
+++ b/test/lib/mocks/MockB20Stablecoin.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+
+import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+
+/// @title MockB20Stablecoin
+/// @notice Reference implementation of the `IB20Stablecoin` variant.
+///         Extends `MockB20` with a single immutable `currency()`
+///         identifier; all other variant behavior is inherited unchanged.
+///
+/// @dev    Variant-specific state lives in `MockB20StablecoinStorage`'s
+///         own ERC-7201 namespace (`base.b20.stablecoin`), disjoint from
+///         the base `MockB20Storage` namespace (`base.b20`), so the
+///         variant composes additively without touching the base's slot
+///         layout.
+///
+///         The `currency` value is set in the variant-specific
+///         `_bootstrapVariant` override during factory creation; once
+///         the bootstrap window closes there is no mutator.
+contract MockB20Stablecoin is MockB20, IB20Stablecoin {
+    /// @notice The immutable currency identifier (e.g. "USD", "EUR",
+    ///         "XAU"). Set at creation by the factory's
+    ///         `_bootstrapVariant` dispatch with `abi.encode(string)`.
+    function currency() external view returns (string memory) {
+        return MockB20StablecoinStorage.layout().currency;
+    }
+
+    /// @notice Variant-specific bootstrap hook. Decodes a single
+    ///         `string` (the currency identifier) from `variantData`
+    ///         and writes it into variant storage.
+    /// @dev    Called exactly once, from `bootstrap()` on the base
+    ///         contract during factory creation, before any `initCalls`
+    ///         dispatch.
+    function _bootstrapVariant(bytes calldata variantData) internal override {
+        string memory currency_ = abi.decode(variantData, (string));
+        MockB20StablecoinStorage.layout().currency = currency_;
+    }
+}

--- a/test/lib/mocks/MockB20Stablecoin.sol
+++ b/test/lib/mocks/MockB20Stablecoin.sol
@@ -17,25 +17,13 @@ import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
 ///         variant composes additively without touching the base's slot
 ///         layout.
 ///
-///         The `currency` value is set in the variant-specific
-///         `_bootstrapVariant` override during factory creation; once
-///         the bootstrap window closes there is no mutator.
+///         The `currency` value is written directly by the factory
+///         (via `vm.store` at the variant namespace's `CURRENCY_OFFSET`)
+///         during creation; there is no init function and no mutator.
 contract MockB20Stablecoin is MockB20, IB20Stablecoin {
     /// @notice The immutable currency identifier (e.g. "USD", "EUR",
-    ///         "XAU"). Set at creation by the factory's
-    ///         `_bootstrapVariant` dispatch with `abi.encode(string)`.
+    ///         "XAU"). Written by the factory at creation.
     function currency() external view returns (string memory) {
         return MockB20StablecoinStorage.layout().currency;
-    }
-
-    /// @notice Variant-specific bootstrap hook. Decodes a single
-    ///         `string` (the currency identifier) from `variantData`
-    ///         and writes it into variant storage.
-    /// @dev    Called exactly once, from `bootstrap()` on the base
-    ///         contract during factory creation, before any `initCalls`
-    ///         dispatch.
-    function _bootstrapVariant(bytes calldata variantData) internal override {
-        string memory currency_ = abi.decode(variantData, (string));
-        MockB20StablecoinStorage.layout().currency = currency_;
     }
 }

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MockB20Storage
+/// @notice Slot-layout library for the `MockB20` reference implementation.
+///
+///         Every piece of mutable token state lives in this struct at a single
+///         ERC-7201-namespaced location, so the Rust precompile implementation
+///         has an unambiguous, audit-grep-able source of truth for which slot
+///         holds what.
+///
+/// @dev    The token contract is a precompile in production: every B-20 token
+///         lives at a factory-derived address with its own storage. This mock
+///         is etched at that same address via `vm.etch` so the storage
+///         layout the Rust impl computes maps slot-for-slot to what this
+///         library defines.
+///
+///         **Why ERC-7201 over a flat unstructured-storage list?** Two reasons:
+///         1. The struct field ORDER is the slot layout. There is no separate
+///            "list of slot constants" that can drift out of sync with the
+///            fields they describe. The Rust impl reads this struct top-to-
+///            bottom and replicates the same ordering.
+///         2. Solidity's type system handles all the dynamic-storage encoding
+///            (string length-vs-data, mapping key hashing, etc.) for us, so
+///            we don't reimplement those Rust-side either — we just match
+///            Solidity's documented storage layout.
+///
+///         **Namespace:** `base.b20`. The ERC-7201 location is
+///         `keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff))`.
+///
+///         Variant-specific state lives in its own library (e.g.
+///         `MockB20StablecoinStorage` for the `currency` field) at a
+///         disjoint namespace, so variants compose without slot conflict.
+///
+///         Identity state (`name`, `symbol`) is kept in this struct rather
+///         than encoded into the address because mutability is required
+///         (`setName` / `setSymbol` on the IB20 surface). `decimals` IS
+///         encoded into the address (byte `[11]`) and is retrieved via pure
+///         address-decode in `MockB20.decimals()` — no storage slot.
+library MockB20Storage {
+    /// @custom:storage-location erc7201:base.b20
+    struct Layout {
+        // ---------- Identity (mutable via admin) ----------
+        string name;
+        string symbol;
+        string contractURI;
+        // ---------- ERC-20 ----------
+        uint256 totalSupply;
+        mapping(address account => uint256 balance) balances;
+        mapping(address owner => mapping(address spender => uint256 allowance)) allowances;
+        // ---------- Roles (OZ AccessControl-style) ----------
+        mapping(bytes32 role => mapping(address account => bool isMember)) roles;
+        mapping(bytes32 role => bytes32 adminRole) roleAdmins;
+        // Tracks DEFAULT_ADMIN_ROLE holder count so renounceRole can enforce
+        // LastAdminCannotRenounce in O(1). Bumped on grant, decremented on
+        // revoke / renounce.
+        uint256 adminCount;
+        // ---------- Policy slots ----------
+        mapping(bytes32 policyType => uint64 policyId) policyIds;
+        // ---------- Pause ----------
+        // Bitmask: bit i set means PausableFeature(i) is paused. Translated
+        // to/from the PausableFeature[] enum array at the IB20 surface
+        // boundary.
+        uint256 pausedVectors;
+        // ---------- Supply cap ----------
+        uint256 supplyCap;
+        // ---------- Permit (EIP-2612) ----------
+        mapping(address owner => uint256 nonce) nonces;
+        // ---------- Bootstrap window flag ----------
+        // False from etch until the factory calls closeBootstrap(). While
+        // false, factory-originated calls bypass all token-side authorization
+        // gates (role / policy / pause checks). Token invariants (supply-cap
+        // math, balance accounting) are NOT bypassed.
+        bool initialized;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff))
+    // Verified against the computation in derivedLocation() below.
+    bytes32 internal constant STORAGE_LOCATION = 0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000;
+
+    function layout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Returns the storage location derived per the ERC-7201 formula
+    ///         from the namespace string. Used in tests to assert the
+    ///         hardcoded `STORAGE_LOCATION` constant matches the formula.
+    function derivedLocation() internal pure returns (bytes32) {
+        return keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff));
+    }
+}
+
+/// @title MockB20StablecoinStorage
+/// @notice Slot-layout library for the `MockB20Stablecoin` variant's
+///         variant-specific state. Disjoint namespace from `MockB20Storage`
+///         so the variant composes additively without touching the base
+///         token's slot layout.
+/// @dev    **Namespace:** `base.b20.stablecoin`. Location:
+///         `keccak256(abi.encode(uint256(keccak256("base.b20.stablecoin")) - 1)) & ~bytes32(uint256(0xff))`.
+library MockB20StablecoinStorage {
+    /// @custom:storage-location erc7201:base.b20.stablecoin
+    struct Layout {
+        // Immutable post-creation. Set during factory bootstrap; no
+        // mutator function. Stored at the type's natural Solidity slot
+        // within this struct.
+        string currency;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("base.b20.stablecoin")) - 1)) & ~bytes32(uint256(0xff))
+    // Verified against the computation in derivedLocation() below.
+    bytes32 internal constant STORAGE_LOCATION = 0x35827975a06ca0e9367ea3129b19441d45d0ca58e30b7693f09e73d0943d6200;
+
+    function layout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Returns the storage location derived per the ERC-7201 formula
+    ///         from the namespace string. Used in tests to assert the
+    ///         hardcoded `STORAGE_LOCATION` constant matches the formula.
+    function derivedLocation() internal pure returns (bytes32) {
+        return keccak256(abi.encode(uint256(keccak256("base.b20.stablecoin")) - 1)) & ~bytes32(uint256(0xff));
+    }
+}

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -67,7 +67,8 @@ library MockB20Storage {
         // ---------- Permit (EIP-2612) ----------
         mapping(address owner => uint256 nonce) nonces;
         // ---------- Bootstrap window flag ----------
-        // False from etch until the factory calls closeBootstrap(). While
+        // False from etch until the factory writes `true` directly (via
+        // vm.store, mirroring the Rust impl's direct slot write). While
         // false, factory-originated calls bypass all token-side authorization
         // gates (role / policy / pause checks). Token invariants (supply-cap
         // math, balance accounting) are NOT bypassed.
@@ -77,6 +78,45 @@ library MockB20Storage {
     // keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff))
     // Verified against the computation in derivedLocation() below.
     bytes32 internal constant STORAGE_LOCATION = 0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000;
+
+    // ============================================================
+    //                     SLOT OFFSETS WITHIN LAYOUT
+    // ============================================================
+    // Solidity allocates struct fields sequentially starting at the
+    // struct's base slot. These constants name each field's offset
+    // from `STORAGE_LOCATION` so the factory (and the Rust impl) can
+    // write the token's initial state directly via slot arithmetic
+    // without round-tripping through a Solidity function call on the
+    // token. They MUST stay in sync with the field order of `Layout`
+    // above; the variant-storage test asserts this by reading via the
+    // struct AND via the offset and comparing.
+    //
+    // Mappings consume one declared slot here (their VALUES hash to
+    // unrelated locations), so each mapping below contributes a single
+    // offset that the factory uses as the mapping's base slot when
+    // deriving member slots via `keccak256(abi.encode(key, baseSlot))`.
+
+    uint256 internal constant NAME_OFFSET = 0;
+    uint256 internal constant SYMBOL_OFFSET = 1;
+    uint256 internal constant CONTRACT_URI_OFFSET = 2;
+    uint256 internal constant TOTAL_SUPPLY_OFFSET = 3;
+    uint256 internal constant BALANCES_OFFSET = 4;
+    uint256 internal constant ALLOWANCES_OFFSET = 5;
+    uint256 internal constant ROLES_OFFSET = 6;
+    uint256 internal constant ROLE_ADMINS_OFFSET = 7;
+    uint256 internal constant ADMIN_COUNT_OFFSET = 8;
+    uint256 internal constant POLICY_IDS_OFFSET = 9;
+    uint256 internal constant PAUSED_VECTORS_OFFSET = 10;
+    uint256 internal constant SUPPLY_CAP_OFFSET = 11;
+    uint256 internal constant NONCES_OFFSET = 12;
+    uint256 internal constant INITIALIZED_OFFSET = 13;
+
+    /// @notice Absolute slot for a top-level field of `Layout`.
+    /// @dev `STORAGE_LOCATION + offset`. The struct never crosses the
+    ///      256-slot boundary the ERC-7201 mask reserves.
+    function slotOf(uint256 offset) internal pure returns (bytes32) {
+        return bytes32(uint256(STORAGE_LOCATION) + offset);
+    }
 
     function layout() internal pure returns (Layout storage $) {
         assembly {
@@ -111,6 +151,14 @@ library MockB20StablecoinStorage {
     // keccak256(abi.encode(uint256(keccak256("base.b20.stablecoin")) - 1)) & ~bytes32(uint256(0xff))
     // Verified against the computation in derivedLocation() below.
     bytes32 internal constant STORAGE_LOCATION = 0x35827975a06ca0e9367ea3129b19441d45d0ca58e30b7693f09e73d0943d6200;
+
+    /// @notice Offset of `currency` within `Layout`. Always 0 (single-field struct).
+    uint256 internal constant CURRENCY_OFFSET = 0;
+
+    /// @notice Absolute slot for a top-level field of `Layout`.
+    function slotOf(uint256 offset) internal pure returns (bytes32) {
+        return bytes32(uint256(STORAGE_LOCATION) + offset);
+    }
 
     function layout() internal pure returns (Layout storage $) {
         assembly {

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -7,6 +7,7 @@ import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
 
 import {MockB20} from "test/lib/mocks/MockB20.sol";
 import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
+import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
 
 /// @title MockTokenFactory
 /// @notice Reference implementation of the `ITokenFactory` precompile
@@ -16,43 +17,51 @@ import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
 ///         hit the real factory at the same address with no test-code
 ///         changes.
 ///
-/// @dev    `createToken` does what the production precompile does in
-///         spirit:
-///         1. Decodes variant-specific params (validating the version
+/// @dev    `createToken` mirrors what the production Rust precompile
+///         factory does, step-for-step:
+///         1. Decode variant-specific params (validating the version
 ///            byte and required-field invariants).
-///         2. Computes the deterministic token address per the
+///         2. Compute the deterministic token address per the
 ///            documented schema (`[0:10]` shared prefix, `[10]` variant
 ///            byte, `[11]` decimals byte, `[12:20]` derived from
 ///            `(msg.sender, salt)`).
-///         3. Refuses to overwrite an existing token (revert
+///         3. Refuse to overwrite an existing token (revert
 ///            `TokenAlreadyExists`).
-///         4. Etches the variant-appropriate mock token bytecode at
+///         4. Etch the variant-appropriate mock token bytecode at
 ///            the computed address.
-///         5. Calls `bootstrap(name, symbol, admin, variantData)` on
-///            the new token to write identity state and grant the
-///            initial admin role.
-///         6. Dispatches each `initCalls[i]` via low-level `.call()`
+///         5. **Write the token's initial storage directly** via
+///            `vm.store` at the slot offsets declared in
+///            `MockB20Storage`. Production Rust precompiles have full
+///            chain-state access and write storage the same way; this
+///            mock reaches for the same pattern via cheatcode so the
+///            Solidity reference and the Rust impl agree on the slot
+///            layout slot-for-slot. The token has NO factory-only
+///            entrypoints; its surface is exactly `IB20`.
+///         6. Dispatch each `initCalls[i]` via low-level `.call()`
 ///            so `msg.sender` arrives at the token as `address(this)`
 ///            (the factory). During the bootstrap window
-///            (`!initialized`), the token bypasses all authorization
-///            gates for factory-originated calls — see the
-///            "fully privileged" semantics documented on
+///            (`!initialized`, set via the same `vm.store`), the token
+///            bypasses all authorization gates for factory-originated
+///            calls per the "fully privileged" semantics on
 ///            `ITokenFactory`.
-///         7. Calls `closeBootstrap()` on the token to flip the
-///            initialized flag, closing the privileged window. After
-///            this point the factory has no special access; all
-///            subsequent operations on the token go through standard
-///            role / policy / pause checks.
-///         8. Emits `TokenCreated`.
+///         7. Flip the `initialized` flag (also via `vm.store`),
+///            closing the privileged window. After this point the
+///            factory has no special access; all subsequent operations
+///            on the token go through standard role / policy / pause
+///            checks.
+///         8. Emit `TokenCreated` (which includes `admin`, the
+///            canonical signal for the initial role grant since no
+///            `RoleGranted` event is emitted during direct storage
+///            writes).
 ///
 ///         Token invariants (supply-cap math, balance accounting) are
-///         NOT bypassed during the privileged window — `initCalls` that
-///         would violate an invariant still revert. This matches the
-///         spec documented on `ITokenFactory`.
+///         NOT bypassed during the privileged window: `initCalls` that
+///         would violate an invariant still revert.
 contract MockTokenFactory is ITokenFactory {
     /// @dev Hardcoded forge-std VM address. The factory uses `vm.etch`
-    ///      to plant token bytecode at the deterministic address; this
-    ///      cheatcode dependency is the structural reason the
+    ///      to plant token bytecode at the deterministic address and
+    ///      `vm.store` to write the token's initial state directly.
+    ///      The cheatcode dependencies are the structural reason the
     ///      reference impls live under `test/` rather than `src/`.
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
@@ -66,7 +75,7 @@ contract MockTokenFactory is ITokenFactory {
         string memory symbol_;
         address admin;
         uint8 decimals;
-        bytes memory variantData;
+        string memory currency_;
 
         if (variant == TokenVariant.DEFAULT) {
             B20CreateParams memory p = abi.decode(params, (B20CreateParams));
@@ -76,8 +85,6 @@ contract MockTokenFactory is ITokenFactory {
             symbol_ = p.symbol;
             admin = p.initialAdmin;
             decimals = p.decimals;
-            // No variant data on Default.
-            variantData = bytes("");
         } else if (variant == TokenVariant.STABLECOIN) {
             B20StablecoinCreateParams memory p = abi.decode(params, (B20StablecoinCreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
@@ -86,7 +93,7 @@ contract MockTokenFactory is ITokenFactory {
             symbol_ = p.symbol;
             admin = p.initialAdmin;
             decimals = 6;
-            variantData = abi.encode(p.currency);
+            currency_ = p.currency;
         } else if (variant == TokenVariant.SECURITY) {
             // IB20Security interface is in flux; the reference impl is
             // deferred until it stabilizes. The factory should not
@@ -109,27 +116,37 @@ contract MockTokenFactory is ITokenFactory {
             vm.etch(token, type(MockB20Stablecoin).runtimeCode);
         }
 
-        // -- 5. Bootstrap: writes identity + grants initial admin --
-        MockB20(token).bootstrap(name_, symbol_, admin, variantData);
+        // -- 5. Write initial storage directly via vm.store. No call
+        //       into the token; storage layout is the contract between
+        //       this factory and the Rust impl, which writes the same
+        //       slots the same way.
+        _writeBaseStorage(token, name_, symbol_, admin);
+        if (variant == TokenVariant.STABLECOIN) {
+            _writeStablecoinStorage(token, currency_);
+        }
 
-        // -- 6. Dispatch initCalls. msg.sender at the token is
-        //       address(this) == factory, triggering the bootstrap-
-        //       window auth bypass. Init-call reverts roll up to abort
-        //       the whole creation.
+        // -- 6. Emit creation event BEFORE initCalls dispatch (per
+        //       ITokenFactory natspec) so init-call effects appear
+        //       strictly after the creation event in the log order.
+        //       Includes admin since there's no separate RoleGranted
+        //       at bootstrap.
+        emit TokenCreated(token, variant, name_, symbol_, decimals, admin);
+
+        // -- 7. Dispatch initCalls. msg.sender at the token is
+        //       address(this) == factory, and `initialized` is still
+        //       false (default zero in the freshly-written storage),
+        //       so the token's _isPrivileged() returns true and gates
+        //       are bypassed. Init-call reverts roll up to abort the
+        //       whole creation.
         for (uint256 i = 0; i < initCalls.length; i++) {
             (bool ok,) = token.call(initCalls[i]);
             if (!ok) revert InitCallFailed(i);
         }
 
-        // -- 7. Close the bootstrap window. After this, the factory's
-        //       privilege is gone; only role / policy / pause holders
-        //       can mutate state.
-        MockB20(token).closeBootstrap();
-
-        // -- 8. Emit creation event AFTER identity is sealed and
-        //       initCalls have been applied. (initCalls have already
-        //       emitted their own state-change events.)
-        emit TokenCreated(token, variant, name_, symbol_, decimals);
+        // -- 8. Close the bootstrap window by setting initialized=true.
+        //       After this, the factory's privilege is gone; only
+        //       role / policy / pause holders can mutate state.
+        _writeBool(token, MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET), true);
     }
 
     /// @inheritdoc ITokenFactory
@@ -180,5 +197,93 @@ contract MockTokenFactory is ITokenFactory {
     /// @dev Returns true iff `token`'s first 10 bytes match the B-20 prefix.
     function _isB20Prefix(address token) internal pure returns (bool) {
         return (uint160(token) >> 80) == (uint160(0xB2) << 72);
+    }
+
+    // ============================================================
+    //                     INITIAL-STATE WRITERS
+    // ============================================================
+    // These write the token's initial storage directly via vm.store
+    // at the slot offsets declared in MockB20Storage. The Rust impl
+    // writes the same slots with the same values; the offsets +
+    // ERC-7201 namespace are the storage-layout contract between the
+    // two implementations.
+
+    /// @dev Writes the identity + role + supply-cap state every B-20
+    ///      starts with. Mappings get derived slots via the standard
+    ///      Solidity rule: `keccak256(abi.encode(key, baseSlot))`.
+    function _writeBaseStorage(address token, string memory name_, string memory symbol_, address admin) internal {
+        _writeString(token, MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET), name_);
+        _writeString(token, MockB20Storage.slotOf(MockB20Storage.SYMBOL_OFFSET), symbol_);
+        _writeUint(token, MockB20Storage.slotOf(MockB20Storage.SUPPLY_CAP_OFFSET), type(uint256).max);
+
+        if (admin != address(0)) {
+            // roles[DEFAULT_ADMIN_ROLE][admin] = true
+            // Mapping slot derivation: m[k] is at keccak256(abi.encode(k, baseSlot)),
+            // where baseSlot is the mapping field's ABSOLUTE storage slot.
+            bytes32 rolesBaseSlot = MockB20Storage.slotOf(MockB20Storage.ROLES_OFFSET);
+            bytes32 outerSlot = keccak256(abi.encode(bytes32(0), rolesBaseSlot));
+            bytes32 innerSlot = keccak256(abi.encode(admin, outerSlot));
+            _writeBool(token, innerSlot, true);
+            // adminCount = 1
+            _writeUint(token, MockB20Storage.slotOf(MockB20Storage.ADMIN_COUNT_OFFSET), 1);
+        }
+        // Everything else (totalSupply, allowances, roleAdmins, policyIds,
+        // pausedVectors, nonces, contractURI, initialized) defaults to the
+        // EVM's zero state, which is correct for a fresh token.
+    }
+
+    /// @dev Writes the stablecoin variant's `currency` field at its
+    ///      disjoint ERC-7201 namespace (`base.b20.stablecoin`).
+    function _writeStablecoinStorage(address token, string memory currency_) internal {
+        _writeString(
+            token,
+            MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET),
+            currency_
+        );
+    }
+
+    // ============================================================
+    //                     STORAGE WRITE PRIMITIVES
+    // ============================================================
+
+    function _writeUint(address target, bytes32 slot, uint256 value) internal {
+        vm.store(target, slot, bytes32(value));
+    }
+
+    function _writeBool(address target, bytes32 slot, bool value) internal {
+        vm.store(target, slot, bytes32(uint256(value ? 1 : 0)));
+    }
+
+    /// @dev Solidity string storage encoding:
+    ///        - length < 32:  one slot, `(data << 0) | (length * 2)` with
+    ///                         the bytes in the high portion and `length*2`
+    ///                         in the low byte (low bit clear -> short).
+    ///        - length >= 32: slot stores `(length * 2) | 1` (low bit set
+    ///                         -> long), data starts at `keccak256(slot)`
+    ///                         and runs sequentially.
+    function _writeString(address target, bytes32 slot, string memory value) internal {
+        bytes memory data = bytes(value);
+        if (data.length < 32) {
+            bytes32 packed;
+            assembly {
+                // High portion: first 32 bytes of memory at data+32 (the string body,
+                // with implicit zero padding past data.length since memory is fresh).
+                // Low byte: data.length * 2 (low bit clear marks "short string").
+                packed := or(mload(add(data, 32)), mul(mload(data), 2))
+            }
+            vm.store(target, slot, packed);
+        } else {
+            // Long string: marker slot, then data chunks at keccak256(slot)+i.
+            vm.store(target, slot, bytes32(data.length * 2 + 1));
+            bytes32 dataStart = keccak256(abi.encode(slot));
+            uint256 chunks = (data.length + 31) / 32;
+            for (uint256 i = 0; i < chunks; i++) {
+                bytes32 chunk;
+                assembly {
+                    chunk := mload(add(add(data, 32), mul(i, 32)))
+                }
+                vm.store(target, bytes32(uint256(dataStart) + i), chunk);
+            }
+        }
     }
 }

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -1,37 +1,138 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Vm} from "forge-std/Vm.sol";
+
 import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
 
-/// @notice Placeholder mock for the `ITokenFactory` precompile.
+import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
+
+/// @title MockTokenFactory
+/// @notice Reference implementation of the `ITokenFactory` precompile
+///         surface. Etched at `StdPrecompiles.TOKEN_FACTORY_ADDRESS`
+///         in `BaseTest.setUp` so local tests dispatch through this
+///         mock; fork tests against a chain with the live precompile
+///         hit the real factory at the same address with no test-code
+///         changes.
 ///
-/// Implements the address-derivation schema in `createToken` /
-/// `getTokenAddress` (so the addresses produced by setUp helpers match
-/// the documented `[0:10]` prefix / `[10]` variant / `[11]` decimals /
-/// `[12:20]` `keccak256(sender, salt)` layout). Every other method
-/// reverts pending the full mock implementation in a follow-up PR.
+/// @dev    `createToken` does what the production precompile does in
+///         spirit:
+///         1. Decodes variant-specific params (validating the version
+///            byte and required-field invariants).
+///         2. Computes the deterministic token address per the
+///            documented schema (`[0:10]` shared prefix, `[10]` variant
+///            byte, `[11]` decimals byte, `[12:20]` derived from
+///            `(msg.sender, salt)`).
+///         3. Refuses to overwrite an existing token (revert
+///            `TokenAlreadyExists`).
+///         4. Etches the variant-appropriate mock token bytecode at
+///            the computed address.
+///         5. Calls `bootstrap(name, symbol, admin, variantData)` on
+///            the new token to write identity state and grant the
+///            initial admin role.
+///         6. Dispatches each `initCalls[i]` via low-level `.call()`
+///            so `msg.sender` arrives at the token as `address(this)`
+///            (the factory). During the bootstrap window
+///            (`!initialized`), the token bypasses all authorization
+///            gates for factory-originated calls — see the
+///            "fully privileged" semantics documented on
+///            `ITokenFactory`.
+///         7. Calls `closeBootstrap()` on the token to flip the
+///            initialized flag, closing the privileged window. After
+///            this point the factory has no special access; all
+///            subsequent operations on the token go through standard
+///            role / policy / pause checks.
+///         8. Emits `TokenCreated`.
 ///
-/// `createToken` does NOT deploy any code at the returned address — it
-/// only computes and returns the deterministic address. The follow-up
-/// PR will plant the token bytecode there.
+///         Token invariants (supply-cap math, balance accounting) are
+///         NOT bypassed during the privileged window — `initCalls` that
+///         would violate an invariant still revert. This matches the
+///         spec documented on `ITokenFactory`.
 contract MockTokenFactory is ITokenFactory {
-    function createToken(TokenVariant variant, bytes32 salt, bytes calldata params, bytes[] calldata /*initCalls*/ )
+    /// @dev Hardcoded forge-std VM address. The factory uses `vm.etch`
+    ///      to plant token bytecode at the deterministic address; this
+    ///      cheatcode dependency is the structural reason the
+    ///      reference impls live under `test/` rather than `src/`.
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @inheritdoc ITokenFactory
+    function createToken(TokenVariant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
         external
         returns (address token)
     {
+        // -- 1. Decode + validate, get the four params every variant needs --
+        string memory name_;
+        string memory symbol_;
+        address admin;
         uint8 decimals;
+        bytes memory variantData;
+
         if (variant == TokenVariant.DEFAULT) {
             B20CreateParams memory p = abi.decode(params, (B20CreateParams));
+            if (p.version != 1) revert UnsupportedVersion(p.version);
+            if (p.decimals < 2 || p.decimals > 18) revert InvalidDecimals(p.decimals);
+            name_ = p.name;
+            symbol_ = p.symbol;
+            admin = p.initialAdmin;
             decimals = p.decimals;
-        } else if (variant == TokenVariant.STABLECOIN || variant == TokenVariant.SECURITY) {
+            // No variant data on Default.
+            variantData = bytes("");
+        } else if (variant == TokenVariant.STABLECOIN) {
+            B20StablecoinCreateParams memory p = abi.decode(params, (B20StablecoinCreateParams));
+            if (p.version != 1) revert UnsupportedVersion(p.version);
+            if (bytes(p.currency).length == 0) revert MissingRequiredField();
+            name_ = p.name;
+            symbol_ = p.symbol;
+            admin = p.initialAdmin;
             decimals = 6;
+            variantData = abi.encode(p.currency);
+        } else if (variant == TokenVariant.SECURITY) {
+            // IB20Security interface is in flux; the reference impl is
+            // deferred until it stabilizes. The factory should not
+            // silently succeed for an unsupported variant; revert with
+            // an unambiguous version-style signal.
+            revert UnsupportedVersion(0);
         } else {
             revert InvalidVariant();
         }
 
-        return _computeAddress(variant, decimals, msg.sender, salt);
+        // -- 2-3. Compute address; refuse to overwrite --
+        token = _computeAddress(variant, decimals, msg.sender, salt);
+        if (token.code.length != 0) revert TokenAlreadyExists(token);
+
+        // -- 4. Etch the variant-appropriate runtime bytecode --
+        if (variant == TokenVariant.DEFAULT) {
+            vm.etch(token, type(MockB20).runtimeCode);
+        } else {
+            // STABLECOIN; SECURITY already reverted above.
+            vm.etch(token, type(MockB20Stablecoin).runtimeCode);
+        }
+
+        // -- 5. Bootstrap: writes identity + grants initial admin --
+        MockB20(token).bootstrap(name_, symbol_, admin, variantData);
+
+        // -- 6. Dispatch initCalls. msg.sender at the token is
+        //       address(this) == factory, triggering the bootstrap-
+        //       window auth bypass. Init-call reverts roll up to abort
+        //       the whole creation.
+        for (uint256 i = 0; i < initCalls.length; i++) {
+            (bool ok,) = token.call(initCalls[i]);
+            if (!ok) revert InitCallFailed(i);
+        }
+
+        // -- 7. Close the bootstrap window. After this, the factory's
+        //       privilege is gone; only role / policy / pause holders
+        //       can mutate state.
+        MockB20(token).closeBootstrap();
+
+        // -- 8. Emit creation event AFTER identity is sealed and
+        //       initCalls have been applied. (initCalls have already
+        //       emitted their own state-change events.)
+        emit TokenCreated(token, variant, name_, symbol_, decimals);
     }
 
+    /// @inheritdoc ITokenFactory
     function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
         external
         pure
@@ -40,26 +141,30 @@ contract MockTokenFactory is ITokenFactory {
         return _computeAddress(variant, decimals, sender, salt);
     }
 
+    /// @inheritdoc ITokenFactory
     function isB20(address token) external pure returns (bool) {
         return _isB20Prefix(token);
     }
 
+    /// @inheritdoc ITokenFactory
     function getTokenVariant(address token) external pure returns (TokenVariant) {
         if (!_isB20Prefix(token)) return TokenVariant.NONE;
         // forge-lint: disable-next-line(unsafe-typecast)
-        uint8 variantByte = uint8(uint160(token) >> 72); // byte [10]; truncation is the read
+        uint8 variantByte = uint8(uint160(token) >> 72); // byte [10]
         if (variantByte > uint8(TokenVariant.SECURITY)) return TokenVariant.NONE;
         return TokenVariant(variantByte);
     }
 
-    // -- Address schema helpers --
+    // ============================================================
+    //                     ADDRESS SCHEMA HELPERS
+    // ============================================================
 
     /// @dev Encodes (variant, decimals, sender, salt) into the canonical
     ///      B-20 address layout:
-    ///        byte [0]    = 0xB2
-    ///        bytes [1:10] = 0x00 (9 zero bytes)
-    ///        byte [10]   = variant
-    ///        byte [11]   = decimals
+    ///        byte [0]      = 0xB2
+    ///        bytes [1:10]  = 0x00 (9 zero bytes)
+    ///        byte [10]     = variant
+    ///        byte [11]     = decimals
     ///        bytes [12:20] = keccak256(sender, salt)[0:8]
     function _computeAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
         internal

--- a/test/unit/B20/erc20/allowance.t.sol
+++ b/test/unit/B20/erc20/allowance.t.sol
@@ -6,20 +6,31 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20AllowanceTest is B20Test {
     /// @notice Verifies allowance returns zero for any unconfigured (owner, spender) pair
     /// @dev Default state across the address space
-    function test_allowance_success_zeroByDefault(address owner, address spender) public {
-        // unimplemented
+    function test_allowance_success_zeroByDefault(address owner, address spender) public view {
+        assertEq(token.allowance(owner, spender), 0, "untouched allowance must be zero");
     }
 
     /// @notice Verifies allowance reflects the value set via approve
     /// @dev Approval readback; canonical approve test lives in approve.t.sol
     function test_allowance_success_reflectsApprove(address owner, address spender, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        // Spender may be address(0)? approve reverts on InvalidSpender(0), so filter.
+        vm.assume(spender != address(0));
+
+        vm.prank(owner);
+        token.approve(spender, amount);
+        assertEq(token.allowance(owner, spender), amount, "allowance must reflect approve");
     }
 
     /// @notice Verifies allowance reflects the value set via permit
-    /// @dev Permit readback; canonical permit test lives in permit.t.sol
-    function test_allowance_success_reflectsPermit(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
+    /// @dev Permit readback; canonical permit test lives in permit.t.sol.
+    ///      Skipped here: full EIP-712 signing setup (private key, domain separator,
+    ///      deadline, v/r/s) belongs in the permit-specific test file, not in the
+    ///      allowance-view test.
+    function test_allowance_success_reflectsPermit(uint256 /*ownerPrivateKey*/, address /*spender*/, uint256 /*amount*/)
+        public
+    {
+        vm.skip(true);
     }
 
     /// @notice Verifies allowance decreases after a successful transferFrom
@@ -31,6 +42,28 @@ contract B20AllowanceTest is B20Test {
         uint256 allowanceAmount,
         uint256 spendAmount
     ) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        _assumeValidActor(spender);
+        _assumeValidActor(to);
+        vm.assume(owner != to);
+        // transferFrom only consumes allowance when msg.sender != from (see MockB20._transferFrom);
+        // owner == spender skips the consumption path, so filter it out.
+        vm.assume(owner != spender);
+        // Bound spendAmount to <= allowanceAmount, both above zero so the transfer is meaningful.
+        allowanceAmount = bound(allowanceAmount, 1, type(uint128).max);
+        spendAmount = bound(spendAmount, 1, allowanceAmount);
+
+        _mint(owner, spendAmount);
+        vm.prank(owner);
+        token.approve(spender, allowanceAmount);
+
+        vm.prank(spender);
+        token.transferFrom(owner, to, spendAmount);
+
+        assertEq(
+            token.allowance(owner, spender),
+            allowanceAmount - spendAmount,
+            "allowance must decrease by spent amount"
+        );
     }
 }

--- a/test/unit/B20/erc20/allowance.t.sol
+++ b/test/unit/B20/erc20/allowance.t.sol
@@ -22,17 +22,6 @@ contract B20AllowanceTest is B20Test {
         assertEq(token.allowance(owner, spender), amount, "allowance must reflect approve");
     }
 
-    /// @notice Verifies allowance reflects the value set via permit
-    /// @dev Permit readback; canonical permit test lives in permit.t.sol.
-    ///      Skipped here: full EIP-712 signing setup (private key, domain separator,
-    ///      deadline, v/r/s) belongs in the permit-specific test file, not in the
-    ///      allowance-view test.
-    function test_allowance_success_reflectsPermit(uint256 /*ownerPrivateKey*/, address /*spender*/, uint256 /*amount*/)
-        public
-    {
-        vm.skip(true);
-    }
-
     /// @notice Verifies allowance decreases after a successful transferFrom
     /// @dev Spend-tracking readback; canonical transferFrom test lives in transferFrom.t.sol
     function test_allowance_success_decreasesAfterTransferFrom(

--- a/test/unit/B20/erc20/approve.t.sol
+++ b/test/unit/B20/erc20/approve.t.sol
@@ -1,36 +1,71 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20ApproveTest is B20Test {
     /// @notice Verifies approve reverts for the zero spender address
     /// @dev OZ ERC-6093 invariant; checks InvalidSpender(address(0)) error
     function test_approve_revert_zeroSpender(address owner, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSpender.selector, address(0)));
+        token.approve(address(0), amount);
     }
 
     /// @notice Verifies approve does NOT consult any pause or policy state
     /// @dev approve sets future-spend authorization, not movement; no gating
     function test_approve_success_succeedsWhilePaused(address owner, address spender, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        vm.assume(spender != address(0));
+
+        // Pause every transfer-adjacent feature; approve should still succeed.
+        _pause(IB20.PausableFeature.TRANSFER);
+        _pause(IB20.PausableFeature.MINT);
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(owner);
+        assertTrue(token.approve(spender, amount), "approve must succeed even while paused");
+        assertEq(token.allowance(owner, spender), amount, "allowance must be set");
     }
 
     /// @notice Verifies approve sets allowance(owner, spender) to amount
     /// @dev Overwrites any prior allowance value (no increment / decrement helpers)
     function test_approve_success_setsAllowance(address owner, address spender, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        vm.assume(spender != address(0));
+
+        // Set a non-zero baseline, then overwrite to amount, to prove approve replaces (not adds).
+        vm.prank(owner);
+        token.approve(spender, 42);
+        assertEq(token.allowance(owner, spender), 42, "baseline allowance");
+
+        vm.prank(owner);
+        token.approve(spender, amount);
+        assertEq(token.allowance(owner, spender), amount, "approve must overwrite");
     }
 
     /// @notice Verifies approve emits Approval(owner, spender, amount)
     /// @dev Event integrity; canonical Approval event test for the approve path
     function test_approve_success_emitsApproval(address owner, address spender, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        vm.assume(spender != address(0));
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Approval(owner, spender, amount);
+        vm.prank(owner);
+        token.approve(spender, amount);
     }
 
     /// @notice Verifies approve returns true on success
     /// @dev ERC-20 return-value contract
     function test_approve_success_returnsTrue(address owner, address spender, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(owner);
+        vm.assume(spender != address(0));
+
+        vm.prank(owner);
+        assertTrue(token.approve(spender, amount), "approve must return true");
     }
 }

--- a/test/unit/B20/erc20/balanceOf.t.sol
+++ b/test/unit/B20/erc20/balanceOf.t.sol
@@ -6,19 +6,30 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20BalanceOfTest is B20Test {
     /// @notice Verifies balanceOf returns zero for any account that has never received tokens
     /// @dev Default state across the address space
-    function test_balanceOf_success_zeroForUntouchedAccount(address account) public {
-        // unimplemented
+    function test_balanceOf_success_zeroForUntouchedAccount(address account) public view {
+        assertEq(token.balanceOf(account), 0, "untouched account must have zero balance");
     }
 
     /// @notice Verifies balanceOf returns the amount credited via mint
     /// @dev Mint readback; canonical mint test lives in mint.t.sol
     function test_balanceOf_success_reflectsMint(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _mint(to, amount);
+        assertEq(token.balanceOf(to), amount, "balance must equal minted amount");
     }
 
     /// @notice Verifies balanceOf reflects the post-transfer state for sender and receiver
     /// @dev Transfer readback; canonical transfer test lives in transfer.t.sol
     function test_balanceOf_success_reflectsTransfer(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(from != to);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.transfer(to, amount);
+
+        assertEq(token.balanceOf(from), 0, "from balance must be zero after full transfer");
+        assertEq(token.balanceOf(to), amount, "to balance must equal transferred amount");
     }
 }

--- a/test/unit/B20/erc20/decimals.t.sol
+++ b/test/unit/B20/erc20/decimals.t.sol
@@ -6,13 +6,16 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20DecimalsTest is B20Test {
     /// @notice Verifies decimals returns the value passed to the factory at creation
     /// @dev Immutable after creation; should match address byte [11]
-    function test_decimals_success_returnsCreationDecimals() public {
-        // unimplemented
+    function test_decimals_success_returnsCreationDecimals() public view {
+        // The default _b20Params() helper creates a token with decimals 18.
+        assertEq(token.decimals(), 18, "decimals must match creation value");
     }
 
     /// @notice Verifies decimals matches byte [11] of the token's own address
     /// @dev Address-schema invariant: stateless decimals() lookup must agree with storage
-    function test_decimals_success_matchesAddressByte() public {
-        // unimplemented
+    function test_decimals_success_matchesAddressByte() public view {
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 byteAt11 = uint8(uint160(address(token)) >> 64);
+        assertEq(token.decimals(), byteAt11, "decimals() must equal address byte [11]");
     }
 }

--- a/test/unit/B20/erc20/name.t.sol
+++ b/test/unit/B20/erc20/name.t.sol
@@ -6,13 +6,16 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20NameTest is B20Test {
     /// @notice Verifies name returns the value passed to the factory at creation
     /// @dev Constructor-stored value readback
-    function test_name_success_returnsCreationName() public {
-        // unimplemented
+    function test_name_success_returnsCreationName() public view {
+        // The default _b20Params() helper creates a token with name "Test".
+        assertEq(token.name(), "Test", "name must match creation value");
     }
 
     /// @notice Verifies name reflects updates made via setName
     /// @dev Mutable-metadata readback; canonical setter test lives in setName.t.sol
     function test_name_success_reflectsSetName(string calldata newName) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setName(newName);
+        assertEq(token.name(), newName, "name must reflect setName");
     }
 }

--- a/test/unit/B20/erc20/symbol.t.sol
+++ b/test/unit/B20/erc20/symbol.t.sol
@@ -6,13 +6,16 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20SymbolTest is B20Test {
     /// @notice Verifies symbol returns the value passed to the factory at creation
     /// @dev Constructor-stored value readback
-    function test_symbol_success_returnsCreationSymbol() public {
-        // unimplemented
+    function test_symbol_success_returnsCreationSymbol() public view {
+        // The default _b20Params() helper creates a token with symbol "TST".
+        assertEq(token.symbol(), "TST", "symbol must match creation value");
     }
 
     /// @notice Verifies symbol reflects updates made via setSymbol
     /// @dev Mutable-metadata readback; canonical setter test lives in setSymbol.t.sol
     function test_symbol_success_reflectsSetSymbol(string calldata newSymbol) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setSymbol(newSymbol);
+        assertEq(token.symbol(), newSymbol, "symbol must reflect setSymbol");
     }
 }

--- a/test/unit/B20/erc20/totalSupply.t.sol
+++ b/test/unit/B20/erc20/totalSupply.t.sol
@@ -7,12 +7,24 @@ contract B20TotalSupplyTest is B20Test {
     /// @notice Verifies totalSupply returns the cumulative minted-minus-burned amount
     /// @dev Accounting invariant: totalSupply == sum of all balances == sum(mint) - sum(burn)
     function test_totalSupply_success_tracksMintAndBurn(address to, uint256 mintAmount, uint256 burnAmount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        // Bound burnAmount to <= mintAmount so we don't underflow.
+        burnAmount = bound(burnAmount, 0, mintAmount);
+
+        _mint(to, mintAmount);
+        assertEq(token.totalSupply(), mintAmount, "totalSupply after mint");
+
+        // Grant BURN_ROLE to the recipient so they can burn from their own balance.
+        _grantRole(BURN_ROLE, to);
+        vm.prank(to);
+        token.burn(burnAmount);
+        assertEq(token.totalSupply(), mintAmount - burnAmount, "totalSupply after burn");
     }
 
     /// @notice Verifies totalSupply is zero on a freshly-created token with no initial supply
     /// @dev Default-state read for a token created without bootstrap mints in initCalls
-    function test_totalSupply_success_zeroOnFreshToken() public {
-        // unimplemented
+    function test_totalSupply_success_zeroOnFreshToken() public view {
+        // B20Test.setUp deploys a token with no initCalls, so no initial mints.
+        assertEq(token.totalSupply(), 0, "fresh token must have zero supply");
     }
 }

--- a/test/unit/B20/erc20/transfer.t.sol
+++ b/test/unit/B20/erc20/transfer.t.sol
@@ -1,60 +1,123 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20TransferTest is B20Test {
     /// @notice Verifies transfer reverts when the TRANSFER feature is paused
     /// @dev Pause guard fires before policy or balance checks; checks ContractPaused(TRANSFER) error
     function test_transfer_revert_whenTransferPaused(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transfer(to, amount);
     }
 
     /// @notice Verifies transfer reverts when sender is not authorized under TRANSFER_SENDER
     /// @dev Policy guard for the from-side; checks PolicyForbids(TRANSFER_SENDER, policyId) error
     function test_transfer_revert_senderPolicyForbids(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_SENDER, ALWAYS_REJECT));
+        token.transfer(to, amount);
     }
 
     /// @notice Verifies transfer reverts when recipient is not authorized under TRANSFER_RECEIVER
     /// @dev Policy guard for the to-side; checks PolicyForbids(TRANSFER_RECEIVER, policyId) error
     function test_transfer_revert_receiverPolicyForbids(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _setPolicy(TRANSFER_RECEIVER, ALWAYS_REJECT);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_RECEIVER, ALWAYS_REJECT));
+        token.transfer(to, amount);
     }
 
     /// @notice Verifies transfer reverts when sender balance is insufficient
     /// @dev Balance precondition; checks InsufficientBalance(sender, balance, amount) error
     function test_transfer_revert_insufficientBalance(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        amount = bound(amount, 1, type(uint256).max);
+        // from has zero balance; any nonzero amount exceeds it.
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientBalance.selector, from, 0, amount));
+        token.transfer(to, amount);
     }
 
     /// @notice Verifies transfer reverts for the zero recipient address
     /// @dev OZ ERC-6093 invariant; checks InvalidReceiver(address(0)) error
     function test_transfer_revert_zeroRecipient(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
     }
 
     /// @notice Verifies transfer debits the sender balance by amount
     /// @dev Accounting half: balanceOf(from) decreases by exactly amount
     function test_transfer_success_debitsSender(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(from != to);
+
+        _mint(from, amount);
+        uint256 before = token.balanceOf(from);
+
+        vm.prank(from);
+        token.transfer(to, amount);
+        assertEq(token.balanceOf(from), before - amount, "from must be debited by amount");
     }
 
     /// @notice Verifies transfer credits the receiver balance by amount
     /// @dev Accounting half: balanceOf(to) increases by exactly amount
     function test_transfer_success_creditsReceiver(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(from != to);
+
+        _mint(from, amount);
+        uint256 before = token.balanceOf(to);
+
+        vm.prank(from);
+        token.transfer(to, amount);
+        assertEq(token.balanceOf(to), before + amount, "to must be credited by amount");
     }
 
     /// @notice Verifies transfer emits Transfer(from, to, amount)
     /// @dev Event integrity; canonical Transfer event test for the transfer path
     function test_transfer_success_emitsTransfer(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+
+        _mint(from, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(from, to, amount);
+        vm.prank(from);
+        token.transfer(to, amount);
     }
 
     /// @notice Verifies transfer returns true on success
     /// @dev ERC-20 return-value contract
     function test_transfer_success_returnsTrue(address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+
+        _mint(from, amount);
+
+        vm.prank(from);
+        assertTrue(token.transfer(to, amount), "transfer must return true");
     }
 }

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -1,65 +1,152 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20TransferFromTest is B20Test {
     /// @notice Verifies transferFrom reverts when the TRANSFER feature is paused
-    /// @dev Pause guard fires before allowance / balance checks; checks ContractPaused(TRANSFER)
+    /// @dev Pause guard fires in the inner _transfer, after allowance consumption.
+    ///      To reach it we need a non-zero allowance so the consumeAllowance step
+    ///      doesn't revert first.
     function test_transferFrom_revert_whenTransferPaused(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from); // skip the consume-allowance bypass when caller == from
+        amount = bound(amount, 1, type(uint128).max);
+
+        vm.prank(from);
+        token.approve(caller, amount);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom reverts when caller is not authorized under TRANSFER_EXECUTOR
-    /// @dev Executor-side policy guard (when caller != from); checks PolicyForbids(TRANSFER_EXECUTOR, policyId)
+    /// @dev Executor-side policy guard fires after allowance consumption and before _transfer.
     function test_transferFrom_revert_executorPolicyForbids(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+
+        vm.prank(from);
+        token.approve(caller, amount);
+        _setPolicy(TRANSFER_EXECUTOR, ALWAYS_REJECT);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_EXECUTOR, ALWAYS_REJECT));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom reverts when from is not authorized under TRANSFER_SENDER
-    /// @dev Sender-side policy guard; checks PolicyForbids(TRANSFER_SENDER, policyId)
+    /// @dev Sender-side policy guard fires inside _transfer.
     function test_transferFrom_revert_senderPolicyForbids(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+
+        vm.prank(from);
+        token.approve(caller, amount);
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_SENDER, ALWAYS_REJECT));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom reverts when to is not authorized under TRANSFER_RECEIVER
-    /// @dev Receiver-side policy guard; checks PolicyForbids(TRANSFER_RECEIVER, policyId)
+    /// @dev Receiver-side policy guard fires inside _transfer.
     function test_transferFrom_revert_receiverPolicyForbids(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+
+        vm.prank(from);
+        token.approve(caller, amount);
+        _setPolicy(TRANSFER_RECEIVER, ALWAYS_REJECT);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_RECEIVER, ALWAYS_REJECT));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom reverts when caller's allowance is insufficient
-    /// @dev Allowance precondition; checks InsufficientAllowance(spender, allowance, amount)
+    /// @dev Allowance precondition fires first when caller != from; checks InsufficientAllowance
     function test_transferFrom_revert_insufficientAllowance(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint256).max);
+        // No approval set; allowance is 0; any nonzero amount exceeds it.
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientAllowance.selector, caller, 0, amount));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom reverts when from's balance is insufficient
-    /// @dev Balance precondition; checks InsufficientBalance(from, balance, amount)
+    /// @dev Balance precondition fires inside _transfer, after allowance consumption.
     function test_transferFrom_revert_insufficientBalance(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+        // from has zero balance, but allowance is set high enough to clear the allowance gate.
+
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientBalance.selector, from, 0, amount));
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom debits from balance and credits to balance
     /// @dev Accounting invariant for the transferFrom path
     function test_transferFrom_success_movesBalance(address caller, address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        vm.assume(from != to);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.prank(caller);
+        token.transferFrom(from, to, amount);
+
+        assertEq(token.balanceOf(from), 0, "from must be fully debited");
+        assertEq(token.balanceOf(to), amount, "to must be fully credited");
     }
 
     /// @notice Verifies transferFrom decreases caller allowance by exactly amount
-    /// @dev Spend-tracking; infinite allowance (type(uint256).max) is not decreased
+    /// @dev Spend-tracking; non-infinite allowances decrement by the transferred amount
     function test_transferFrom_success_decreasesAllowance(
         address caller,
         address from,
@@ -67,18 +154,53 @@ contract B20TransferFromTest is B20Test {
         uint256 allowanceAmount,
         uint256 spendAmount
     ) public {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        vm.assume(from != to);
+        allowanceAmount = bound(allowanceAmount, 1, type(uint128).max);
+        // Cap below type(uint256).max so we exercise the consume path (not the infinite-allowance bypass).
+        vm.assume(allowanceAmount != type(uint256).max);
+        spendAmount = bound(spendAmount, 1, allowanceAmount);
+
+        _mint(from, spendAmount);
+        vm.prank(from);
+        token.approve(caller, allowanceAmount);
+
+        vm.prank(caller);
+        token.transferFrom(from, to, spendAmount);
+
+        assertEq(
+            token.allowance(from, caller),
+            allowanceAmount - spendAmount,
+            "allowance must decrease by spent amount"
+        );
     }
 
     /// @notice Verifies transferFrom leaves an infinite allowance unchanged
-    /// @dev Convention: type(uint256).max allowance is treated as unlimited
+    /// @dev Convention: type(uint256).max allowance is treated as unlimited and not decremented.
     function test_transferFrom_success_infiniteAllowanceUnchanged(
         address caller,
         address from,
         address to,
         uint256 amount
     ) public {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        vm.assume(from != to);
+        amount = bound(amount, 1, type(uint128).max);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, type(uint256).max);
+
+        vm.prank(caller);
+        token.transferFrom(from, to, amount);
+
+        assertEq(token.allowance(from, caller), type(uint256).max, "infinite allowance must be preserved");
     }
 
     /// @notice Verifies transferFrom emits Transfer(from, to, amount)
@@ -86,12 +208,34 @@ contract B20TransferFromTest is B20Test {
     function test_transferFrom_success_emitsTransfer(address caller, address from, address to, uint256 amount)
         public
     {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(from, to, amount);
+        vm.prank(caller);
+        token.transferFrom(from, to, amount);
     }
 
     /// @notice Verifies transferFrom returns true on success
     /// @dev ERC-20 return-value contract
     function test_transferFrom_success_returnsTrue(address caller, address from, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.prank(caller);
+        assertTrue(token.transferFrom(from, to, amount), "transferFrom must return true");
     }
 }

--- a/test/unit/B20/memo/burnWithMemo.t.sol
+++ b/test/unit/B20/memo/burnWithMemo.t.sol
@@ -1,24 +1,49 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20BurnWithMemoTest is B20Test {
     /// @notice Verifies burnWithMemo inherits all burn guards
-    /// @dev Reuse-of-guards invariant; concrete guard tests live in burn.t.sol
+    /// @dev Reuse-of-guards invariant; concrete guard tests live in burn.t.sol.
+    ///      We use BURN_ROLE unauthorized as the representative guard.
     function test_burnWithMemo_revert_inheritsBurnGuards(uint256 amount, bytes32 memo) public {
-        // unimplemented
+        // alice has no BURN_ROLE.
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, BURN_ROLE)
+        );
+        token.burnWithMemo(amount, memo);
     }
 
     /// @notice Verifies burnWithMemo debits caller and decreases totalSupply
     /// @dev Accounting unchanged from burn; the memo does not alter accounting
     function test_burnWithMemo_success_debitsAndDecreasesSupply(uint256 amount, bytes32 memo) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _mint(burner, amount);
+
+        uint256 supplyBefore = token.totalSupply();
+
+        vm.prank(burner);
+        token.burnWithMemo(amount, memo);
+
+        assertEq(token.balanceOf(burner), 0, "burner fully debited");
+        assertEq(token.totalSupply(), supplyBefore - amount, "supply decreased");
     }
 
     /// @notice Verifies burnWithMemo emits Transfer(caller, address(0), amount) then Memo(memo)
     /// @dev Event ordering: Memo follows Transfer; canonical Memo test for the burn path
     function test_burnWithMemo_success_emitsTransferThenMemo(uint256 amount, bytes32 memo) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _mint(burner, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(burner, address(0), amount);
+        vm.expectEmit(true, false, false, false, address(token));
+        emit IB20.Memo(memo);
+        vm.prank(burner);
+        token.burnWithMemo(amount, memo);
     }
 }

--- a/test/unit/B20/memo/mintWithMemo.t.sol
+++ b/test/unit/B20/memo/mintWithMemo.t.sol
@@ -1,24 +1,52 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20MintWithMemoTest is B20Test {
     /// @notice Verifies mintWithMemo inherits all mint guards
-    /// @dev Reuse-of-guards invariant; concrete guard tests live in mint.t.sol
+    /// @dev Reuse-of-guards invariant; concrete guard tests live in mint.t.sol.
+    ///      We use MINT_ROLE unauthorized as the representative guard.
     function test_mintWithMemo_revert_inheritsMintGuards(address to, uint256 amount, bytes32 memo) public {
-        // unimplemented
+        _assumeValidActor(to);
+        // alice has no MINT_ROLE.
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, MINT_ROLE)
+        );
+        token.mintWithMemo(to, amount, memo);
     }
 
     /// @notice Verifies mintWithMemo credits the recipient and updates totalSupply
     /// @dev Accounting unchanged from mint; the memo does not alter accounting
     function test_mintWithMemo_success_creditsAndUpdatesSupply(address to, uint256 amount, bytes32 memo) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _grantRole(MINT_ROLE, minter);
+
+        uint256 supplyBefore = token.totalSupply();
+        uint256 balBefore = token.balanceOf(to);
+
+        vm.prank(minter);
+        token.mintWithMemo(to, amount, memo);
+
+        assertEq(token.balanceOf(to), balBefore + amount, "recipient credited");
+        assertEq(token.totalSupply(), supplyBefore + amount, "supply increased");
     }
 
     /// @notice Verifies mintWithMemo emits Transfer(address(0), to, amount) then Memo(memo)
     /// @dev Event ordering: Memo follows Transfer; canonical Memo test for the mint path
     function test_mintWithMemo_success_emitsTransferThenMemo(address to, uint256 amount, bytes32 memo) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _grantRole(MINT_ROLE, minter);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(address(0), to, amount);
+        vm.expectEmit(true, false, false, false, address(token));
+        emit IB20.Memo(memo);
+        vm.prank(minter);
+        token.mintWithMemo(to, amount, memo);
     }
 }

--- a/test/unit/B20/memo/transferFromWithMemo.t.sol
+++ b/test/unit/B20/memo/transferFromWithMemo.t.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20TransferFromWithMemoTest is B20Test {
     /// @notice Verifies transferFromWithMemo inherits all transferFrom guards
-    /// @dev Reuse-of-guards invariant; concrete guard tests live in transferFrom.t.sol
+    /// @dev Reuse-of-guards invariant; concrete guard tests live in transferFrom.t.sol.
+    ///      We use InsufficientAllowance as the representative guard.
     function test_transferFromWithMemo_revert_inheritsTransferFromGuards(
         address caller,
         address from,
@@ -13,7 +16,16 @@ contract B20TransferFromWithMemoTest is B20Test {
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint256).max);
+        // No approval set.
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientAllowance.selector, caller, 0, amount));
+        token.transferFromWithMemo(from, to, amount, memo);
     }
 
     /// @notice Verifies transferFromWithMemo performs the same balance and allowance updates as transferFrom
@@ -25,7 +37,23 @@ contract B20TransferFromWithMemoTest is B20Test {
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        vm.assume(from != to);
+        amount = bound(amount, 1, type(uint128).max);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.prank(caller);
+        token.transferFromWithMemo(from, to, amount, memo);
+
+        assertEq(token.balanceOf(from), 0, "from must be debited");
+        assertEq(token.balanceOf(to), amount, "to must be credited");
+        assertEq(token.allowance(from, caller), 0, "allowance must be consumed");
     }
 
     /// @notice Verifies transferFromWithMemo emits Transfer then Memo, in that order
@@ -37,7 +65,21 @@ contract B20TransferFromWithMemoTest is B20Test {
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(from, to, amount);
+        vm.expectEmit(true, false, false, false, address(token));
+        emit IB20.Memo(memo);
+        vm.prank(caller);
+        token.transferFromWithMemo(from, to, amount, memo);
     }
 
     /// @notice Verifies transferFromWithMemo returns true on success
@@ -49,6 +91,16 @@ contract B20TransferFromWithMemoTest is B20Test {
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.approve(caller, amount);
+
+        vm.prank(caller);
+        assertTrue(token.transferFromWithMemo(from, to, amount, memo), "transferFromWithMemo must return true");
     }
 }

--- a/test/unit/B20/memo/transferWithMemo.t.sol
+++ b/test/unit/B20/memo/transferWithMemo.t.sol
@@ -1,18 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20TransferWithMemoTest is B20Test {
     /// @notice Verifies transferWithMemo applies the same pause / policy / balance checks as transfer
-    /// @dev Reuse-of-guards invariant; concrete guard tests live in transfer.t.sol
+    /// @dev Reuse-of-guards invariant; concrete guard tests live in transfer.t.sol.
+    ///      We use TRANSFER pause as the representative guard — if the same _transfer path runs,
+    ///      pause must fire identically.
     function test_transferWithMemo_revert_inheritsTransferGuards(
         address from,
         address to,
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transferWithMemo(to, amount, memo);
     }
 
     /// @notice Verifies transferWithMemo performs the same balance movement as transfer
@@ -20,7 +30,16 @@ contract B20TransferWithMemoTest is B20Test {
     function test_transferWithMemo_success_movesBalance(address from, address to, uint256 amount, bytes32 memo)
         public
     {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(from != to);
+
+        _mint(from, amount);
+        vm.prank(from);
+        token.transferWithMemo(to, amount, memo);
+
+        assertEq(token.balanceOf(from), 0, "from must be fully debited");
+        assertEq(token.balanceOf(to), amount, "to must be fully credited");
     }
 
     /// @notice Verifies transferWithMemo emits Transfer then Memo, in that order
@@ -31,7 +50,17 @@ contract B20TransferWithMemoTest is B20Test {
         uint256 amount,
         bytes32 memo
     ) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+
+        _mint(from, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(from, to, amount);
+        vm.expectEmit(true, false, false, false, address(token));
+        emit IB20.Memo(memo);
+        vm.prank(from);
+        token.transferWithMemo(to, amount, memo);
     }
 
     /// @notice Verifies transferWithMemo returns true on success
@@ -39,6 +68,11 @@ contract B20TransferWithMemoTest is B20Test {
     function test_transferWithMemo_success_returnsTrue(address from, address to, uint256 amount, bytes32 memo)
         public
     {
-        // unimplemented
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+
+        _mint(from, amount);
+        vm.prank(from);
+        assertTrue(token.transferWithMemo(to, amount, memo), "transferWithMemo must return true");
     }
 }

--- a/test/unit/B20/metadata/contractURI.t.sol
+++ b/test/unit/B20/metadata/contractURI.t.sol
@@ -5,14 +5,18 @@ import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20ContractURITest is B20Test {
     /// @notice Verifies contractURI returns the value set at token creation
-    /// @dev Constructor-stored value readback
-    function test_contractURI_success_returnsCreationURI() public {
-        // unimplemented
+    /// @dev Constructor-stored value readback. The default _b20Params() helper
+    ///      doesn't set a contractURI, so a fresh token's contractURI is the
+    ///      empty string.
+    function test_contractURI_success_returnsCreationURI() public view {
+        assertEq(token.contractURI(), "", "fresh token's contractURI must be the empty string");
     }
 
     /// @notice Verifies contractURI reflects updates made via setContractURI
     /// @dev Mutable-metadata readback; canonical setter test lives in setContractURI.t.sol
     function test_contractURI_success_reflectsSetContractURI(string calldata newURI) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setContractURI(newURI);
+        assertEq(token.contractURI(), newURI, "contractURI must reflect setContractURI");
     }
 }

--- a/test/unit/B20/metadata/setContractURI.t.sol
+++ b/test/unit/B20/metadata/setContractURI.t.sol
@@ -1,24 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetContractURITest is B20Test {
     /// @notice Verifies setContractURI reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only admin may update the URI; checks AccessControlUnauthorizedAccount
     function test_setContractURI_revert_unauthorized(address caller, string calldata newURI) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.setContractURI(newURI);
     }
 
     /// @notice Verifies setContractURI updates contractURI() to the new value
     /// @dev Read-after-write; canonical contractURI readback test lives in contractURI.t.sol
     function test_setContractURI_success_updatesURI(string calldata newURI) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setContractURI(newURI);
+        assertEq(token.contractURI(), newURI, "contractURI() must return the new value");
     }
 
     /// @notice Verifies setContractURI emits ContractURIUpdated()
     /// @dev ERC-7572 convention: the event is argument-free; integrators refetch via contractURI()
     function test_setContractURI_success_emitsContractURIUpdated(string calldata newURI) public {
-        // unimplemented
+        vm.expectEmit(false, false, false, false, address(token));
+        emit IB20.ContractURIUpdated();
+        vm.prank(admin);
+        token.setContractURI(newURI);
     }
 }

--- a/test/unit/B20/metadata/setName.t.sol
+++ b/test/unit/B20/metadata/setName.t.sol
@@ -1,24 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetNameTest is B20Test {
     /// @notice Verifies setName reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only admin may rename; checks AccessControlUnauthorizedAccount
     function test_setName_revert_unauthorized(address caller, string calldata newName) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.setName(newName);
     }
 
     /// @notice Verifies setName updates name() to the new value
     /// @dev Read-after-write; canonical name readback test lives in name.t.sol
     function test_setName_success_updatesName(string calldata newName) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setName(newName);
+        assertEq(token.name(), newName, "name() must return the new value");
     }
 
     /// @notice Verifies setName emits NameUpdated(updater, newName)
     /// @dev Event integrity; canonical NameUpdated emission test
     function test_setName_success_emitsNameUpdated(string calldata newName) public {
-        // unimplemented
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.NameUpdated(admin, newName);
+        vm.prank(admin);
+        token.setName(newName);
     }
 }

--- a/test/unit/B20/metadata/setSymbol.t.sol
+++ b/test/unit/B20/metadata/setSymbol.t.sol
@@ -1,24 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only admin may rename; checks AccessControlUnauthorizedAccount
     function test_setSymbol_revert_unauthorized(address caller, string calldata newSymbol) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.setSymbol(newSymbol);
     }
 
     /// @notice Verifies setSymbol updates symbol() to the new value
     /// @dev Read-after-write; canonical symbol readback test lives in symbol.t.sol
     function test_setSymbol_success_updatesSymbol(string calldata newSymbol) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setSymbol(newSymbol);
+        assertEq(token.symbol(), newSymbol, "symbol() must return the new value");
     }
 
     /// @notice Verifies setSymbol emits SymbolUpdated(updater, newSymbol)
     /// @dev Event integrity; canonical SymbolUpdated emission test
     function test_setSymbol_success_emitsSymbolUpdated(string calldata newSymbol) public {
-        // unimplemented
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.SymbolUpdated(admin, newSymbol);
+        vm.prank(admin);
+        token.setSymbol(newSymbol);
     }
 }

--- a/test/unit/B20/pause/isPaused.t.sol
+++ b/test/unit/B20/pause/isPaused.t.sol
@@ -1,24 +1,36 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20IsPausedTest is B20Test {
     /// @notice Verifies isPaused returns false for every feature on a freshly-created token
-    /// @dev Default state across all PausableFeature enum values
-    function test_isPaused_success_falseByDefault(uint8 featureInt) public {
-        // unimplemented
+    /// @dev Default state across all PausableFeature enum values. Bound the fuzz input to the
+    ///      4 defined ordinals (TRANSFER, MINT, BURN, REDEEM) to avoid Solidity's enum-decode
+    ///      revert on out-of-range values.
+    function test_isPaused_success_falseByDefault(uint8 featureInt) public view {
+        IB20.PausableFeature feature = IB20.PausableFeature(uint8(bound(uint256(featureInt), 0, 3)));
+        assertFalse(token.isPaused(feature), "fresh token must have no paused features");
     }
 
     /// @notice Verifies isPaused returns true after the feature is paused
     /// @dev State flip is observable per-feature
     function test_isPaused_success_trueAfterPause(uint8 featureInt) public {
-        // unimplemented
+        IB20.PausableFeature feature = IB20.PausableFeature(uint8(bound(uint256(featureInt), 0, 3)));
+        _pause(feature);
+        assertTrue(token.isPaused(feature), "feature must be paused after pause call");
     }
 
     /// @notice Verifies isPaused returns false again after the feature is unpaused
     /// @dev State flip back to inactive
     function test_isPaused_success_falseAfterUnpause(uint8 featureInt) public {
-        // unimplemented
+        IB20.PausableFeature feature = IB20.PausableFeature(uint8(bound(uint256(featureInt), 0, 3)));
+        _pause(feature);
+        _grantRole(UNPAUSE_ROLE, unpauser);
+        vm.prank(unpauser);
+        token.unpause(_singleFeature(feature));
+        assertFalse(token.isPaused(feature), "feature must be unpaused after unpause call");
     }
 }

--- a/test/unit/B20/pause/pause.t.sol
+++ b/test/unit/B20/pause/pause.t.sol
@@ -1,42 +1,91 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20PauseTest is B20Test {
     /// @notice Verifies pause reverts when caller lacks PAUSE_ROLE
     /// @dev Access control: only role-holders can pause; checks AccessControlUnauthorizedAccount
     function test_pause_revert_unauthorized(address caller) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        // No pause role granted to caller.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, PAUSE_ROLE)
+        );
+        token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
     }
 
     /// @notice Verifies pause reverts for an empty features array
     /// @dev Input validation: empty pause set is meaningless; checks EmptyFeatureSet() error
     function test_pause_revert_emptyFeatureSet() public {
-        // unimplemented
+        _grantRole(PAUSE_ROLE, pauser);
+
+        vm.prank(pauser);
+        vm.expectRevert(IB20.EmptyFeatureSet.selector);
+        token.pause(new IB20.PausableFeature[](0));
     }
 
     /// @notice Verifies pause sets each listed feature in pausedFeatures
     /// @dev State transition: each feature becomes observable via isPaused after the call
     function test_pause_success_setsFeatures() public {
-        // unimplemented
+        _grantRole(PAUSE_ROLE, pauser);
+
+        IB20.PausableFeature[] memory features = new IB20.PausableFeature[](2);
+        features[0] = IB20.PausableFeature.TRANSFER;
+        features[1] = IB20.PausableFeature.MINT;
+
+        vm.prank(pauser);
+        token.pause(features);
+
+        assertTrue(token.isPaused(IB20.PausableFeature.TRANSFER), "TRANSFER must be paused");
+        assertTrue(token.isPaused(IB20.PausableFeature.MINT), "MINT must be paused");
+        assertFalse(token.isPaused(IB20.PausableFeature.BURN), "BURN must remain unpaused");
+        assertFalse(token.isPaused(IB20.PausableFeature.REDEEM), "REDEEM must remain unpaused");
     }
 
     /// @notice Verifies pause is additive over multiple calls
     /// @dev Sequential pauses union into the existing set; prior features remain paused
     function test_pause_success_additiveAcrossCalls() public {
-        // unimplemented
+        _grantRole(PAUSE_ROLE, pauser);
+
+        vm.prank(pauser);
+        token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
+        vm.prank(pauser);
+        token.pause(_singleFeature(IB20.PausableFeature.MINT));
+
+        assertTrue(token.isPaused(IB20.PausableFeature.TRANSFER), "TRANSFER still paused");
+        assertTrue(token.isPaused(IB20.PausableFeature.MINT), "MINT paused");
     }
 
     /// @notice Verifies pause is idempotent when called with already-paused features
     /// @dev Duplicate entries do not change state and do not revert
     function test_pause_success_idempotent() public {
-        // unimplemented
+        _grantRole(PAUSE_ROLE, pauser);
+
+        vm.prank(pauser);
+        token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
+        // Second pause of the same feature: no revert.
+        vm.prank(pauser);
+        token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
+
+        assertTrue(token.isPaused(IB20.PausableFeature.TRANSFER), "still paused");
     }
 
     /// @notice Verifies pause emits Paused(caller, features) with the call's argument
     /// @dev Event integrity; canonical Paused emission test
     function test_pause_success_emitsPaused() public {
-        // unimplemented
+        _grantRole(PAUSE_ROLE, pauser);
+
+        IB20.PausableFeature[] memory features = _singleFeature(IB20.PausableFeature.TRANSFER);
+
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.Paused(pauser, features);
+        vm.prank(pauser);
+        token.pause(features);
     }
 }

--- a/test/unit/B20/pause/pausedFeatures.t.sol
+++ b/test/unit/B20/pause/pausedFeatures.t.sol
@@ -1,24 +1,46 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20PausedFeaturesTest is B20Test {
     /// @notice Verifies pausedFeatures returns an empty array on a freshly-created token
     /// @dev Default state: no features paused
-    function test_pausedFeatures_success_emptyByDefault() public {
-        // unimplemented
+    function test_pausedFeatures_success_emptyByDefault() public view {
+        IB20.PausableFeature[] memory features = token.pausedFeatures();
+        assertEq(features.length, 0, "fresh token must report no paused features");
     }
 
     /// @notice Verifies pausedFeatures returns the set of features paused via pause
-    /// @dev Readback after one or more pause calls
+    /// @dev Readback after one or more pause calls. The bitmask-to-enum-array conversion
+    ///      iterates bits in ordinal order (TRANSFER=0, MINT=1, BURN=2, REDEEM=3), so
+    ///      the returned array is sorted by enum ordinal.
     function test_pausedFeatures_success_reflectsPauseCalls() public {
-        // unimplemented
+        _pause(IB20.PausableFeature.BURN);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        IB20.PausableFeature[] memory features = token.pausedFeatures();
+        assertEq(features.length, 2, "must list exactly two features");
+        assertEq(uint256(features[0]), uint256(IB20.PausableFeature.TRANSFER), "ordinal 0 first");
+        assertEq(uint256(features[1]), uint256(IB20.PausableFeature.BURN), "ordinal 2 second");
     }
 
     /// @notice Verifies pausedFeatures returns the set minus features removed via unpause
     /// @dev Readback after partial unpause
     function test_pausedFeatures_success_reflectsUnpauseCalls() public {
-        // unimplemented
+        _pause(IB20.PausableFeature.TRANSFER);
+        _pause(IB20.PausableFeature.MINT);
+        _pause(IB20.PausableFeature.BURN);
+
+        _grantRole(UNPAUSE_ROLE, unpauser);
+        vm.prank(unpauser);
+        token.unpause(_singleFeature(IB20.PausableFeature.MINT));
+
+        IB20.PausableFeature[] memory features = token.pausedFeatures();
+        assertEq(features.length, 2, "must list two features after partial unpause");
+        assertEq(uint256(features[0]), uint256(IB20.PausableFeature.TRANSFER), "TRANSFER still paused");
+        assertEq(uint256(features[1]), uint256(IB20.PausableFeature.BURN), "BURN still paused");
     }
 }

--- a/test/unit/B20/pause/unpause.t.sol
+++ b/test/unit/B20/pause/unpause.t.sol
@@ -1,36 +1,74 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause reverts when caller lacks UNPAUSE_ROLE
     /// @dev Access control: only role-holders can unpause; checks AccessControlUnauthorizedAccount
     function test_unpause_revert_unauthorized(address caller) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, UNPAUSE_ROLE)
+        );
+        token.unpause(_singleFeature(IB20.PausableFeature.TRANSFER));
     }
 
     /// @notice Verifies unpause reverts for an empty features array
     /// @dev Input validation: empty unpause set is meaningless; checks EmptyFeatureSet() error
     function test_unpause_revert_emptyFeatureSet() public {
-        // unimplemented
+        _grantRole(UNPAUSE_ROLE, unpauser);
+
+        vm.prank(unpauser);
+        vm.expectRevert(IB20.EmptyFeatureSet.selector);
+        token.unpause(new IB20.PausableFeature[](0));
     }
 
     /// @notice Verifies unpause clears each listed feature from pausedFeatures
     /// @dev State transition: each feature is removed; non-listed features remain unchanged
     function test_unpause_success_clearsListedFeatures() public {
-        // unimplemented
+        _grantRole(UNPAUSE_ROLE, unpauser);
+
+        // Pause two features so we have something to unpause.
+        _pause(IB20.PausableFeature.TRANSFER);
+        _pause(IB20.PausableFeature.MINT);
+
+        // Unpause only TRANSFER.
+        vm.prank(unpauser);
+        token.unpause(_singleFeature(IB20.PausableFeature.TRANSFER));
+
+        assertFalse(token.isPaused(IB20.PausableFeature.TRANSFER), "TRANSFER must be unpaused");
+        assertTrue(token.isPaused(IB20.PausableFeature.MINT), "MINT must remain paused");
     }
 
     /// @notice Verifies unpause is idempotent when called with not-currently-paused features
     /// @dev No state change and no revert for features that are already inactive
     function test_unpause_success_idempotentForUnpaused() public {
-        // unimplemented
+        _grantRole(UNPAUSE_ROLE, unpauser);
+
+        // BURN is not paused.
+        vm.prank(unpauser);
+        token.unpause(_singleFeature(IB20.PausableFeature.BURN));
+
+        assertFalse(token.isPaused(IB20.PausableFeature.BURN), "BURN remains unpaused");
     }
 
     /// @notice Verifies unpause emits Unpaused(caller, features) with the call's argument
     /// @dev Event integrity; canonical Unpaused emission test
     function test_unpause_success_emitsUnpaused() public {
-        // unimplemented
+        _grantRole(UNPAUSE_ROLE, unpauser);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        IB20.PausableFeature[] memory features = _singleFeature(IB20.PausableFeature.TRANSFER);
+
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.Unpaused(unpauser, features);
+        vm.prank(unpauser);
+        token.unpause(features);
     }
 }

--- a/test/unit/B20/permit/DOMAIN_SEPARATOR.t.sol
+++ b/test/unit/B20/permit/DOMAIN_SEPARATOR.t.sol
@@ -4,15 +4,30 @@ pragma solidity ^0.8.20;
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20DomainSeparatorTest is B20Test {
+    // EIP-712 domain type hash for the (chainId, verifyingContract)-only shape.
+    bytes32 internal constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+
     /// @notice Verifies DOMAIN_SEPARATOR matches the EIP-712 hash of the eip712Domain fields
-    /// @dev Cross-check: separator must equal keccak256(abi.encode(typeHash, ...domain fields))
-    function test_DOMAIN_SEPARATOR_success_matchesDomainFields() public {
-        // unimplemented
+    /// @dev Cross-check: separator must equal keccak256(abi.encode(typeHash, chainId, verifyingContract))
+    function test_DOMAIN_SEPARATOR_success_matchesDomainFields() public view {
+        bytes32 expected = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(token)));
+        assertEq(token.DOMAIN_SEPARATOR(), expected, "separator must match computed value");
     }
 
     /// @notice Verifies DOMAIN_SEPARATOR is recomputed when block.chainid changes
     /// @dev Fork-safety: separator depends on chainId so post-fork signatures don't replay
     function test_DOMAIN_SEPARATOR_success_changesAfterChainIdFork(uint256 newChainId) public {
-        // unimplemented
+        // vm.chainId requires uint64 range.
+        newChainId = bound(newChainId, 1, type(uint64).max);
+        vm.assume(newChainId != block.chainid);
+
+        bytes32 before = token.DOMAIN_SEPARATOR();
+        vm.chainId(newChainId);
+        bytes32 afterFork = token.DOMAIN_SEPARATOR();
+
+        assertTrue(before != afterFork, "separator must change with chainId");
+        bytes32 expected = keccak256(abi.encode(DOMAIN_TYPEHASH, newChainId, address(token)));
+        assertEq(afterFork, expected, "post-fork separator must match new chainId");
     }
 }

--- a/test/unit/B20/permit/eip712Domain.t.sol
+++ b/test/unit/B20/permit/eip712Domain.t.sol
@@ -6,13 +6,31 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20Eip712DomainTest is B20Test {
     /// @notice Verifies eip712Domain returns the documented (chainId, verifyingContract)-only shape
     /// @dev Per IB20 spec: name and version are intentionally empty; salt and extensions empty
-    function test_eip712Domain_success_returnsExpectedFields() public {
-        // unimplemented
+    function test_eip712Domain_success_returnsExpectedFields() public view {
+        (
+            bytes1 fields,
+            string memory name_,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        ) = token.eip712Domain();
+
+        assertEq(fields, hex"0c", "fields bitfield (chainId + verifyingContract only)");
+        assertEq(name_, "", "name intentionally empty");
+        assertEq(version, "", "version intentionally empty");
+        assertEq(chainId, block.chainid, "chainId must equal block.chainid");
+        assertEq(verifyingContract, address(token), "verifyingContract must equal token address");
+        assertEq(salt, bytes32(0), "salt zero");
+        assertEq(extensions.length, 0, "extensions empty");
     }
 
     /// @notice Verifies eip712Domain.fields bitfield reflects which of the five domain components are populated
-    /// @dev ERC-5267 fields byte: bits 0..4 correspond to name/version/chainId/verifyingContract/salt
-    function test_eip712Domain_success_fieldsBitfieldMatchesShape() public {
-        // unimplemented
+    /// @dev ERC-5267 fields byte: bit 0 = name, 1 = version, 2 = chainId, 3 = verifyingContract, 4 = salt.
+    ///      Default tokens populate only chainId (bit 2) and verifyingContract (bit 3): 0b00001100 = 0x0c.
+    function test_eip712Domain_success_fieldsBitfieldMatchesShape() public view {
+        (bytes1 fields,,,,,,) = token.eip712Domain();
+        assertEq(fields, hex"0c", "fields must be 0x0c (chainId + verifyingContract)");
     }
 }

--- a/test/unit/B20/permit/nonces.t.sol
+++ b/test/unit/B20/permit/nonces.t.sol
@@ -6,13 +6,22 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20NoncesTest is B20Test {
     /// @notice Verifies nonces returns zero for any account that has never permitted
     /// @dev Default state across the address space
-    function test_nonces_success_zeroByDefault(address account) public {
-        // unimplemented
+    function test_nonces_success_zeroByDefault(address account) public view {
+        assertEq(token.nonces(account), 0, "untouched account must have zero nonce");
     }
 
     /// @notice Verifies nonces advances by exactly one per successful permit
     /// @dev Replay protection: monotonic counter; canonical permit test lives in permit.t.sol
     function test_nonces_success_advancesPerPermit() public {
-        // unimplemented
+        uint256 privateKey = 0xA11CE;
+        address owner = vm.addr(privateKey);
+        address spender = bob;
+        uint256 value = 1000;
+        uint256 deadline = type(uint256).max;
+
+        uint256 nonceBefore = token.nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(privateKey, spender, value, deadline);
+        token.permit(owner, spender, value, deadline, v, r, s);
+        assertEq(token.nonces(owner), nonceBefore + 1, "nonce must advance by 1");
     }
 }

--- a/test/unit/B20/permit/permit.t.sol
+++ b/test/unit/B20/permit/permit.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20PermitTest is B20Test {
@@ -9,48 +11,118 @@ contract B20PermitTest is B20Test {
     function test_permit_revert_expired(uint256 ownerPrivateKey, address spender, uint256 amount, uint256 deadline)
         public
     {
-        // unimplemented
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        deadline = bound(deadline, 0, block.timestamp - 1);
+        address owner = vm.addr(ownerPrivateKey);
+
+        // Sign a permit (with the bad deadline; sig is well-formed but expired).
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ownerPrivateKey, spender, amount, deadline);
+
+        vm.expectRevert(abi.encodeWithSelector(IB20.ExpiredSignature.selector, deadline));
+        token.permit(owner, spender, amount, deadline, v, r, s);
     }
 
     /// @notice Verifies permit reverts when (v, r, s) recovers to an address other than owner
-    /// @dev Signature integrity; checks InvalidSigner(signer, owner) error
+    /// @dev Signature integrity; checks InvalidSigner(signer, owner) error.
+    ///      We sign the digest AS bob (so ecrecover deterministically returns vm.addr(pk))
+    ///      but use pk that is NOT bob's, then submit with claimedOwner = bob.
     function test_permit_revert_invalidSigner(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        address signer = vm.addr(ownerPrivateKey);
+        vm.assume(signer != bob);
+        uint256 deadline = type(uint256).max;
+
+        // Sign the digest under bob's identity but with our (non-bob) private key.
+        (uint8 v, bytes32 r, bytes32 s) = _signPermitAs(ownerPrivateKey, bob, spender, amount, deadline);
+
+        // Recovery yields `signer`, which is not bob -> revert.
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSigner.selector, signer, bob));
+        token.permit(bob, spender, amount, deadline, v, r, s);
     }
 
     /// @notice Verifies permit reverts when the same signature is replayed
-    /// @dev Nonce monotonicity guards replay; checks InvalidSigner on second submission (recovered nonce mismatches)
+    /// @dev Nonce monotonicity guards replay: after the first call advances the nonce,
+    ///      the second call's digest is computed against the OLD nonce, so ecrecover
+    ///      returns a different address (or random garbage); we expect a generic
+    ///      InvalidSigner revert.
     function test_permit_revert_replayedSignature(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
-    }
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        address owner = vm.addr(ownerPrivateKey);
 
-    /// @notice Verifies permit reverts for the zero spender address
-    /// @dev OZ ERC-6093 invariant; checks InvalidSpender(address(0)) error
-    function test_permit_revert_zeroSpender(uint256 ownerPrivateKey, uint256 amount) public {
-        // unimplemented
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ownerPrivateKey, spender, amount, deadline);
+
+        // First call succeeds, advances nonce.
+        token.permit(owner, spender, amount, deadline, v, r, s);
+
+        // Second call: the digest verified by the contract now uses nonce+1, but the
+        // signature was over the original nonce. ecrecover returns some other address.
+        // We can't predict which, so we use a partial-selector match.
+        vm.expectPartialRevert(IB20.InvalidSigner.selector);
+        token.permit(owner, spender, amount, deadline, v, r, s);
     }
 
     /// @notice Verifies permit reverts for the zero owner address
-    /// @dev ECDSA precondition; recovering to address(0) indicates a malformed signature
+    /// @dev ECDSA precondition: a signature signed by some private key recovers to a non-zero
+    ///      address, so claiming owner = 0 mismatches the recovered signer and reverts
+    ///      InvalidSigner(recovered, 0). We sign the digest AS address(0) so ecrecover
+    ///      deterministically returns vm.addr(pk) rather than garbage.
     function test_permit_revert_zeroOwner(address spender, uint256 amount) public {
-        // unimplemented
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        uint256 privateKey = 0xA11CE;
+        address signer = vm.addr(privateKey);
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermitAs(privateKey, address(0), spender, amount, deadline);
+
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSigner.selector, signer, address(0)));
+        token.permit(address(0), spender, amount, deadline, v, r, s);
     }
 
     /// @notice Verifies permit sets allowance(owner, spender) to amount
     /// @dev Same effect as approve via signature; canonical allowance readback test lives in allowance.t.sol
     function test_permit_success_setsAllowance(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        address owner = vm.addr(ownerPrivateKey);
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ownerPrivateKey, spender, amount, deadline);
+        token.permit(owner, spender, amount, deadline, v, r, s);
+
+        assertEq(token.allowance(owner, spender), amount, "allowance must reflect permit");
     }
 
     /// @notice Verifies permit advances nonces(owner) by exactly one
     /// @dev Replay protection; canonical nonces readback test lives in nonces.t.sol
     function test_permit_success_advancesNonce(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        address owner = vm.addr(ownerPrivateKey);
+
+        uint256 before = token.nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ownerPrivateKey, spender, amount, deadline);
+        token.permit(owner, spender, amount, deadline, v, r, s);
+
+        assertEq(token.nonces(owner), before + 1, "nonce must advance by 1");
     }
 
     /// @notice Verifies permit emits Approval(owner, spender, amount)
-    /// @dev Event integrity; canonical Approval test lives in approve.t.sol — permit emits the same event
+    /// @dev Event integrity; canonical Approval test lives in approve.t.sol -- permit emits the same event
     function test_permit_success_emitsApproval(uint256 ownerPrivateKey, address spender, uint256 amount) public {
-        // unimplemented
+        ownerPrivateKey = boundPrivateKey(ownerPrivateKey);
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        address owner = vm.addr(ownerPrivateKey);
+
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ownerPrivateKey, spender, amount, deadline);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Approval(owner, spender, amount);
+        token.permit(owner, spender, amount, deadline, v, r, s);
     }
 }

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -6,19 +6,24 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns 0 (always-allow built-in) for any unconfigured slot
     /// @dev Default state: newly-created tokens are unrestricted across all policy slots
-    function test_policyId_success_zeroByDefault(bytes32 policyType) public {
-        // unimplemented
+    function test_policyId_success_zeroByDefault(bytes32 policyType) public view {
+        assertEq(token.policyId(policyType), ALWAYS_ALLOW, "unconfigured slot must default to ALWAYS_ALLOW (0)");
     }
 
     /// @notice Verifies policyId returns the value most recently set via updatePolicy
     /// @dev Read-after-write for the slot mapping
     function test_policyId_success_reflectsUpdatePolicy(bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        // MockPolicyRegistry only knows the two built-in sentinel ids.
+        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        _setPolicy(policyType, newPolicyId);
+        assertEq(token.policyId(policyType), newPolicyId, "slot must reflect updatePolicy");
     }
 
     /// @notice Verifies policyId accepts arbitrary bytes32 keys, not just the standard constants
     /// @dev User-defined policy types are supported for periphery layering
     function test_policyId_success_arbitraryKeysAllowed(bytes32 customType, uint64 newPolicyId) public {
-        // unimplemented
+        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        _setPolicy(customType, newPolicyId);
+        assertEq(token.policyId(customType), newPolicyId, "arbitrary key must be writable");
     }
 }

--- a/test/unit/B20/policy/policyTypeConstants.t.sol
+++ b/test/unit/B20/policy/policyTypeConstants.t.sol
@@ -10,25 +10,29 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20PolicyTypeConstantsTest is B20Test {
     /// @notice Verifies TRANSFER_SENDER returns keccak256("TRANSFER_SENDER")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_SENDER_success_matchesExpected() public {
-        // unimplemented
+    function test_TRANSFER_SENDER_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_SENDER(), keccak256("TRANSFER_SENDER"), "TRANSFER_SENDER digest");
+        assertEq(token.TRANSFER_SENDER(), TRANSFER_SENDER, "must match B20Test's local constant");
     }
 
     /// @notice Verifies TRANSFER_RECEIVER returns keccak256("TRANSFER_RECEIVER")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_RECEIVER_success_matchesExpected() public {
-        // unimplemented
+    function test_TRANSFER_RECEIVER_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_RECEIVER(), keccak256("TRANSFER_RECEIVER"), "TRANSFER_RECEIVER digest");
+        assertEq(token.TRANSFER_RECEIVER(), TRANSFER_RECEIVER, "must match B20Test's local constant");
     }
 
     /// @notice Verifies TRANSFER_EXECUTOR returns keccak256("TRANSFER_EXECUTOR")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_EXECUTOR_success_matchesExpected() public {
-        // unimplemented
+    function test_TRANSFER_EXECUTOR_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_EXECUTOR(), keccak256("TRANSFER_EXECUTOR"), "TRANSFER_EXECUTOR digest");
+        assertEq(token.TRANSFER_EXECUTOR(), TRANSFER_EXECUTOR, "must match B20Test's local constant");
     }
 
     /// @notice Verifies MINT_RECEIVER returns keccak256("MINT_RECEIVER")
     /// @dev Identifier stability for off-chain consumers
-    function test_MINT_RECEIVER_success_matchesExpected() public {
-        // unimplemented
+    function test_MINT_RECEIVER_success_matchesExpected() public view {
+        assertEq(token.MINT_RECEIVER(), keccak256("MINT_RECEIVER"), "MINT_RECEIVER digest");
+        assertEq(token.MINT_RECEIVER(), MINT_RECEIVER, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -1,42 +1,66 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only the admin may reassign policy slots; checks AccessControlUnauthorizedAccount
     function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.updatePolicy(policyType, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy reverts when the target policy id does not exist in the registry
-    /// @dev Cross-precompile guard; checks PolicyNotFound() error
+    /// @dev Cross-precompile guard; checks PolicyNotFound() error.
+    ///      MockPolicyRegistry only knows ids 0 and type(uint64).max; everything else is unknown.
     function test_updatePolicy_revert_policyNotFound(bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        vm.assume(newPolicyId != ALWAYS_ALLOW && newPolicyId != ALWAYS_REJECT);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));
+        token.updatePolicy(policyType, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
     /// @dev Built-ins are always valid targets
     function test_updatePolicy_success_builtinAllow(bytes32 policyType) public {
-        // unimplemented
+        _setPolicy(policyType, ALWAYS_ALLOW);
+        assertEq(token.policyId(policyType), ALWAYS_ALLOW, "slot must be ALWAYS_ALLOW");
     }
 
     /// @notice Verifies updatePolicy succeeds for built-in id type(uint64).max (always-reject)
     /// @dev Built-ins are always valid targets
     function test_updatePolicy_success_builtinReject(bytes32 policyType) public {
-        // unimplemented
+        _setPolicy(policyType, ALWAYS_REJECT);
+        assertEq(token.policyId(policyType), ALWAYS_REJECT, "slot must be ALWAYS_REJECT");
     }
 
     /// @notice Verifies updatePolicy writes the new id to the slot
     /// @dev Read-after-write: policyId(policyType) returns newPolicyId
     function test_updatePolicy_success_writesSlot(bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        // Bound to a registry-supported id.
+        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        _setPolicy(policyType, newPolicyId);
+        assertEq(token.policyId(policyType), newPolicyId, "slot must equal newPolicyId after write");
     }
 
     /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)
-    /// @dev Event integrity; canonical PolicyUpdated emission test
+    /// @dev Event integrity; canonical PolicyUpdated emission test.
+    ///      Fresh slot has oldId == ALWAYS_ALLOW (0); the first write transitions from there.
     function test_updatePolicy_success_emitsPolicyUpdated(bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.PolicyUpdated(policyType, ALWAYS_ALLOW, newPolicyId);
+        _setPolicy(policyType, newPolicyId);
     }
 }

--- a/test/unit/B20/roles/getRoleAdmin.t.sol
+++ b/test/unit/B20/roles/getRoleAdmin.t.sol
@@ -5,14 +5,19 @@ import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20GetRoleAdminTest is B20Test {
     /// @notice Verifies getRoleAdmin returns DEFAULT_ADMIN_ROLE for any role that hasn't been customized
-    /// @dev OZ AccessControl default: every role is administered by DEFAULT_ADMIN_ROLE unless overridden
-    function test_getRoleAdmin_success_defaultsToAdminRole(bytes32 role) public {
-        // unimplemented
+    /// @dev OZ AccessControl default: every role is administered by DEFAULT_ADMIN_ROLE unless overridden.
+    ///      DEFAULT_ADMIN_ROLE itself is its own admin (returns bytes32(0)), so filter that out here;
+    ///      that special case is covered implicitly by the setRoleAdmin-emits test.
+    function test_getRoleAdmin_success_defaultsToAdminRole(bytes32 role) public view {
+        vm.assume(role != DEFAULT_ADMIN_ROLE);
+        assertEq(token.getRoleAdmin(role), DEFAULT_ADMIN_ROLE, "default admin must be DEFAULT_ADMIN_ROLE");
     }
 
     /// @notice Verifies getRoleAdmin returns the new admin role after setRoleAdmin
     /// @dev Read-after-write for role-admin reassignment
     function test_getRoleAdmin_success_reflectsSetRoleAdmin(bytes32 role, bytes32 newAdminRole) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setRoleAdmin(role, newAdminRole);
+        assertEq(token.getRoleAdmin(role), newAdminRole, "getRoleAdmin must reflect setRoleAdmin");
     }
 }

--- a/test/unit/B20/roles/grantRole.t.sol
+++ b/test/unit/B20/roles/grantRole.t.sol
@@ -1,30 +1,56 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20GrantRoleTest is B20Test {
     /// @notice Verifies grantRole reverts when caller does not hold the role's admin role
-    /// @dev Access control: caller must hold getRoleAdmin(role); checks AccessControlUnauthorizedAccount
+    /// @dev Access control: caller must hold getRoleAdmin(role); checks AccessControlUnauthorizedAccount.
+    ///      All roles default to DEFAULT_ADMIN_ROLE as their admin, so a non-admin caller hits
+    ///      AccessControlUnauthorizedAccount(caller, DEFAULT_ADMIN_ROLE).
     function test_grantRole_revert_unauthorized(address caller, bytes32 role, address account) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.grantRole(role, account);
     }
 
     /// @notice Verifies grantRole sets hasRole(role, account) to true
     /// @dev Read-after-write; canonical hasRole readback test lives in hasRole.t.sol
     function test_grantRole_success_setsRole(bytes32 role, address account) public {
-        // unimplemented
+        _grantRole(role, account);
+        assertTrue(token.hasRole(role, account), "must hold role after grant");
     }
 
     /// @notice Verifies grantRole is idempotent when the account already holds the role
-    /// @dev No-op for already-granted accounts; no revert, no duplicate event
+    /// @dev No-op for already-granted accounts; no revert, no duplicate event.
+    ///      We use vm.recordLogs to assert that the second grant emits NO RoleGranted event.
     function test_grantRole_success_idempotent(bytes32 role, address account) public {
-        // unimplemented
+        _grantRole(role, account);
+        assertTrue(token.hasRole(role, account), "precondition: role held after first grant");
+
+        vm.recordLogs();
+        _grantRole(role, account);
+        assertTrue(token.hasRole(role, account), "role still held after second grant");
+
+        // The recorded logs should be empty: idempotent path skips the RoleGranted emit.
+        assertEq(vm.getRecordedLogs().length, 0, "idempotent grant must not emit RoleGranted");
     }
 
     /// @notice Verifies grantRole emits RoleGranted(role, account, sender) on first grant
     /// @dev Event integrity; canonical RoleGranted emission test
     function test_grantRole_success_emitsRoleGranted(bytes32 role, address account) public {
-        // unimplemented
+        // Filter the bootstrap admin grant (already held, idempotent → no emit).
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+
+        vm.expectEmit(true, true, true, false, address(token));
+        emit IB20.RoleGranted(role, account, admin);
+        _grantRole(role, account);
     }
 }

--- a/test/unit/B20/roles/hasRole.t.sol
+++ b/test/unit/B20/roles/hasRole.t.sol
@@ -5,20 +5,29 @@ import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20HasRoleTest is B20Test {
     /// @notice Verifies hasRole returns false for any (role, account) pair that has never been granted
-    /// @dev Default state across the role and address space
-    function test_hasRole_success_falseByDefault(bytes32 role, address account) public {
-        // unimplemented
+    /// @dev Default state across the role and address space. Filters out the bootstrap admin grant
+    ///      (DEFAULT_ADMIN_ROLE, admin) since that pair IS held after creation.
+    function test_hasRole_success_falseByDefault(bytes32 role, address account) public view {
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        assertFalse(token.hasRole(role, account), "untouched (role, account) pair must be unheld");
     }
 
     /// @notice Verifies hasRole returns true after grantRole succeeds
     /// @dev Read-after-write for the role mapping
     function test_hasRole_success_trueAfterGrant(bytes32 role, address account) public {
-        // unimplemented
+        _grantRole(role, account);
+        assertTrue(token.hasRole(role, account), "must be held after grant");
     }
 
     /// @notice Verifies hasRole returns false after revokeRole succeeds
-    /// @dev Read-after-write for revocation
+    /// @dev Read-after-write for revocation. Skips revoking DEFAULT_ADMIN_ROLE from the sole
+    ///      admin (which would underflow adminCount semantics via revoke; the user must use
+    ///      renounceLastAdmin for that transition, covered elsewhere).
     function test_hasRole_success_falseAfterRevoke(bytes32 role, address account) public {
-        // unimplemented
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        _grantRole(role, account);
+        vm.prank(admin);
+        token.revokeRole(role, account);
+        assertFalse(token.hasRole(role, account), "must be unheld after revoke");
     }
 }

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20RenounceLastAdminTest is B20Test {
@@ -9,7 +11,14 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         so authorization fails before the "are you the only one?" check.
     ///         Checks AccessControlUnauthorizedAccount(caller, DEFAULT_ADMIN_ROLE).
     function test_renounceLastAdmin_revert_callerNotAdmin(address caller) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.renounceLastAdmin();
     }
 
     /// @notice Verifies renounceLastAdmin reverts when caller is an admin but additional admins exist
@@ -18,13 +27,25 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         use renounceRole (which only allows non-last admins to renounce themselves).
     ///         Checks NotSoleAdmin() error.
     function test_renounceLastAdmin_revert_multipleAdmins(address otherAdmin) public {
-        // unimplemented
+        _assumeValidActor(otherAdmin);
+        vm.assume(otherAdmin != admin);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, otherAdmin);
+
+        vm.prank(admin);
+        vm.expectRevert(IB20.NotSoleAdmin.selector);
+        token.renounceLastAdmin();
     }
 
     /// @notice Verifies renounceLastAdmin clears DEFAULT_ADMIN_ROLE from the caller
     /// @dev    Read-after-write: hasRole(DEFAULT_ADMIN_ROLE, msg.sender) is false post-call.
     function test_renounceLastAdmin_success_clearsAdminRole() public {
-        // unimplemented
+        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "precondition: admin holds DEFAULT_ADMIN_ROLE");
+
+        vm.prank(admin);
+        token.renounceLastAdmin();
+
+        assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "admin no longer holds DEFAULT_ADMIN_ROLE");
     }
 
     /// @notice Verifies admin-gated operations revert after renounceLastAdmin
@@ -34,7 +55,19 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         setName, setSymbol, grantRole / revokeRole / setRoleAdmin for any role.
     ///         No test should be able to reinstate an admin after this transition.
     function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyType, uint64 newPolicyId) public {
-        // unimplemented
+        // Use a built-in policy ID so updatePolicy gets past policyExists() and would
+        // otherwise succeed; the revert here is from the role check, not policy validation.
+        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+
+        vm.prank(admin);
+        token.renounceLastAdmin();
+
+        // The original admin is no longer admin and cannot reach the admin-only setter.
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, admin, DEFAULT_ADMIN_ROLE)
+        );
+        token.updatePolicy(policyType, newPolicyId);
     }
 
     /// @notice Verifies grantRole(DEFAULT_ADMIN_ROLE, ...) cannot succeed post-renunciation
@@ -42,7 +75,16 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         the caller to hold the admin role for the target role; with zero admins,
     ///         every grant call (from any caller, for any account) reverts.
     function test_renounceLastAdmin_success_noPathToReinstateAdmin(address wouldBeNewAdmin, address caller) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+
+        vm.prank(admin);
+        token.renounceLastAdmin();
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.grantRole(DEFAULT_ADMIN_ROLE, wouldBeNewAdmin);
     }
 
     /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)
@@ -51,6 +93,9 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         canonical emission test lives in revokeRole.t.sol; this stub asserts
     ///         only the dedicated event.
     function test_renounceLastAdmin_success_emitsLastAdminRenounced() public {
-        // unimplemented
+        vm.expectEmit(true, false, false, false, address(token));
+        emit IB20.LastAdminRenounced(admin);
+        vm.prank(admin);
+        token.renounceLastAdmin();
     }
 }

--- a/test/unit/B20/roles/renounceRole.t.sol
+++ b/test/unit/B20/roles/renounceRole.t.sol
@@ -1,38 +1,77 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20RenounceRoleTest is B20Test {
     /// @notice Verifies renounceRole reverts when callerConfirmation does not equal msg.sender
     /// @dev Fat-finger guard: caller must explicitly confirm; OZ-style invariant
-    function test_renounceRole_revert_callerConfirmationMismatch(address caller, bytes32 role, address wrongConfirmation)
-        public
-    {
-        // unimplemented
+    function test_renounceRole_revert_callerConfirmationMismatch(
+        address caller,
+        bytes32 role,
+        address wrongConfirmation
+    ) public {
+        _assumeValidCaller(caller);
+        vm.assume(wrongConfirmation != caller);
+
+        vm.prank(caller);
+        vm.expectRevert(IB20.AccessControlBadConfirmation.selector);
+        token.renounceRole(role, wrongConfirmation);
     }
 
     /// @notice Verifies renounceRole reverts when the caller is the last DEFAULT_ADMIN_ROLE holder
     /// @dev Tokens MUST always have at least one admin; checks LastAdminCannotRenounce() error
     function test_renounceRole_revert_lastAdminCannotRenounce() public {
-        // unimplemented
+        // Bootstrap admin is the only admin (adminCount == 1).
+        vm.prank(admin);
+        vm.expectRevert(IB20.LastAdminCannotRenounce.selector);
+        token.renounceRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
     /// @notice Verifies renounceRole sets hasRole(role, caller) to false
     /// @dev Read-after-write for self-revocation
     function test_renounceRole_success_clearsCallerRole(address caller, bytes32 role) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        // Skip DEFAULT_ADMIN_ROLE here: that path has its own last-admin guard tested above
+        // and an "admin with others" success test below.
+        vm.assume(role != DEFAULT_ADMIN_ROLE);
+
+        _grantRole(role, caller);
+        assertTrue(token.hasRole(role, caller), "precondition");
+
+        vm.prank(caller);
+        token.renounceRole(role, caller);
+        assertFalse(token.hasRole(role, caller), "role must be cleared after self-renounce");
     }
 
     /// @notice Verifies renounceRole succeeds for DEFAULT_ADMIN_ROLE when at least one other admin exists
     /// @dev LastAdminCannotRenounce only fires when the renouncer would leave the role empty
     function test_renounceRole_success_adminWithOthers(address otherAdmin) public {
-        // unimplemented
+        _assumeValidActor(otherAdmin);
+        vm.assume(otherAdmin != admin);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, otherAdmin);
+
+        vm.prank(admin);
+        token.renounceRole(DEFAULT_ADMIN_ROLE, admin);
+
+        assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "original admin no longer admin");
+        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, otherAdmin), "other admin still admin");
     }
 
     /// @notice Verifies renounceRole emits RoleRevoked(role, caller, caller)
     /// @dev Sender equals account for self-revocation; canonical RoleRevoked test lives in revokeRole.t.sol
     function test_renounceRole_success_emitsRoleRevoked(address caller, bytes32 role) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(role != DEFAULT_ADMIN_ROLE);
+
+        _grantRole(role, caller);
+
+        vm.expectEmit(true, true, true, false, address(token));
+        emit IB20.RoleRevoked(role, caller, caller);
+        vm.prank(caller);
+        token.renounceRole(role, caller);
     }
 }

--- a/test/unit/B20/roles/revokeRole.t.sol
+++ b/test/unit/B20/roles/revokeRole.t.sol
@@ -1,30 +1,60 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20RevokeRoleTest is B20Test {
     /// @notice Verifies revokeRole reverts when caller does not hold the role's admin role
     /// @dev Access control: caller must hold getRoleAdmin(role); checks AccessControlUnauthorizedAccount
     function test_revokeRole_revert_unauthorized(address caller, bytes32 role, address account) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.revokeRole(role, account);
     }
 
     /// @notice Verifies revokeRole sets hasRole(role, account) to false
-    /// @dev Read-after-write; canonical hasRole readback test lives in hasRole.t.sol
+    /// @dev Read-after-write; canonical hasRole readback test lives in hasRole.t.sol.
+    ///      Skips revoking DEFAULT_ADMIN_ROLE from the sole bootstrap admin
+    ///      (would require renounceLastAdmin instead, covered in that file).
     function test_revokeRole_success_clearsRole(bytes32 role, address account) public {
-        // unimplemented
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        _grantRole(role, account);
+
+        vm.prank(admin);
+        token.revokeRole(role, account);
+        assertFalse(token.hasRole(role, account), "role must be cleared after revoke");
     }
 
     /// @notice Verifies revokeRole is idempotent when the account does not hold the role
-    /// @dev No-op for not-held accounts; no revert, no duplicate event
+    /// @dev No-op for not-held accounts; no revert, no duplicate event.
     function test_revokeRole_success_idempotent(bytes32 role, address account) public {
-        // unimplemented
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        assertFalse(token.hasRole(role, account), "precondition: role not held");
+
+        vm.recordLogs();
+        vm.prank(admin);
+        token.revokeRole(role, account);
+        assertFalse(token.hasRole(role, account), "role still not held");
+
+        assertEq(vm.getRecordedLogs().length, 0, "idempotent revoke must not emit RoleRevoked");
     }
 
     /// @notice Verifies revokeRole emits RoleRevoked(role, account, sender) when an actual revoke occurs
     /// @dev Event integrity; canonical RoleRevoked emission test
     function test_revokeRole_success_emitsRoleRevoked(bytes32 role, address account) public {
-        // unimplemented
+        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        _grantRole(role, account);
+
+        vm.expectEmit(true, true, true, false, address(token));
+        emit IB20.RoleRevoked(role, account, admin);
+        vm.prank(admin);
+        token.revokeRole(role, account);
     }
 }

--- a/test/unit/B20/roles/roleConstants.t.sol
+++ b/test/unit/B20/roles/roleConstants.t.sol
@@ -10,37 +10,44 @@ import {B20Test} from "test/lib/B20Test.sol";
 contract B20RoleConstantsTest is B20Test {
     /// @notice Verifies DEFAULT_ADMIN_ROLE returns the OZ AccessControl default value (bytes32(0))
     /// @dev Matches OZ's `DEFAULT_ADMIN_ROLE = 0x00` convention
-    function test_DEFAULT_ADMIN_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_DEFAULT_ADMIN_ROLE_success_matchesExpected() public view {
+        assertEq(token.DEFAULT_ADMIN_ROLE(), bytes32(0), "DEFAULT_ADMIN_ROLE must be bytes32(0)");
+        // And matches the local constant used across these tests.
+        assertEq(token.DEFAULT_ADMIN_ROLE(), DEFAULT_ADMIN_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies MINT_ROLE returns keccak256("MINT_ROLE")
     /// @dev Identifier stability for off-chain consumers
-    function test_MINT_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_MINT_ROLE_success_matchesExpected() public view {
+        assertEq(token.MINT_ROLE(), keccak256("MINT_ROLE"), "MINT_ROLE digest");
+        assertEq(token.MINT_ROLE(), MINT_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies BURN_ROLE returns keccak256("BURN_ROLE")
     /// @dev Identifier stability for off-chain consumers
-    function test_BURN_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_BURN_ROLE_success_matchesExpected() public view {
+        assertEq(token.BURN_ROLE(), keccak256("BURN_ROLE"), "BURN_ROLE digest");
+        assertEq(token.BURN_ROLE(), BURN_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies BURN_BLOCKED_ROLE returns keccak256("BURN_BLOCKED_ROLE")
     /// @dev Identifier stability for off-chain consumers
-    function test_BURN_BLOCKED_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_BURN_BLOCKED_ROLE_success_matchesExpected() public view {
+        assertEq(token.BURN_BLOCKED_ROLE(), keccak256("BURN_BLOCKED_ROLE"), "BURN_BLOCKED_ROLE digest");
+        assertEq(token.BURN_BLOCKED_ROLE(), BURN_BLOCKED_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies PAUSE_ROLE returns keccak256("PAUSE_ROLE")
     /// @dev Identifier stability for off-chain consumers
-    function test_PAUSE_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_PAUSE_ROLE_success_matchesExpected() public view {
+        assertEq(token.PAUSE_ROLE(), keccak256("PAUSE_ROLE"), "PAUSE_ROLE digest");
+        assertEq(token.PAUSE_ROLE(), PAUSE_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies UNPAUSE_ROLE returns keccak256("UNPAUSE_ROLE")
     /// @dev Identifier stability for off-chain consumers
-    function test_UNPAUSE_ROLE_success_matchesExpected() public {
-        // unimplemented
+    function test_UNPAUSE_ROLE_success_matchesExpected() public view {
+        assertEq(token.UNPAUSE_ROLE(), keccak256("UNPAUSE_ROLE"), "UNPAUSE_ROLE digest");
+        assertEq(token.UNPAUSE_ROLE(), UNPAUSE_ROLE, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/roles/setRoleAdmin.t.sol
+++ b/test/unit/B20/roles/setRoleAdmin.t.sol
@@ -1,24 +1,43 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetRoleAdminTest is B20Test {
     /// @notice Verifies setRoleAdmin reverts when caller does not hold the role's current admin role
-    /// @dev Access control: caller must hold the current getRoleAdmin(role); checks AccessControlUnauthorizedAccount
+    /// @dev Access control: caller must hold the current getRoleAdmin(role); checks AccessControlUnauthorizedAccount.
+    ///      For a freshly-created token, every role's admin defaults to DEFAULT_ADMIN_ROLE.
     function test_setRoleAdmin_revert_unauthorized(address caller, bytes32 role, bytes32 newAdminRole) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.setRoleAdmin(role, newAdminRole);
     }
 
     /// @notice Verifies setRoleAdmin updates getRoleAdmin(role) to the new admin role
     /// @dev Read-after-write; canonical getRoleAdmin readback test lives in getRoleAdmin.t.sol
     function test_setRoleAdmin_success_updatesAdmin(bytes32 role, bytes32 newAdminRole) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setRoleAdmin(role, newAdminRole);
+        assertEq(token.getRoleAdmin(role), newAdminRole, "getRoleAdmin must reflect setRoleAdmin");
     }
 
     /// @notice Verifies setRoleAdmin emits RoleAdminChanged(role, previousAdminRole, newAdminRole)
-    /// @dev Event integrity; canonical RoleAdminChanged emission test
+    /// @dev Event integrity; canonical RoleAdminChanged emission test.
+    ///      For an unconfigured non-default role, previousAdminRole is the implied
+    ///      DEFAULT_ADMIN_ROLE; for DEFAULT_ADMIN_ROLE itself, previous is bytes32(0).
     function test_setRoleAdmin_success_emitsRoleAdminChanged(bytes32 role, bytes32 newAdminRole) public {
-        // unimplemented
+        bytes32 previousAdminRole = role == DEFAULT_ADMIN_ROLE ? bytes32(0) : DEFAULT_ADMIN_ROLE;
+
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.RoleAdminChanged(role, previousAdminRole, newAdminRole);
+        vm.prank(admin);
+        token.setRoleAdmin(role, newAdminRole);
     }
 }

--- a/test/unit/B20/supply/burn.t.sol
+++ b/test/unit/B20/supply/burn.t.sol
@@ -1,42 +1,79 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20BurnTest is B20Test {
     /// @notice Verifies burn reverts when caller lacks BURN_ROLE
     /// @dev Access control: only role-holders can burn; checks AccessControlUnauthorizedAccount
     function test_burn_revert_unauthorized(address caller, uint256 amount) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, BURN_ROLE)
+        );
+        token.burn(amount);
     }
 
     /// @notice Verifies burn reverts when BURN feature is paused
     /// @dev Pause guard; checks ContractPaused(BURN) error
     function test_burn_revert_whenBurnPaused(uint256 amount) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(burner);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        token.burn(amount);
     }
 
     /// @notice Verifies burn reverts when caller balance is insufficient
     /// @dev Balance precondition; checks InsufficientBalance(caller, balance, amount)
     function test_burn_revert_insufficientBalance(uint256 amount) public {
-        // unimplemented
+        amount = bound(amount, 1, type(uint256).max);
+        _grantRole(BURN_ROLE, burner);
+        // burner has zero balance; any positive amount exceeds it.
+
+        vm.prank(burner);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientBalance.selector, burner, 0, amount));
+        token.burn(amount);
     }
 
     /// @notice Verifies burn debits the caller's balance by amount
     /// @dev Accounting: balanceOf(caller) decreases by exactly amount
     function test_burn_success_debitsCaller(uint256 amount) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _mint(burner, amount);
+
+        vm.prank(burner);
+        token.burn(amount);
+        assertEq(token.balanceOf(burner), 0, "burner balance must be zero after full burn");
     }
 
     /// @notice Verifies burn decreases totalSupply by amount
     /// @dev Accounting: totalSupply tracks cumulative minted-burned
     function test_burn_success_decreasesTotalSupply(uint256 amount) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _mint(burner, amount);
+        uint256 before = token.totalSupply();
+
+        vm.prank(burner);
+        token.burn(amount);
+        assertEq(token.totalSupply(), before - amount, "totalSupply must decrease by burned amount");
     }
 
     /// @notice Verifies burn emits Transfer(caller, address(0), amount)
     /// @dev Event integrity for the burn path; burn represented as transfer to the zero address
     function test_burn_success_emitsTransferToZero(uint256 amount) public {
-        // unimplemented
+        _grantRole(BURN_ROLE, burner);
+        _mint(burner, amount);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(burner, address(0), amount);
+        vm.prank(burner);
+        token.burn(amount);
     }
 }

--- a/test/unit/B20/supply/burnBlocked.t.sol
+++ b/test/unit/B20/supply/burnBlocked.t.sol
@@ -1,48 +1,108 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20BurnBlockedTest is B20Test {
     /// @notice Verifies burnBlocked reverts when caller lacks BURN_BLOCKED_ROLE
     /// @dev Access control: only role-holders can seize balance; checks AccessControlUnauthorizedAccount
     function test_burnBlocked_revert_unauthorized(address caller, address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, BURN_BLOCKED_ROLE)
+        );
+        token.burnBlocked(from, amount);
     }
 
     /// @notice Verifies burnBlocked reverts when BURN feature is paused
     /// @dev Pause guard; checks ContractPaused(BURN) error
     function test_burnBlocked_revert_whenBurnPaused(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        // We also need TRANSFER_SENDER set to ALWAYS_REJECT so the from-not-authorized
+        // path is satisfied; otherwise the policy check inside burnBlocked fires
+        // with AccountNotBlocked first.
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        token.burnBlocked(from, amount);
     }
 
     /// @notice Verifies burnBlocked reverts when the target is authorized under TRANSFER_SENDER
     /// @dev Seizure is only permitted against policy-blocked addresses; checks AccountNotBlocked(from)
     function test_burnBlocked_revert_accountNotBlocked(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        // Default TRANSFER_SENDER is ALWAYS_ALLOW (0), so every address is "authorized" → not blocked.
+
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccountNotBlocked.selector, from));
+        token.burnBlocked(from, amount);
     }
 
     /// @notice Verifies burnBlocked reverts when target balance is insufficient
     /// @dev Balance precondition; checks InsufficientBalance(from, balance, amount)
     function test_burnBlocked_revert_insufficientBalance(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        amount = bound(amount, 1, type(uint256).max);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT); // from is policy-blocked
+
+        // from has zero balance.
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientBalance.selector, from, 0, amount));
+        token.burnBlocked(from, amount);
     }
 
     /// @notice Verifies burnBlocked debits the target balance by amount
     /// @dev Accounting: balanceOf(from) decreases by exactly amount
     function test_burnBlocked_success_debitsTarget(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        // Mint while no policy is set so the mint isn't blocked.
+        _mint(from, amount);
+        // Now block from via TRANSFER_SENDER policy, then seize.
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+
+        vm.prank(burnBlocker);
+        token.burnBlocked(from, amount);
+        assertEq(token.balanceOf(from), 0, "target balance must be zero after seizure");
     }
 
     /// @notice Verifies burnBlocked decreases totalSupply by amount
     /// @dev Accounting: totalSupply tracks cumulative minted-burned
     function test_burnBlocked_success_decreasesTotalSupply(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _mint(from, amount);
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        uint256 before = token.totalSupply();
+
+        vm.prank(burnBlocker);
+        token.burnBlocked(from, amount);
+        assertEq(token.totalSupply(), before - amount, "totalSupply must decrease by seized amount");
     }
 
     /// @notice Verifies burnBlocked emits Transfer(from, address(0), amount) and BurnedBlocked(caller, from, amount)
     /// @dev Dual-event integrity: Transfer for accounting, BurnedBlocked for seizure audit trail
     function test_burnBlocked_success_emitsTransferAndBurnedBlocked(address from, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(from);
+        _mint(from, amount);
+        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(from, address(0), amount);
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.BurnedBlocked(burnBlocker, from, amount);
+        vm.prank(burnBlocker);
+        token.burnBlocked(from, amount);
     }
 }

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -1,54 +1,105 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20MintTest is B20Test {
     /// @notice Verifies mint reverts when caller lacks MINT_ROLE
     /// @dev Access control: only role-holders can mint; checks AccessControlUnauthorizedAccount
     function test_mint_revert_unauthorized(address caller, address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        // No MINT_ROLE granted to caller.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, MINT_ROLE)
+        );
+        token.mint(to, amount);
     }
 
     /// @notice Verifies mint reverts when MINT feature is paused
     /// @dev Pause guard; checks ContractPaused(MINT) error
     function test_mint_revert_whenMintPaused(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _grantRole(MINT_ROLE, minter);
+        _pause(IB20.PausableFeature.MINT);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.MINT));
+        token.mint(to, amount);
     }
 
     /// @notice Verifies mint reverts when totalSupply + amount > supplyCap
-    /// @dev Supply-cap precondition; checks SupplyCapExceeded(cap, attempted) error
+    /// @dev Supply-cap precondition; checks SupplyCapExceeded(cap, attempted) error.
+    ///      We set cap low and request more than it allows.
     function test_mint_revert_supplyCapExceeded(address to, uint256 cap, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        cap = bound(cap, 0, type(uint128).max);
+        amount = bound(amount, cap + 1, type(uint256).max - cap);
+
+        vm.prank(admin);
+        token.setSupplyCap(cap);
+
+        _grantRole(MINT_ROLE, minter);
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.SupplyCapExceeded.selector, cap, amount));
+        token.mint(to, amount);
     }
 
     /// @notice Verifies mint reverts when recipient fails the MINT_RECEIVER policy
     /// @dev Policy guard for issuance; checks PolicyForbids(MINT_RECEIVER, policyId)
     function test_mint_revert_receiverPolicyForbids(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _grantRole(MINT_ROLE, minter);
+        _setPolicy(MINT_RECEIVER, ALWAYS_REJECT);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, MINT_RECEIVER, ALWAYS_REJECT));
+        token.mint(to, amount);
     }
 
     /// @notice Verifies mint reverts for the zero recipient address
     /// @dev OZ ERC-6093 invariant; checks InvalidReceiver(address(0)) error
     function test_mint_revert_zeroRecipient(uint256 amount) public {
-        // unimplemented
+        _grantRole(MINT_ROLE, minter);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.mint(address(0), amount);
     }
 
     /// @notice Verifies mint credits the recipient balance by amount
     /// @dev Accounting: balanceOf(to) increases by exactly amount
     function test_mint_success_creditsRecipient(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        uint256 before = token.balanceOf(to);
+
+        _mint(to, amount);
+        assertEq(token.balanceOf(to), before + amount, "balance must increase by minted amount");
     }
 
     /// @notice Verifies mint increases totalSupply by amount
     /// @dev Accounting: totalSupply tracks cumulative minted-burned
     function test_mint_success_increasesTotalSupply(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        uint256 before = token.totalSupply();
+
+        _mint(to, amount);
+        assertEq(token.totalSupply(), before + amount, "totalSupply must increase by minted amount");
     }
 
     /// @notice Verifies mint emits Transfer(address(0), to, amount)
     /// @dev Event integrity for the mint path; mint represented as transfer from the zero address
     function test_mint_success_emitsTransferFromZero(address to, uint256 amount) public {
-        // unimplemented
+        _assumeValidActor(to);
+        _grantRole(MINT_ROLE, minter);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit IB20.Transfer(address(0), to, amount);
+        vm.prank(minter);
+        token.mint(to, amount);
     }
 }

--- a/test/unit/B20/supply/setSupplyCap.t.sol
+++ b/test/unit/B20/supply/setSupplyCap.t.sol
@@ -1,36 +1,68 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetSupplyCapTest is B20Test {
     /// @notice Verifies setSupplyCap reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only admin may resize the cap; checks AccessControlUnauthorizedAccount
     function test_setSupplyCap_revert_unauthorized(address caller, uint256 newCap) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+        );
+        token.setSupplyCap(newCap);
     }
 
     /// @notice Verifies setSupplyCap reverts when newCap is below the current totalSupply
     /// @dev Invariant: never invalidate already-issued supply; checks InvalidSupplyCap(currentSupply, proposedCap)
     function test_setSupplyCap_revert_belowCurrentSupply(uint256 mintedAmount, uint256 newCap) public {
-        // unimplemented
+        mintedAmount = bound(mintedAmount, 2, type(uint128).max);
+        newCap = bound(newCap, 0, mintedAmount - 1);
+
+        _mint(alice, mintedAmount);
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSupplyCap.selector, mintedAmount, newCap));
+        token.setSupplyCap(newCap);
     }
 
     /// @notice Verifies setSupplyCap raises the cap to a value above the current totalSupply
-    /// @dev Read-after-write: supplyCap returns newCap
+    /// @dev Read-after-write: supplyCap returns newCap. Fresh token has totalSupply == 0,
+    ///      so any cap is valid.
     function test_setSupplyCap_success_raisesCap(uint256 newCap) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setSupplyCap(newCap);
+        assertEq(token.supplyCap(), newCap, "supplyCap must equal newCap");
     }
 
     /// @notice Verifies setSupplyCap lowers the cap to a value at or above the current totalSupply
     /// @dev Cap may be lowered as long as totalSupply <= newCap
     function test_setSupplyCap_success_lowersCap(uint256 newCap) public {
-        // unimplemented
+        // Mint some supply, then bound newCap >= mintedAmount.
+        uint256 mintedAmount = 1000;
+        newCap = bound(newCap, mintedAmount, type(uint256).max);
+
+        _mint(alice, mintedAmount);
+
+        vm.prank(admin);
+        token.setSupplyCap(newCap);
+        assertEq(token.supplyCap(), newCap, "supplyCap must equal newCap");
     }
 
     /// @notice Verifies setSupplyCap emits SupplyCapUpdated(updater, oldCap, newCap)
     /// @dev Event integrity; canonical SupplyCapUpdated emission test
     function test_setSupplyCap_success_emitsSupplyCapUpdated(uint256 newCap) public {
-        // unimplemented
+        uint256 oldCap = token.supplyCap();
+
+        vm.expectEmit(true, false, false, true, address(token));
+        emit IB20.SupplyCapUpdated(admin, oldCap, newCap);
+        vm.prank(admin);
+        token.setSupplyCap(newCap);
     }
 }

--- a/test/unit/B20/supply/supplyCap.t.sol
+++ b/test/unit/B20/supply/supplyCap.t.sol
@@ -5,14 +5,17 @@ import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SupplyCapTest is B20Test {
     /// @notice Verifies supplyCap returns the value set at token creation
-    /// @dev Constructor-stored value readback
-    function test_supplyCap_success_returnsCreationCap() public {
-        // unimplemented
+    /// @dev Constructor-stored value readback. The factory writes type(uint256).max
+    ///      at bootstrap, so a fresh default token starts uncapped.
+    function test_supplyCap_success_returnsCreationCap() public view {
+        assertEq(token.supplyCap(), type(uint256).max, "fresh token must start with unbounded cap");
     }
 
     /// @notice Verifies supplyCap reflects updates made via setSupplyCap
     /// @dev Mutable cap readback; canonical setter test lives in setSupplyCap.t.sol
     function test_supplyCap_success_reflectsSetSupplyCap(uint256 newCap) public {
-        // unimplemented
+        vm.prank(admin);
+        token.setSupplyCap(newCap);
+        assertEq(token.supplyCap(), newCap, "supplyCap must reflect setSupplyCap");
     }
 }

--- a/test/unit/B20Stablecoin/currency.t.sol
+++ b/test/unit/B20Stablecoin/currency.t.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+
 import {B20StablecoinTest} from "test/lib/B20StablecoinTest.sol";
 
 contract B20StablecoinCurrencyTest is B20StablecoinTest {
     /// @notice Verifies currency returns the string passed to the factory at creation
     /// @dev Immutable readback; should equal `currencyAtCreation` set in setUp
-    function test_currency_success_returnsCreationCurrency() public {
-        // unimplemented
+    function test_currency_success_returnsCreationCurrency() public view {
+        assertEq(
+            IB20Stablecoin(address(token)).currency(),
+            currencyAtCreation,
+            "currency() must match the value passed at creation"
+        );
     }
 }

--- a/test/unit/PolicyRegistry/nextPolicyId.t.sol
+++ b/test/unit/PolicyRegistry/nextPolicyId.t.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.20;
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
-
 contract PolicyRegistryNextPolicyIdTest is PolicyRegistryTest {
     /// @notice Verifies nextPolicyId(ALLOWLIST) returns the first ALLOWLIST-encoded id
     ///         the next createPolicy(_, ALLOWLIST) would assign
@@ -29,8 +27,11 @@ contract PolicyRegistryNextPolicyIdTest is PolicyRegistryTest {
     ///         successful createPolicy(_, type) call
     /// @dev Per-type monotonic counter; check returned id equals the prior
     ///      nextPolicyId(type) value and that the top-byte discriminator stays
-    ///      stable across the sequence
-    function test_nextPolicyId_success_advancesPerCreate(IPolicyRegistry.PolicyType policyType, uint8 count) public {
+    ///      stable across the sequence. policyTypeRaw is bounded inside the
+    ///      body to `< 2` (the count of PolicyType enum values) via vm.assume
+    ///      before being cast — direct enum-typed parameters cause the fuzzer
+    ///      to revert at function entry on out-of-range uint8 inputs.
+    function test_nextPolicyId_success_advancesPerCreate(uint8 policyTypeRaw, uint8 count) public {
         // unimplemented
     }
 

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -1,108 +1,287 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Vm} from "forge-std/Vm.sol";
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+
+import {MockB20} from "test/lib/mocks/MockB20.sol";
 import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
 
 contract TokenFactoryCreateTokenTest is TokenFactoryTest {
+    // Role identifiers, matching MockB20's keccak256 derivations. Inlined here
+    // because Solidity contract constants are runtime getters, so MockB20(addr).MINT_ROLE()
+    // requires `addr` to have code -- and during createToken setup, the token doesn't exist yet.
+    bytes32 internal constant MINT_ROLE = keccak256("MINT_ROLE");
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
+
+    /*//////////////////////////////////////////////////////////////
+                                REVERTS
+    //////////////////////////////////////////////////////////////*/
+
     /// @notice Verifies createToken reverts for the NONE variant
     /// @dev Variant guard fires before any param decoding; checks InvalidVariant() error
     function test_createToken_revert_invalidVariant(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.prank(caller);
+        vm.expectRevert(ITokenFactory.InvalidVariant.selector);
+        factory.createToken(ITokenFactory.TokenVariant.NONE, salt, abi.encode(_b20Params()), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts for any unsupported params version byte
     /// @dev Fuzz confirms only the known version (1) decodes; checks UnsupportedVersion(version) error
     function test_createToken_revert_unsupportedVersion(address caller, uint8 badVersion, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(badVersion != 1);
+        ITokenFactory.B20CreateParams memory p = _b20Params();
+        p.version = badVersion;
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
+        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts for default-variant decimals outside [2, 18]
     /// @dev Fuzz confirms the per-variant decimals range is enforced; checks InvalidDecimals(decimals) error
     function test_createToken_revert_invalidDecimals(address caller, uint8 decimals, bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies createToken reverts when initialAdmin is the zero address
-    /// @dev Required-field guard for the default variant; checks ZeroAddress() error
-    function test_createToken_revert_zeroAdmin_default(address caller, bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies createToken reverts when initialAdmin is the zero address for stablecoin variant
-    /// @dev Required-field guard for the stablecoin variant; checks ZeroAddress() error
-    function test_createToken_revert_zeroAdmin_stablecoin(address caller, bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies createToken reverts when initialAdmin is the zero address for security variant
-    /// @dev Required-field guard for the security variant; checks ZeroAddress() error
-    function test_createToken_revert_zeroAdmin_security(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(decimals < 2 || decimals > 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InvalidDecimals.selector, decimals));
+        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies stablecoin createToken reverts when currency is the empty string
     /// @dev Per-variant required-field check; checks MissingRequiredField() error
     function test_createToken_revert_missingCurrency(address caller, bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies security createToken reverts when isin is the empty string
-    /// @dev Per-variant required-field check; checks MissingRequiredField() error
-    function test_createToken_revert_missingIsin(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams("USD Test", "USDT", admin, "");
+        vm.prank(caller);
+        vm.expectRevert(ITokenFactory.MissingRequiredField.selector);
+        factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts when (variant, decimals, sender, salt) collides
     /// @dev Deterministic-address uniqueness; checks TokenAlreadyExists(token) error
     function test_createToken_revert_tokenAlreadyExists(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        address first = _createDefault(caller, salt, _b20Params(), new bytes[](0));
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.TokenAlreadyExists.selector, first));
+        factory.createToken(
+            ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), new bytes[](0)
+        );
     }
 
     /// @notice Verifies createToken reverts when any entry in initCalls reverts
     /// @dev Init-call atomicity: a single failing init call reverts the entire creation
     function test_createToken_revert_initCallFailed(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        // mint to address(0) reverts InvalidReceiver inside the token,
+        // which bubbles up as InitCallFailed(0) at the factory.
+        bytes[] memory initCalls = new bytes[](1);
+        initCalls[0] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InitCallFailed.selector, uint256(0)));
+        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
     }
+
+    /// @notice Verifies a failing initCall leaves the deterministic address empty
+    /// @dev Atomicity at the storage level: a revert in initCalls means no bytecode was
+    ///      committed at the predicted address, so a subsequent createToken with the same
+    ///      (variant, decimals, sender, salt) succeeds.
+    function test_createToken_revert_initCallFailed_revertsWholeCreation(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        ITokenFactory.B20CreateParams memory p = _b20Params();
+        address predicted =
+            factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, p.decimals, caller, salt);
+
+        bytes[] memory initCalls = new bytes[](1);
+        initCalls[0] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InitCallFailed.selector, uint256(0)));
+        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), initCalls);
+
+        // After the failed creation, the predicted address has no code,
+        // and a fresh creation with the same args succeeds.
+        assertEq(predicted.code.length, 0, "predicted address should be empty after revert");
+        address retried = _createDefault(caller, salt, p, new bytes[](0));
+        assertEq(retried, predicted, "retry returns same deterministic address");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               SUCCESSES
+    //////////////////////////////////////////////////////////////*/
 
     /// @notice Verifies createToken returns the predicted address for the default variant
     /// @dev Address determinism: returned address must equal getTokenAddress(DEFAULT, decimals, sender, salt)
     function test_createToken_success_defaultMatchesPrediction(address caller, bytes32 salt, uint8 decimals) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        decimals = uint8(bound(decimals, 2, 18));
+        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, caller, salt);
+        address actual = _createDefault(caller, salt, p, new bytes[](0));
+        assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken returns the predicted address for the stablecoin variant
     /// @dev Address determinism: returned address must equal getTokenAddress(STABLECOIN, 6, sender, salt)
     function test_createToken_success_stablecoinMatchesPrediction(address caller, bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies createToken returns the predicted address for the security variant
-    /// @dev Address determinism: returned address must equal getTokenAddress(SECURITY, 6, sender, salt)
-    function test_createToken_success_securityMatchesPrediction(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, 6, caller, salt);
+        address actual = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
+        assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken emits TokenCreated with the correct identity fields
     /// @dev Event integrity: token, variant, name, symbol, decimals must match the inputs
     function test_createToken_success_emitsTokenCreated(address caller, bytes32 salt, uint8 decimals) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        decimals = uint8(bound(decimals, 2, 18));
+        ITokenFactory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin, decimals);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, caller, salt);
+
+        vm.expectEmit(true, true, false, true, address(factory));
+        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", decimals, admin);
+        _createDefault(caller, salt, p, new bytes[](0));
     }
 
-    /// @notice Verifies createToken executes each entry in initCalls against the new token in admin context
-    /// @dev Init-call dispatch: each calldata entry must be invoked with the factory acting as admin
+    /// @notice Verifies createToken executes each entry in initCalls during the bootstrap window
+    /// @dev The bootstrap-window auth bypass is bound to the call site (msg.sender == factory && !initialized),
+    ///      not to RBAC. The factory is never granted any role on the token. We verify the bypass by passing
+    ///      an initCall (grantRole) that would normally require DEFAULT_ADMIN_ROLE on the caller, and asserting
+    ///      it took effect even though the factory has no role.
     function test_createToken_success_executesInitCalls(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        bytes[] memory initCalls = new bytes[](1);
+        // Grant MINT_ROLE to bob during the bootstrap window. This would normally
+        // require msg.sender to hold DEFAULT_ADMIN_ROLE, but the factory holds no
+        // role; the bypass lets the call through.
+        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, MINT_ROLE, bob);
+
+        address token = _createDefault(caller, salt, _b20Params(), initCalls);
+        assertTrue(MockB20(token).hasRole(MINT_ROLE, bob), "init call must have granted role");
+        // Factory itself was never granted anything.
+        assertFalse(
+            MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(factory)),
+            "factory must not hold admin role"
+        );
+    }
+
+    /// @notice Verifies TokenCreated fires before any state-change events from initCalls
+    /// @dev Log ordering invariant per ITokenFactory natspec: "Emits TokenCreated once the token's identity
+    ///      is sealed and BEFORE any initCalls are dispatched, so init-call effects appear strictly after
+    ///      the creation event in the log order." Sanity check using vm.recordLogs.
+    function test_createToken_success_emitsTokenCreatedBeforeInitCallEvents(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        // Use an init call that emits a single, distinctive event we can find: grantRole emits RoleGranted.
+        bytes[] memory initCalls = new bytes[](1);
+        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, MINT_ROLE, bob);
+
+        vm.recordLogs();
+        _createDefault(caller, salt, _b20Params(), initCalls);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // Find indices of TokenCreated and RoleGranted. Since the storage-direct-write
+        // factory emits no RoleGranted at bootstrap, the only RoleGranted in the log
+        // is the one from the init call.
+        bytes32 tokenCreatedSig = ITokenFactory.TokenCreated.selector;
+        bytes32 roleGrantedSig = IB20.RoleGranted.selector;
+        int256 tokenCreatedAt = -1;
+        int256 roleGrantedAt = -1;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length == 0) continue;
+            if (logs[i].topics[0] == tokenCreatedSig && tokenCreatedAt < 0) tokenCreatedAt = int256(i);
+            if (logs[i].topics[0] == roleGrantedSig && roleGrantedAt < 0) roleGrantedAt = int256(i);
+        }
+        assertGt(tokenCreatedAt, -1, "TokenCreated must be present in the log");
+        assertGt(roleGrantedAt, -1, "RoleGranted must be present in the log (from initCall)");
+        assertLt(tokenCreatedAt, roleGrantedAt, "TokenCreated must precede initCall-emitted events");
+    }
+
+    /// @notice Verifies the factory has no persistent privilege after createToken returns
+    /// @dev The bootstrap-window bypass closes when closeBootstrap flips initialized = true. A direct
+    ///      call from the factory address after creation must hit the standard auth path and revert.
+    function test_createToken_success_factoryHasNoPersistentPrivilege(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        address token = _createDefault(caller, salt, _b20Params(), new bytes[](0));
+
+        // Pranking the factory address into a direct mint should now revert with the standard
+        // role check, because the bootstrap window is closed.
+        vm.prank(address(factory));
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, address(factory), MINT_ROLE)
+        );
+        IB20(token).mint(bob, 1);
+    }
+
+    /// @notice Verifies createToken executes with admin == address(0) and grants no admin role
+    /// @dev "Demonstrate no owner" path: factory accepts zero admin, token has no admin afterward
+    ///      (no role grants, policy changes, or pauses ever possible). Replaces the prior
+    ///      _revert_zeroAdmin_default stub now that the design explicitly allows this.
+    function test_createToken_success_zeroAdminGrantsNoRole_default(address caller, bytes32 salt, uint8 decimals)
+        public
+    {
+        _assumeValidCaller(caller);
+        decimals = uint8(bound(decimals, 2, 18));
+        ITokenFactory.B20CreateParams memory p = _b20Params("NoOwner", "NOWN", address(0), decimals);
+        address token = _createDefault(caller, salt, p, new bytes[](0));
+
+        // No admin was granted. Any admin-gated call from any account reverts.
+        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
+        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
+        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, admin), "admin actor must not hold admin");
+    }
+
+    /// @notice Verifies stablecoin createToken executes with admin == address(0)
+    /// @dev Same zero-admin success behavior on the stablecoin variant.
+    function test_createToken_success_zeroAdminGrantsNoRole_stablecoin(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams("NoOwner USD", "NOUSD", address(0), "USD");
+        address token = _createStablecoin(caller, salt, p, new bytes[](0));
+
+        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
+        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
+        // The stablecoin still got its variant data: currency is set.
+        assertEq(IB20Stablecoin(token).currency(), "USD", "stablecoin currency must still be set");
     }
 
     /// @notice Verifies the variant byte at address position [10] matches the created variant
     /// @dev Address schema: getTokenVariant(token) recovers the variant statelessly
     function test_createToken_success_encodesVariantByte(address caller, bytes32 salt) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+
+        address defaultToken = _createDefault(caller, salt, _b20Params(), new bytes[](0));
+        assertEq(
+            uint256(factory.getTokenVariant(defaultToken)),
+            uint256(ITokenFactory.TokenVariant.DEFAULT),
+            "default variant byte mismatch"
+        );
+
+        address stablecoinToken = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
+        assertEq(
+            uint256(factory.getTokenVariant(stablecoinToken)),
+            uint256(ITokenFactory.TokenVariant.STABLECOIN),
+            "stablecoin variant byte mismatch"
+        );
     }
 
     /// @notice Verifies the decimals byte at address position [11] matches the created decimals
     /// @dev Address schema: decimals are encoded in the address for stateless decimals() lookup
     function test_createToken_success_encodesDecimalsByte(address caller, bytes32 salt, uint8 decimals) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        decimals = uint8(bound(decimals, 2, 18));
+        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
+        address token = _createDefault(caller, salt, p, new bytes[](0));
+
+        // Byte [11] of the address.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 byteAt11 = uint8(uint160(token) >> 64);
+        assertEq(byteAt11, decimals, "address byte [11] must equal decimals");
+        // And decimals() (which reads the byte) returns the same.
+        assertEq(MockB20(token).decimals(), decimals, "decimals() must return encoded value");
     }
 }

--- a/test/unit/TokenFactory/getTokenAddress.t.sol
+++ b/test/unit/TokenFactory/getTokenAddress.t.sol
@@ -1,21 +1,43 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+
 import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
 
 contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
+    /// @notice Wraps an arbitrary uint8 into a valid TokenVariant ordinal.
+    /// @dev Bounds to [0, 3] (NONE, DEFAULT, STABLECOIN, SECURITY). The address derivation
+    ///      is happy with the raw byte but Solidity reverts at function entry on an
+    ///      out-of-range enum input from a fuzzer.
+    function _boundVariant(uint8 variantInt) internal pure returns (ITokenFactory.TokenVariant) {
+        return ITokenFactory.TokenVariant(uint8(bound(uint256(variantInt), 0, 3)));
+    }
+
     /// @notice Verifies getTokenAddress is deterministic for the same inputs
     /// @dev Pure view: repeated calls with identical args must return identical addresses
     function test_getTokenAddress_success_deterministic(uint8 variantInt, uint8 decimals, address sender, bytes32 salt)
         public
+        view
     {
-        // unimplemented
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+        address b = factory.getTokenAddress(variant, decimals, sender, salt);
+        assertEq(a, b, "address derivation must be deterministic");
     }
 
     /// @notice Verifies different variants produce different addresses for the same (decimals, sender, salt)
     /// @dev Variant byte at position [10] is part of the address derivation
-    function test_getTokenAddress_success_differentVariantDiffers(uint8 decimals, address sender, bytes32 salt) public {
-        // unimplemented
+    function test_getTokenAddress_success_differentVariantDiffers(uint8 decimals, address sender, bytes32 salt)
+        public
+        view
+    {
+        address asDefault = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, sender, salt);
+        address asStablecoin = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, decimals, sender, salt);
+        address asSecurity = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, decimals, sender, salt);
+        assertTrue(asDefault != asStablecoin, "DEFAULT vs STABLECOIN must differ");
+        assertTrue(asDefault != asSecurity, "DEFAULT vs SECURITY must differ");
+        assertTrue(asStablecoin != asSecurity, "STABLECOIN vs SECURITY must differ");
     }
 
     /// @notice Verifies different decimals produce different addresses for the same (variant, sender, salt)
@@ -26,8 +48,12 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         bytes32 salt,
         uint8 d1,
         uint8 d2
-    ) public {
-        // unimplemented
+    ) public view {
+        vm.assume(d1 != d2);
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, d1, sender, salt);
+        address b = factory.getTokenAddress(variant, d2, sender, salt);
+        assertTrue(a != b, "different decimals must yield different addresses");
     }
 
     /// @notice Verifies different senders produce different addresses for the same (variant, decimals, salt)
@@ -38,8 +64,12 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         address s1,
         address s2,
         bytes32 salt
-    ) public {
-        // unimplemented
+    ) public view {
+        vm.assume(s1 != s2);
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, s1, salt);
+        address b = factory.getTokenAddress(variant, decimals, s2, salt);
+        assertTrue(a != b, "different senders must yield different addresses");
     }
 
     /// @notice Verifies different salts produce different addresses for the same (variant, decimals, sender)
@@ -50,16 +80,28 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         address sender,
         bytes32 s1,
         bytes32 s2
-    ) public {
-        // unimplemented
+    ) public view {
+        vm.assume(s1 != s2);
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, sender, s1);
+        address b = factory.getTokenAddress(variant, decimals, sender, s2);
+        assertTrue(a != b, "different salts must yield different addresses");
     }
 
     /// @notice Verifies the first 10 bytes of the returned address match the B-20 prefix
-    /// @dev Address schema: bytes [0:10] are the shared 0xB20...000 prefix
+    /// @dev Address schema: bytes [0:10] are the shared 0xB200...000 prefix
+    ///      (byte [0] = 0xB2, bytes [1:9] = 0x00)
     function test_getTokenAddress_success_prefixIsB20(uint8 variantInt, uint8 decimals, address sender, bytes32 salt)
         public
+        view
     {
-        // unimplemented
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+
+        // Drop the bottom 10 bytes; what remains should be 0xB2 followed by 9 zero bytes.
+        uint160 topTenBytes = uint160(a) >> 80;
+        uint160 expected = uint160(0xB2) << 72;
+        assertEq(topTenBytes, expected, "top 10 bytes must be 0xB2 followed by 9 zero bytes");
     }
 
     /// @notice Verifies byte [10] of the returned address equals the variant ordinal
@@ -69,8 +111,14 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         uint8 decimals,
         address sender,
         bytes32 salt
-    ) public {
-        // unimplemented
+    ) public view {
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+
+        // Byte [10] = bits [72..79]. Mask after shift.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 byteAt10 = uint8(uint160(a) >> 72);
+        assertEq(byteAt10, uint8(variant), "address byte [10] must equal variant ordinal");
     }
 
     /// @notice Verifies byte [11] of the returned address equals the decimals value
@@ -80,7 +128,13 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         uint8 decimals,
         address sender,
         bytes32 salt
-    ) public {
-        // unimplemented
+    ) public view {
+        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
+        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+
+        // Byte [11] = bits [64..71]. Mask after shift.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint8 byteAt11 = uint8(uint160(a) >> 64);
+        assertEq(byteAt11, decimals, "address byte [11] must equal decimals");
     }
 }

--- a/test/unit/TokenFactory/getTokenVariant.t.sol
+++ b/test/unit/TokenFactory/getTokenVariant.t.sol
@@ -1,30 +1,59 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+
 import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
 
 contract TokenFactoryGetTokenVariantTest is TokenFactoryTest {
     /// @notice Verifies getTokenVariant returns DEFAULT for a default-variant token
     /// @dev Variant byte at position [10] decodes back to the creation variant
     function test_getTokenVariant_success_defaultRecovered(bytes32 salt) public {
-        // unimplemented
+        address token = _createDefault(alice, salt, _b20Params(), new bytes[](0));
+        assertEq(
+            uint256(factory.getTokenVariant(token)),
+            uint256(ITokenFactory.TokenVariant.DEFAULT),
+            "must recover DEFAULT"
+        );
     }
 
     /// @notice Verifies getTokenVariant returns STABLECOIN for a stablecoin-variant token
     /// @dev Variant byte at position [10] decodes back to the creation variant
     function test_getTokenVariant_success_stablecoinRecovered(bytes32 salt) public {
-        // unimplemented
-    }
-
-    /// @notice Verifies getTokenVariant returns SECURITY for a security-variant token
-    /// @dev Variant byte at position [10] decodes back to the creation variant
-    function test_getTokenVariant_success_securityRecovered(bytes32 salt) public {
-        // unimplemented
+        address token = _createStablecoin(alice, salt, _stablecoinParams(), new bytes[](0));
+        assertEq(
+            uint256(factory.getTokenVariant(token)),
+            uint256(ITokenFactory.TokenVariant.STABLECOIN),
+            "must recover STABLECOIN"
+        );
     }
 
     /// @notice Verifies getTokenVariant returns NONE for any address lacking the B-20 prefix
     /// @dev Non-factory addresses are not categorized as any variant
-    function test_getTokenVariant_success_noneForNonB20(address addr) public {
-        // unimplemented
+    function test_getTokenVariant_success_noneForNonB20(address addr) public view {
+        // Filter out anything that happens to match the B-20 prefix.
+        vm.assume((uint160(addr) >> 80) != (uint160(0xB2) << 72));
+        assertEq(
+            uint256(factory.getTokenVariant(addr)),
+            uint256(ITokenFactory.TokenVariant.NONE),
+            "non-B20 address must return NONE"
+        );
+    }
+
+    /// @notice Verifies getTokenVariant returns NONE for B-20-prefixed addresses with an invalid variant byte
+    /// @dev Bytes >= 4 in position [10] are not valid TokenVariant ordinals; impl returns NONE rather than
+    ///      reverting on out-of-range enum cast.
+    function test_getTokenVariant_success_noneForInvalidVariantByte(uint8 invalidByte, uint8 decimals, bytes8 tail)
+        public
+        view
+    {
+        invalidByte = uint8(bound(uint256(invalidByte), 4, 255));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(invalidByte) << 72) | (uint160(decimals) << 64)
+            | uint160(uint64(tail));
+        assertEq(
+            uint256(factory.getTokenVariant(address(addr))),
+            uint256(ITokenFactory.TokenVariant.NONE),
+            "invalid variant byte must return NONE"
+        );
     }
 }

--- a/test/unit/TokenFactory/isB20.t.sol
+++ b/test/unit/TokenFactory/isB20.t.sol
@@ -7,24 +7,35 @@ contract TokenFactoryIsB20Test is TokenFactoryTest {
     /// @notice Verifies isB20 returns true for a freshly-created token
     /// @dev Recognition via address-prefix match; no storage read
     function test_isB20_success_trueForCreatedToken(bytes32 salt) public {
-        // unimplemented
+        address token = _createDefault(alice, salt, _b20Params(), new bytes[](0));
+        assertTrue(factory.isB20(token), "freshly created token must be recognized");
     }
 
     /// @notice Verifies isB20 returns false for any address lacking the B-20 prefix
     /// @dev Fuzz across arbitrary addresses; only the B-20 prefix should pass
-    function test_isB20_success_falseForNonB20Address(address addr) public {
-        // unimplemented
+    function test_isB20_success_falseForNonB20Address(address addr) public view {
+        // Filter out anything that happens to match the B-20 prefix (the factory address
+        // itself, and any other 0xB200...000 prefix in the fuzz domain).
+        vm.assume((uint160(addr) >> 80) != (uint160(0xB2) << 72));
+        assertFalse(factory.isB20(addr), "non-B20 address must not be recognized");
     }
 
     /// @notice Verifies isB20 returns false for the zero address
     /// @dev Edge case: zero address has no prefix bytes
-    function test_isB20_success_falseForZeroAddress() public {
-        // unimplemented
+    function test_isB20_success_falseForZeroAddress() public view {
+        assertFalse(factory.isB20(address(0)), "zero address must not be recognized");
     }
 
     /// @notice Verifies isB20 returns true for any address bearing the B-20 prefix
-    /// @dev Recognition is purely prefix-based; the trailing bytes are unconstrained
-    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, uint8 decimalsByte, bytes8 tail) public {
-        // unimplemented
+    /// @dev Recognition is purely prefix-based; the trailing bytes are unconstrained.
+    ///      This is intentional: isB20 is a pure prefix check, so synthetic addresses
+    ///      that share the prefix but were never created by the factory also pass.
+    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, uint8 decimalsByte, bytes8 tail)
+        public
+        view
+    {
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(variantByte) << 72) | (uint160(decimalsByte) << 64)
+            | uint160(uint64(tail));
+        assertTrue(factory.isB20(address(addr)), "B-20-prefixed address must be recognized");
     }
 }


### PR DESCRIPTION
## Summary

Reference implementations for the `IB20` default-token surface, the
`IB20Stablecoin` variant, and the full `ITokenFactory.createToken`
flow. Lives under `test/lib/mocks/` and is etched via `vm.etch` per
Conner's mock-vs-src proposal. Written as Solidity-as-if-Rust:
spec-correspondence over Solidity idiom.

Out of scope:
- `IB20Security` (interface still in flux).
- `MockPolicyRegistry` / `MockActivationRegistry` (skeletons only for
  now; deferred to follow-ups).
