### PR TITLE
feat(interfaces): Add Activation Registry Deactivate

### DIFF
--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -4,14 +4,13 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IActivationRegistry
 /// @notice Singleton precompile that gates Base-native features behind
 ///         an activation admin. Each feature is identified by an opaque
-///         `bytes32` feature id and is either activated or not;
+///         `bytes32` feature id and is either active or inactive;
 ///         consumers (other precompiles, system configuration, or
 ///         downstream contracts) consult `isActivated` to gate behavior.
 ///
 ///         The activation admin is the only address authorized to call
-///         `activate`; all other callers revert with `Unauthorized`.
-///         Activation is one-way: once a feature is activated it cannot
-///         be deactivated.
+///         `activate` or `deactivate`; all other callers revert with
+///         `Unauthorized`.
 ///
 /// @dev    The precompile enforces two call-context invariants that are
 ///         surfaced as reverts but cannot originate from normal Solidity
@@ -20,8 +19,8 @@ pragma solidity >=0.8.20 <0.9.0;
 ///           via `CALL` (not `DELEGATECALL` or `CALLCODE`), so the admin
 ///           identity is bound to `msg.sender` rather than the calling
 ///           contract's storage context.
-///         - `StaticCallNotAllowed`: `activate` mutates state and cannot
-///           be invoked from a `STATICCALL` frame.
+///         - `StaticCallNotAllowed`: activation control mutates state and
+///           cannot be invoked from a `STATICCALL` frame.
 ///
 ///         Feature ids are opaque to the registry: it does not interpret
 ///         them, and any `bytes32` is a valid id. By convention the
@@ -34,25 +33,26 @@ interface IActivationRegistry {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice `caller` is not the activation admin and is therefore
-    ///         not authorized to call `activate`.
+    ///         not authorized to call `activate` or `deactivate`.
     error Unauthorized(address caller);
 
     /// @notice `activate` was called on a feature that is already
     ///         activated.
     error AlreadyActivated(bytes32 feature);
 
-    /// @notice `feature` is not activated. Returned by precompiles that
-    ///         consult the registry as a hard gate (the chain node
-    ///         uses an `assertActivated`-style flow for this); not
-    ///         raised by `isActivated`, which returns `false` instead.
+    /// @notice `feature` is not activated. Returned by `deactivate` and
+    ///         by precompiles that consult the registry as a hard gate
+    ///         (the chain node uses an `assertActivated`-style flow for
+    ///         this); not raised by `isActivated`, which returns `false`
+    ///         instead.
     error FeatureNotActivated(bytes32 feature);
 
     /// @notice The precompile was invoked via `DELEGATECALL` or
     ///         `CALLCODE`. All entry points require a direct `CALL`.
     error DelegateCallNotAllowed();
 
-    /// @notice A state-mutating entry point (`activate`) was invoked
-    ///         from a `STATICCALL` frame.
+    /// @notice A state-mutating entry point (`activate` or `deactivate`)
+    ///         was invoked from a `STATICCALL` frame.
     error StaticCallNotAllowed();
 
     /*//////////////////////////////////////////////////////////////
@@ -63,16 +63,20 @@ interface IActivationRegistry {
     ///         activated. `caller` is the activation admin.
     event FeatureActivated(bytes32 indexed feature, address indexed caller);
 
+    /// @notice Emitted when `feature` transitions from activated to
+    ///         inactive. `caller` is the activation admin.
+    event FeatureDeactivated(bytes32 indexed feature, address indexed caller);
+
     /*//////////////////////////////////////////////////////////////
                             ACTIVATION QUERIES
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Whether `feature` is currently activated. Returns
-    ///         `false` for any feature id that has never been
-    ///         activated (the default state).
+    ///         `false` for any feature id that has never been activated
+    ///         or has since been deactivated.
     function isActivated(bytes32 feature) external view returns (bool);
 
-    /// @notice The address authorized to call `activate`.
+    /// @notice The address authorized to call `activate` and `deactivate`.
     function admin() external view returns (address);
 
     /*//////////////////////////////////////////////////////////////
@@ -83,7 +87,13 @@ interface IActivationRegistry {
     ///         `Unauthorized`). Reverts with `AlreadyActivated` if the
     ///         feature is already activated; reverts with
     ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
-    ///         Emits `FeatureActivated` on success. Activation is
-    ///         one-way: there is no `deactivate` counterpart.
+    ///         Emits `FeatureActivated` on success.
     function activate(bytes32 feature) external;
+
+    /// @notice Deactivates `feature`. Caller MUST equal `admin()` (else
+    ///         `Unauthorized`). Reverts with `FeatureNotActivated` if
+    ///         the feature is not currently activated; reverts with
+    ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
+    ///         Emits `FeatureDeactivated` on success.
+    function deactivate(bytes32 feature) external;
 }

--- a/test/lib/mocks/MockActivationRegistry.sol
+++ b/test/lib/mocks/MockActivationRegistry.sol
@@ -24,4 +24,8 @@ contract MockActivationRegistry is IActivationRegistry {
     function activate(bytes32) external pure {
         revert("MockActivationRegistry: not implemented");
     }
+
+    function deactivate(bytes32) external pure {
+        revert("MockActivationRegistry: not implemented");
+    }
 }

--- a/test/unit/ActivationRegistry/activate.t.sol
+++ b/test/unit/ActivationRegistry/activate.t.sol
@@ -11,7 +11,7 @@ contract ActivationRegistryActivateTest is ActivationRegistryTest {
     }
 
     /// @notice Verifies activate reverts when invoked on a feature that is already activated
-    /// @dev Activation is one-way and not idempotent; checks AlreadyActivated(feature) error
+    /// @dev Activation is not idempotent; checks AlreadyActivated(feature) error
     function test_activate_revert_alreadyActivated(bytes32 feature) public {
         // unimplemented
     }

--- a/test/unit/ActivationRegistry/deactivate.t.sol
+++ b/test/unit/ActivationRegistry/deactivate.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+
+contract ActivationRegistryDeactivateTest is ActivationRegistryTest {
+    /// @notice Verifies deactivate reverts when called by any non-admin caller
+    /// @dev Access control: only the activation admin may deactivate; checks Unauthorized(caller) error
+    function test_deactivate_revert_unauthorized(address caller, bytes32 feature) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies deactivate reverts when invoked on a feature that is not activated
+    /// @dev Deactivation is not idempotent; checks FeatureNotActivated(feature) error
+    function test_deactivate_revert_featureNotActivated(bytes32 feature) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies deactivate flips isActivated(feature) from true to false
+    /// @dev Successful deactivation persists for future isActivated queries
+    function test_deactivate_success_setsInactive(bytes32 feature) public {
+        // unimplemented
+    }
+
+    /// @notice Verifies deactivate emits FeatureDeactivated(feature, caller)
+    /// @dev Event integrity: indexed feature and caller match the call
+    function test_deactivate_success_emitsFeatureDeactivated(bytes32 feature) public {
+        // unimplemented
+    }
+}


### PR DESCRIPTION
## Summary

This adds deactivate(bytes32 feature) to IActivationRegistry so the interface models features as active or inactive rather than one-way activation. The interface now includes a FeatureDeactivated event and documents the inactive-state error behavior. The test mock and ActivationRegistry placeholder test surface were updated so downstream implementations have a matching compile target.