### PR TITLE
MockPolicyRegistry cleanups

### DIFF
--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -71,6 +71,10 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         SLOADs if the type required a separate storage lookup. The
 ///         built-in IDs cost 0 SLOADs (short-circuited).
 ///
+///         Separately from `policyId` encoding, implementations store mutable
+///         per-policy state (notably admin) in policy-record storage keyed by
+///         `policyId`; admin is not encoded into the ID itself.
+///
 ///         Custom policy IDs are assigned from a single global monotonic
 ///         counter starting at `2` (reserving `0` and `1` for the
 ///         built-ins); see `nextPolicyId(PolicyType)` to predict the

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -19,7 +19,11 @@ import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorag
 ///         slot layout the Rust impl mirrors. See `MockPolicyRegistryStorage`
 ///         for the full layout documentation and per-field slot offsets.
 ///
-///         **Policy ID encoding:**
+///         This implementation uses two independent encodings:
+///         1) `policyId` (uint64) packs type + counter only.
+///         2) `policies[policyId]` (uint256) packs policyType + mutable admin.
+///
+///         **Policy ID encoding (`policyId`):**
 ///           [63:56]  uint8(PolicyType) discriminator
 ///           [55:0]   nextCounter value at creation time
 ///         `_create` rejects ALWAYS_ALLOW and ALWAYS_BLOCK types, so no
@@ -35,12 +39,14 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     uint64 internal constant ALWAYS_ALLOW_ID = 0;
     uint64 internal constant ALWAYS_BLOCK_ID = 1;
+    uint56 internal constant INITIAL_CUSTOM_COUNTER = 2;
 
     // Policy ID encoding: top byte = uint8(PolicyType), low 56 bits = counter.
-    uint256 internal constant TYPE_SHIFT = 56;
+    uint64 internal constant POLICY_ID_TYPE_SHIFT = 56;
 
-    // Admin address occupies bits [167:8]; PolicyType occupies bits [7:0].
-    uint256 internal constant ADMIN_SHIFT = 8;
+    // Packed policy slot encoding (`policies[policyId]`):
+    // admin address occupies bits [167:8]; PolicyType occupies bits [7:0].
+    uint256 internal constant PACKED_ADMIN_SHIFT = 8;
 
     // ============================================================
     //                       POLICY CREATION
@@ -136,7 +142,9 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function nextPolicyId(PolicyType policyType) external view returns (uint64) {
-        return _makeId({policyType: policyType, counter: MockPolicyRegistryStorage.layout().nextCounter});
+        uint56 counter = MockPolicyRegistryStorage.layout().nextCounter;
+        if (counter < INITIAL_CUSTOM_COUNTER) counter = INITIAL_CUSTOM_COUNTER;
+        return _makeId({policyType: policyType, counter: counter});
     }
 
     /// @inheritdoc IPolicyRegistry
@@ -177,6 +185,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
         if (admin == address(0)) revert ZeroAddress();
         MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
         uint56 counter = $.nextCounter;
