### PR TITLE
Coverage fixes + rebase onto post-#24/#27/#28 main

### DIFF
--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -31,6 +31,7 @@ contract B20Test is TokenFactoryTest {
     bytes32 internal constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
     bytes32 internal constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
     bytes32 internal constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+    bytes32 internal constant METADATA_ROLE = keccak256("METADATA_ROLE");
 
     // -- Policy-type identifiers --
     bytes32 internal constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
@@ -38,9 +39,9 @@ contract B20Test is TokenFactoryTest {
     bytes32 internal constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
     bytes32 internal constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
 
-    // -- Built-in policy sentinel IDs (MockPolicyRegistry-supported) --
+    // -- Built-in policy sentinel IDs (per IPolicyRegistry: ALWAYS_ALLOW=0, ALWAYS_BLOCK=1) --
     uint64 internal constant ALWAYS_ALLOW = 0;
-    uint64 internal constant ALWAYS_REJECT = type(uint64).max;
+    uint64 internal constant ALWAYS_REJECT = 1;
 
     // -- Token-specific role-holder actors --
     address internal minter = makeAddr("minter");

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -71,6 +71,7 @@ contract MockB20 is IB20 {
     bytes32 public constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
     bytes32 public constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
     bytes32 public constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+    bytes32 public constant METADATA_ROLE = keccak256("METADATA_ROLE");
 
     /// @notice Policy-type identifiers. Same `keccak256` convention.
     bytes32 public constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
@@ -160,13 +161,13 @@ contract MockB20 is IB20 {
     // ============================================================
 
     function setName(string calldata newName) external {
-        _requireAdmin();
+        _requireRole(METADATA_ROLE);
         MockB20Storage.layout().name = newName;
         emit NameUpdated(msg.sender, newName);
     }
 
     function setSymbol(string calldata newSymbol) external {
-        _requireAdmin();
+        _requireRole(METADATA_ROLE);
         MockB20Storage.layout().symbol = newSymbol;
         emit SymbolUpdated(msg.sender, newSymbol);
     }
@@ -452,6 +453,13 @@ contract MockB20 is IB20 {
         if (_isPrivileged()) return;
         if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);
+        }
+    }
+
+    function _requireRole(bytes32 role) internal view {
+        if (_isPrivileged()) return;
+        if (!hasRole(role, msg.sender)) {
+            revert AccessControlUnauthorizedAccount(msg.sender, role);
         }
     }
 

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -7,25 +7,31 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 ///
 /// Implements only the built-in sentinel semantics that B20 tests rely
 /// on to exercise policy gating without configuring custom policies:
-///   - `isAuthorized(0, _)`             → true  (always-allow)
-///   - `isAuthorized(type(uint64).max, _)` → false (always-reject)
+///   - `isAuthorized(0, _)` → true  (ALWAYS_ALLOW, built-in ID 0)
+///   - `isAuthorized(1, _)` → false (ALWAYS_BLOCK, built-in ID 1)
 ///   - `policyExists` returns true for those two built-ins
+///   - `policyType` returns the matching PolicyType enum for those two
+///
+/// Built-in ID assignments updated per IPolicyRegistry's
+/// ALWAYS_ALLOW = 0, ALWAYS_BLOCK = 1 design (PR #24): the built-in
+/// IDs are now the small numeric values that match the PolicyType
+/// ordinals rather than the previous (0, type(uint64).max) convention.
 ///
 /// Every other method reverts pending the full mock implementation in
 /// a follow-up PR. Custom policy creation, admin rotation, and
 /// membership mutation are out of scope until then.
 contract MockPolicyRegistry is IPolicyRegistry {
     uint64 internal constant ALWAYS_ALLOW_ID = 0;
-    uint64 internal constant ALWAYS_REJECT_ID = type(uint64).max;
+    uint64 internal constant ALWAYS_BLOCK_ID = 1;
 
     function isAuthorized(uint64 policyId, address /*account*/ ) external pure returns (bool) {
         if (policyId == ALWAYS_ALLOW_ID) return true;
-        if (policyId == ALWAYS_REJECT_ID) return false;
+        if (policyId == ALWAYS_BLOCK_ID) return false;
         revert PolicyNotFound();
     }
 
     function policyExists(uint64 policyId) external pure returns (bool) {
-        return policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_REJECT_ID;
+        return policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID;
     }
 
     function createPolicy(address, PolicyType) external pure returns (uint64) {
@@ -60,7 +66,9 @@ contract MockPolicyRegistry is IPolicyRegistry {
         revert("MockPolicyRegistry: not implemented");
     }
 
-    function policyType(uint64) external pure returns (PolicyType) {
+    function policyType(uint64 policyId) external pure returns (PolicyType) {
+        if (policyId == ALWAYS_ALLOW_ID) return PolicyType.ALWAYS_ALLOW;
+        if (policyId == ALWAYS_BLOCK_ID) return PolicyType.ALWAYS_BLOCK;
         revert("MockPolicyRegistry: not implemented");
     }
 

--- a/test/unit/B20/erc20/approve.t.sol
+++ b/test/unit/B20/erc20/approve.t.sol
@@ -15,6 +15,17 @@ contract B20ApproveTest is B20Test {
         token.approve(address(0), amount);
     }
 
+    /// @notice Verifies approve reverts when called by the zero address
+    /// @dev Defense-in-depth check fired before the spender guard. Reaching it requires
+    ///      pranking address(0) directly (our standard _assumeValidActor filter excludes
+    ///      it), so this test explicitly does so.
+    function test_approve_revert_zeroApprover(address spender, uint256 amount) public {
+        vm.assume(spender != address(0));
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidApprover.selector, address(0)));
+        token.approve(spender, amount);
+    }
+
     /// @notice Verifies approve does NOT consult any pause or policy state
     /// @dev approve sets future-spend authorization, not movement; no gating
     function test_approve_success_succeedsWhilePaused(address owner, address spender, uint256 amount) public {

--- a/test/unit/B20/erc20/name.t.sol
+++ b/test/unit/B20/erc20/name.t.sol
@@ -12,8 +12,10 @@ contract B20NameTest is B20Test {
     }
 
     /// @notice Verifies name reflects updates made via setName
-    /// @dev Mutable-metadata readback; canonical setter test lives in setName.t.sol
+    /// @dev Mutable-metadata readback; canonical setter test lives in setName.t.sol.
+    ///      setName requires METADATA_ROLE, which is held by no one by default.
     function test_name_success_reflectsSetName(string calldata newName) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.prank(admin);
         token.setName(newName);
         assertEq(token.name(), newName, "name must reflect setName");

--- a/test/unit/B20/erc20/symbol.t.sol
+++ b/test/unit/B20/erc20/symbol.t.sol
@@ -12,8 +12,10 @@ contract B20SymbolTest is B20Test {
     }
 
     /// @notice Verifies symbol reflects updates made via setSymbol
-    /// @dev Mutable-metadata readback; canonical setter test lives in setSymbol.t.sol
+    /// @dev Mutable-metadata readback; canonical setter test lives in setSymbol.t.sol.
+    ///      setSymbol requires METADATA_ROLE, which is held by no one by default.
     function test_symbol_success_reflectsSetSymbol(string calldata newSymbol) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.prank(admin);
         token.setSymbol(newSymbol);
         assertEq(token.symbol(), newSymbol, "symbol must reflect setSymbol");

--- a/test/unit/B20/erc20/transfer.t.sol
+++ b/test/unit/B20/erc20/transfer.t.sol
@@ -65,6 +65,19 @@ contract B20TransferTest is B20Test {
         token.transfer(address(0), amount);
     }
 
+    /// @notice Verifies transfer reverts when called by the zero address
+    /// @dev Defense-in-depth check inside _transfer: from == address(0) reverts InvalidSender
+    ///      before any pause / policy / balance checks. For the public `transfer` path
+    ///      from = msg.sender, so reaching this branch requires pranking address(0)
+    ///      (filtered out of our normal fuzz tests by _assumeValidActor).
+    function test_transfer_revert_zeroSender(address to, uint256 amount) public {
+        _assumeValidActor(to);
+
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSender.selector, address(0)));
+        token.transfer(to, amount);
+    }
+
     /// @notice Verifies transfer debits the sender balance by amount
     /// @dev Accounting half: balanceOf(from) decreases by exactly amount
     function test_transfer_success_debitsSender(address from, address to, uint256 amount) public {

--- a/test/unit/B20/metadata/setName.t.sol
+++ b/test/unit/B20/metadata/setName.t.sol
@@ -6,15 +6,19 @@ import {IB20} from "src/interfaces/IB20.sol";
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetNameTest is B20Test {
-    /// @notice Verifies setName reverts when caller lacks DEFAULT_ADMIN_ROLE
-    /// @dev Access control: only admin may rename; checks AccessControlUnauthorizedAccount
+    /// @notice Verifies setName reverts when caller lacks METADATA_ROLE
+    /// @dev Access control: only METADATA_ROLE holders may rename (separated from
+    ///      DEFAULT_ADMIN_ROLE per IB20 spec so metadata authority can be delegated
+    ///      to a corporate-actions desk). Checks AccessControlUnauthorizedAccount.
     function test_setName_revert_unauthorized(address caller, string calldata newName) public {
         _assumeValidCaller(caller);
-        vm.assume(caller != admin);
+        // Admin doesn't hold METADATA_ROLE by default either; only filter out callers we've
+        // explicitly granted the role.
+        vm.assume(!token.hasRole(METADATA_ROLE, caller));
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, METADATA_ROLE)
         );
         token.setName(newName);
     }
@@ -22,6 +26,7 @@ contract B20SetNameTest is B20Test {
     /// @notice Verifies setName updates name() to the new value
     /// @dev Read-after-write; canonical name readback test lives in name.t.sol
     function test_setName_success_updatesName(string calldata newName) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.prank(admin);
         token.setName(newName);
         assertEq(token.name(), newName, "name() must return the new value");
@@ -30,6 +35,7 @@ contract B20SetNameTest is B20Test {
     /// @notice Verifies setName emits NameUpdated(updater, newName)
     /// @dev Event integrity; canonical NameUpdated emission test
     function test_setName_success_emitsNameUpdated(string calldata newName) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.NameUpdated(admin, newName);
         vm.prank(admin);

--- a/test/unit/B20/metadata/setSymbol.t.sol
+++ b/test/unit/B20/metadata/setSymbol.t.sol
@@ -6,15 +6,16 @@ import {IB20} from "src/interfaces/IB20.sol";
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20SetSymbolTest is B20Test {
-    /// @notice Verifies setSymbol reverts when caller lacks DEFAULT_ADMIN_ROLE
-    /// @dev Access control: only admin may rename; checks AccessControlUnauthorizedAccount
+    /// @notice Verifies setSymbol reverts when caller lacks METADATA_ROLE
+    /// @dev Access control: only METADATA_ROLE holders may rename (separated from
+    ///      DEFAULT_ADMIN_ROLE per IB20 spec). Checks AccessControlUnauthorizedAccount.
     function test_setSymbol_revert_unauthorized(address caller, string calldata newSymbol) public {
         _assumeValidCaller(caller);
-        vm.assume(caller != admin);
+        vm.assume(!token.hasRole(METADATA_ROLE, caller));
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, METADATA_ROLE)
         );
         token.setSymbol(newSymbol);
     }
@@ -22,6 +23,7 @@ contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol updates symbol() to the new value
     /// @dev Read-after-write; canonical symbol readback test lives in symbol.t.sol
     function test_setSymbol_success_updatesSymbol(string calldata newSymbol) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.prank(admin);
         token.setSymbol(newSymbol);
         assertEq(token.symbol(), newSymbol, "symbol() must return the new value");
@@ -30,6 +32,7 @@ contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol emits SymbolUpdated(updater, newSymbol)
     /// @dev Event integrity; canonical SymbolUpdated emission test
     function test_setSymbol_success_emitsSymbolUpdated(string calldata newSymbol) public {
+        _grantRole(METADATA_ROLE, admin);
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.SymbolUpdated(admin, newSymbol);
         vm.prank(admin);

--- a/test/unit/B20/roles/roleConstants.t.sol
+++ b/test/unit/B20/roles/roleConstants.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
 
-/// @notice Folds the six trivial role-identifier constant readers into one
+/// @notice Folds the seven trivial role-identifier constant readers into one
 ///         file since each is a one-stub assertion against a fixed keccak
 ///         digest. Substantive role-related functions (`grantRole`,
 ///         `revokeRole`, etc.) live in their own files.
@@ -49,5 +49,13 @@ contract B20RoleConstantsTest is B20Test {
     function test_UNPAUSE_ROLE_success_matchesExpected() public view {
         assertEq(token.UNPAUSE_ROLE(), keccak256("UNPAUSE_ROLE"), "UNPAUSE_ROLE digest");
         assertEq(token.UNPAUSE_ROLE(), UNPAUSE_ROLE, "must match B20Test's local constant");
+    }
+
+    /// @notice Verifies METADATA_ROLE returns keccak256("METADATA_ROLE")
+    /// @dev Identifier stability for off-chain consumers. METADATA_ROLE gates `setName`
+    ///      and `setSymbol` (separated from DEFAULT_ADMIN_ROLE per IB20 spec).
+    function test_METADATA_ROLE_success_matchesExpected() public view {
+        assertEq(token.METADATA_ROLE(), keccak256("METADATA_ROLE"), "METADATA_ROLE digest");
+        assertEq(token.METADATA_ROLE(), METADATA_ROLE, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -7,10 +7,14 @@ import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20MintTest is B20Test {
     /// @notice Verifies mint reverts when caller lacks MINT_ROLE
-    /// @dev Access control: only role-holders can mint; checks AccessControlUnauthorizedAccount
+    /// @dev Access control: only role-holders can mint; checks AccessControlUnauthorizedAccount.
+    ///      Note _mint's check order: InvalidReceiver(0) fires BEFORE the role check, so
+    ///      we filter to != 0 to exercise the role-check path specifically. The
+    ///      InvalidReceiver path is covered by test_mint_revert_zeroRecipient.
     function test_mint_revert_unauthorized(address caller, address to, uint256 amount) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);
+        vm.assume(to != address(0));
         // No MINT_ROLE granted to caller.
 
         vm.prank(caller);

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -30,7 +30,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         factory.createToken(ITokenFactory.TokenVariant.NONE, salt, abi.encode(_b20Params()), new bytes[](0));
     }
 
-    /// @notice Verifies createToken reverts for any unsupported params version byte
+    /// @notice Verifies createToken reverts for any unsupported params version byte (DEFAULT variant)
     /// @dev Fuzz confirms only the known version (1) decodes; checks UnsupportedVersion(version) error
     function test_createToken_revert_unsupportedVersion(address caller, uint8 badVersion, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -40,6 +40,21 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         vm.prank(caller);
         vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
         factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), new bytes[](0));
+    }
+
+    /// @notice Verifies createToken reverts for any unsupported version byte on the STABLECOIN variant
+    /// @dev Each variant arm has its own version check; this exercises the stablecoin arm's check
+    ///      (the default-variant arm has a parallel test above).
+    function test_createToken_revert_unsupportedVersion_stablecoin(address caller, uint8 badVersion, bytes32 salt)
+        public
+    {
+        _assumeValidCaller(caller);
+        vm.assume(badVersion != 1);
+        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams();
+        p.version = badVersion;
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
+        factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts for default-variant decimals outside [2, 18]
@@ -61,6 +76,22 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         vm.prank(caller);
         vm.expectRevert(ITokenFactory.MissingRequiredField.selector);
         factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
+    }
+
+    /// @notice Verifies the SECURITY variant currently reverts UnsupportedVersion(0)
+    /// @dev Pins down the current "Security variant deferred to Katzman" behavior so it
+    ///      can't silently start succeeding before the variant impl actually lands. Delete
+    ///      this test when MockTokenFactory.createToken grows a real SECURITY arm.
+    function test_createToken_revert_securityVariantDeferred(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+
+        // Use a stablecoin params struct as a stand-in (the security struct doesn't matter:
+        // the factory reverts before decoding because the variant arm short-circuits).
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, uint8(0)));
+        factory.createToken(
+            ITokenFactory.TokenVariant.SECURITY, salt, abi.encode(_stablecoinParams()), new bytes[](0)
+        );
     }
 
     /// @notice Verifies createToken reverts when (variant, decimals, sender, salt) collides
@@ -267,6 +298,26 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
             uint256(ITokenFactory.TokenVariant.STABLECOIN),
             "stablecoin variant byte mismatch"
         );
+    }
+
+    /// @notice Verifies createToken correctly stores name and symbol strings >= 32 bytes
+    /// @dev Solidity's storage layout switches encoding at length 32 (short vs long string).
+    ///      The factory's _writeString handles both paths via vm.store; this test exercises
+    ///      the long-string path explicitly. Short-string path is covered by every other
+    ///      success test (default name "Test", symbol "TST" are both < 32 bytes).
+    function test_createToken_success_writesLongStrings(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        // Both strings are 40 bytes -> exercises the long-string storage encoding.
+        string memory longName = "A token name that is forty bytes long!!!";
+        string memory longSymbol = "ASYMBOLALSODELIBERATELYFORTYBYTES.....!!";
+        assertEq(bytes(longName).length, 40, "test setup: longName must be 40 bytes");
+        assertEq(bytes(longSymbol).length, 40, "test setup: longSymbol must be 40 bytes");
+
+        ITokenFactory.B20CreateParams memory p = _b20Params(longName, longSymbol, admin, 18);
+        address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
+
+        assertEq(MockB20(tokenAddr).name(), longName, "long name must round-trip via storage");
+        assertEq(MockB20(tokenAddr).symbol(), longSymbol, "long symbol must round-trip via storage");
     }
 
     /// @notice Verifies the decimals byte at address position [11] matches the created decimals