+        if (counter < INITIAL_CUSTOM_COUNTER) counter = INITIAL_CUSTOM_COUNTER;
         // No overflow guard: at one policy per 2-second block, exhausting the
         // 56-bit counter space (~7.2e16 values) takes ~4.6 billion years.
         unchecked {
@@ -208,11 +217,11 @@ contract MockPolicyRegistry is IPolicyRegistry {
     }
 
     function _makeId(PolicyType policyType, uint56 counter) internal pure returns (uint64) {
-        return (uint64(uint8(policyType)) << TYPE_SHIFT) | uint64(counter);
+        return (uint64(uint8(policyType)) << POLICY_ID_TYPE_SHIFT) | uint64(counter);
     }
 
     function _encode(PolicyType policyType, address admin) internal pure returns (uint256) {
-        return (uint256(uint160(admin)) << ADMIN_SHIFT) | uint256(policyType);
+        return (uint256(uint160(admin)) << PACKED_ADMIN_SHIFT) | uint256(policyType);
     }
 
     function _decodeType(uint256 packed) internal pure returns (PolicyType) {
@@ -220,6 +229,6 @@ contract MockPolicyRegistry is IPolicyRegistry {
     }
 
     function _decodeAdmin(uint256 packed) internal pure returns (address) {
-        return address(uint160(packed >> ADMIN_SHIFT));
+        return address(uint160(packed >> PACKED_ADMIN_SHIFT));
     }
 }

--- a/test/lib/mocks/MockPolicyRegistryStorage.sol
+++ b/test/lib/mocks/MockPolicyRegistryStorage.sol
@@ -36,8 +36,8 @@ library MockPolicyRegistryStorage {
         // Staged pending admin for in-flight two-step admin transfers.
         mapping(uint64 policyId => address pendingAdmin) pendingAdmins;
         // Global monotonic counter for the low 56 bits of custom policy IDs.
-        // Starts at 0 (ERC-7201 default). The discriminator byte in bits [63:56]
-        // of any custom ID ensures it can never equal built-in IDs 0 or 1.
+        // MockPolicyRegistry floors this to 2 on first read/write so the first
+        // custom ID explicitly reserves built-ins 0 and 1.
         uint56 nextCounter;
     }
 

--- a/test/unit/PolicyRegistry/nextPolicyId.t.sol
+++ b/test/unit/PolicyRegistry/nextPolicyId.t.sol
@@ -6,22 +6,22 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
 contract PolicyRegistryNextPolicyIdTest is PolicyRegistryTest {
-    uint256 private constant TYPE_SHIFT = 56;
+    uint64 private constant TYPE_SHIFT = 56;
+    uint56 private constant INITIAL_CUSTOM_COUNTER = 2;
 
     /// @notice Verifies nextPolicyId(ALLOWLIST) returns the correct initial encoded id
-    /// @dev Global counter starts at 0. The first ALLOWLIST id is
-    ///      `(uint64(uint8(PolicyType.ALLOWLIST)) << 56) | 0`
-    ///      The discriminator byte (0x02) ensures this never equals built-in IDs 0 or 1.
+    /// @dev Global counter starts at 2. The first ALLOWLIST id is
+    ///      `(uint64(uint8(PolicyType.ALLOWLIST)) << 56) | 2`.
     function test_nextPolicyId_success_allowlistInitialEncoded() public view {
-        uint64 expected = (uint64(uint8(IPolicyRegistry.PolicyType.ALLOWLIST)) << TYPE_SHIFT) | 0;
+        uint64 expected = (uint64(uint8(IPolicyRegistry.PolicyType.ALLOWLIST)) << TYPE_SHIFT) | INITIAL_CUSTOM_COUNTER;
         assertEq(policyRegistry.nextPolicyId(IPolicyRegistry.PolicyType.ALLOWLIST), expected);
     }
 
     /// @notice Verifies nextPolicyId(BLOCKLIST) returns the correct initial encoded id
-    /// @dev Global counter starts at 0. The first BLOCKLIST id is
-    ///      `(uint64(uint8(PolicyType.BLOCKLIST)) << 56) | 0`
+    /// @dev Global counter starts at 2. The first BLOCKLIST id is
+    ///      `(uint64(uint8(PolicyType.BLOCKLIST)) << 56) | 2`.
     function test_nextPolicyId_success_blocklistInitialEncoded() public view {
-        uint64 expected = (uint64(uint8(IPolicyRegistry.PolicyType.BLOCKLIST)) << TYPE_SHIFT) | 0;
+        uint64 expected = (uint64(uint8(IPolicyRegistry.PolicyType.BLOCKLIST)) << TYPE_SHIFT) | INITIAL_CUSTOM_COUNTER;
         assertEq(policyRegistry.nextPolicyId(IPolicyRegistry.PolicyType.BLOCKLIST), expected);
     }
 


### PR DESCRIPTION
- Floor `nextCounter` to 2 on first read/write so the first custom policy ID's low 56 bits are 2 instead of 0; built-in IDs 0/1 are now reserved by the counter itself, not only by the discriminator byte.
- Rename shift constants to disambiguate the two independent encodings: `POLICY_ID_TYPE_SHIFT` (uint64 policyId) and `PACKED_ADMIN_SHIFT` (uint256 packed slot).
- Document in IPolicyRegistry that mutable per-policy state (admin) lives in a separate policy-record slot keyed by policyId, not in the ID.
- Update nextPolicyId tests to expect the new initial counter value.