--- a/test/unit/storage/MockB20Storage.t.sol
+++ b/test/unit/storage/MockB20Storage.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+
+/// @notice Asserts the hardcoded `STORAGE_LOCATION` constants on the B-20
+///         storage libraries match the ERC-7201 formula they document.
+///
+/// These constants are the storage-layout contract between the Solidity
+/// mocks and the Rust precompile impl: both sides hash the same namespace
+/// string and arrive at the same root slot. Verifying the constant against
+/// the formula in-tree ensures a stale `STORAGE_LOCATION` literal can't
+/// drift silently when the namespace changes.
+contract MockB20StorageLocationTest is Test {
+    /// @notice `MockB20Storage.STORAGE_LOCATION` equals
+    ///         keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff)).
+    function test_MockB20Storage_storageLocation_matchesFormula() public pure {
+        assertEq(
+            MockB20Storage.STORAGE_LOCATION,
+            MockB20Storage.derivedLocation(),
+            "MockB20Storage.STORAGE_LOCATION must match its ERC-7201 derivation"
+        );
+    }
+
+    /// @notice `MockB20StablecoinStorage.STORAGE_LOCATION` equals
+    ///         keccak256(abi.encode(uint256(keccak256("base.b20.stablecoin")) - 1)) & ~bytes32(uint256(0xff)).
+    function test_MockB20StablecoinStorage_storageLocation_matchesFormula() public pure {
+        assertEq(
+            MockB20StablecoinStorage.STORAGE_LOCATION,
+            MockB20StablecoinStorage.derivedLocation(),
+            "MockB20StablecoinStorage.STORAGE_LOCATION must match its ERC-7201 derivation"
+        );
+    }
+
+    /// @notice The two namespaces (`base.b20` and `base.b20.stablecoin`) must derive
+    ///         to disjoint storage roots so the variant's storage doesn't collide
+    ///         with the base token's storage.
+    function test_storageLocations_disjoint() public pure {
+        assertTrue(
+            MockB20Storage.STORAGE_LOCATION != MockB20StablecoinStorage.STORAGE_LOCATION,
+            "base and stablecoin namespaces must derive to disjoint roots"
+        );
+    }
+}


### PR DESCRIPTION
** Build fixes (interface changes landed in main without mock updates) **
- IB20 added METADATA_ROLE (#28): MockB20 declares the constant, setName / setSymbol now require METADATA_ROLE (separated from DEFAULT_ADMIN_ROLE per IB20 spec so metadata authority can be delegated). Added _requireRole(bytes32) helper; setName/setSymbol tests grant METADATA_ROLE to admin in success paths and assert METADATA_ROLE in revert paths.
- IPolicyRegistry changed built-in ALWAYS_BLOCK from type(uint64).max to 1 (#24): MockPolicyRegistry renamed ALWAYS_REJECT_ID -> ALWAYS_BLOCK_ID and bound to 1; added policyType() resolution for the two built-ins; B20Test.ALWAYS_REJECT constant updated to 1.

** Coverage tightening (from forge coverage run on amie/mock-impls) ** Drove MockB20 / MockB20Stablecoin / MockB20Storage / MockTokenFactory to 100% line, 99-100% statement, 100% branch coverage. Total: 92.34% line / 95.31% statement / 100% branch. Remaining drag is the policy + activation skeleton mocks (Eric's / future work).

- test_mint_revert_unauthorized: filter to != 0 (different fuzz seed hit to=0, which triggers InvalidReceiver before the role check). Real latent bug surfaced by coverage.
- test/unit/storage/MockB20Storage.t.sol: new file. Asserts STORAGE_LOCATION == derivedLocation() for both base and stablecoin namespaces, plus disjointness. Closes the gap where derivedLocation() existed for this exact assertion but was never called.
- test_createToken_success_writesLongStrings: exercises the long-string (length >= 32) branch in MockTokenFactory._writeString.
- test_createToken_revert_securityVariantDeferred: pins down current "SECURITY reverts UnsupportedVersion(0)" behavior so it can't silently start succeeding before Katzman's impl lands.
- test_createToken_revert_unsupportedVersion_stablecoin: parallel version-check test for the STABLECOIN variant arm.
- test_approve_revert_zeroApprover, test_transfer_revert_zeroSender: defense-in-depth zero-msg.sender checks. Reaching them requires pranking address(0) directly (filtered by _assumeValidCaller in normal tests).

** Role constant fillout **
- test_METADATA_ROLE_success_matchesExpected added; roleConstants doc updated from "six" to "seven" constants.

forge test: 295 passed, 0 failed, 0 skipped.