### PR TITLE
Address PR #26 review: pack policy IDs, canonical RoleGranted, dedup constants

### DIFF
--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -200,25 +200,26 @@ interface ITokenFactory {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted once per `createToken` invocation. The common
-    ///         fields cover the universal token-identity surface; all
+    /// @notice Emitted once per `createToken` invocation. The fields
+    ///         cover the universal token-identity surface only;
     ///         variant-specific state changes (e.g. `currency`, `isin`,
     ///         supply cap, policy slots) are observable via the
     ///         token's own events as they're applied during `initCalls`.
-    /// @dev    The factory writes the token's initial storage directly
-    ///         (no `bootstrap` call into the token), so the initial
-    ///         admin grant does not produce a separate `RoleGranted`
-    ///         event. This event is the canonical signal for both
-    ///         "token created" AND "initial admin set". A zero `admin`
-    ///         indicates the "demonstrate no owner" path. Post-creation
-    ///         role grants emit `RoleGranted` from the token as usual.
+    /// @dev    The initial admin grant (when `initialAdmin != address(0)`)
+    ///         is announced via the standard `RoleGranted(DEFAULT_ADMIN_ROLE,
+    ///         admin, factory)` event emitted from the token's own
+    ///         context during the same transaction — NOT as a field on
+    ///         this event. Role state is always observable via the
+    ///         `RoleGranted` / `RoleRevoked` event stream from the token;
+    ///         `TokenCreated` is the token-identity signal only. The
+    ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
+    ///         skips the grant and emits no `RoleGranted` at bootstrap.
     event TokenCreated(
         address indexed token,
         TokenVariant indexed variant,
         string name,
         string symbol,
-        uint8 decimals,
-        address admin
+        uint8 decimals
     );
 
     /*//////////////////////////////////////////////////////////////

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.20;
 
 import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 import {IB20} from "src/interfaces/IB20.sol";
+
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 /// @notice Base test contract for `IB20` unit tests.
 ///
@@ -20,28 +23,15 @@ import {IB20} from "src/interfaces/IB20.sol";
 /// `unpauser`, `burnBlocker`) so role-gated tests have explicit named
 /// accounts to grant roles to in setUp's initCalls.
 contract B20Test is TokenFactoryTest {
-    // -- Role identifiers (match MockB20's keccak256 derivations) --
-    // Inlined here so tests can avoid `token.MINT_ROLE()` calls during
-    // setup paths where the token may not yet exist (e.g. createToken
-    // tests). Verified against MockB20's constants by direct equality
-    // in the role-constants test suite.
-    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
-    bytes32 internal constant MINT_ROLE = keccak256("MINT_ROLE");
-    bytes32 internal constant BURN_ROLE = keccak256("BURN_ROLE");
-    bytes32 internal constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
-    bytes32 internal constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
-    bytes32 internal constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
-    bytes32 internal constant METADATA_ROLE = keccak256("METADATA_ROLE");
-
-    // -- Policy-type identifiers --
-    bytes32 internal constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
-    bytes32 internal constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
-    bytes32 internal constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
-    bytes32 internal constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
-
-    // -- Built-in policy sentinel IDs (per IPolicyRegistry: ALWAYS_ALLOW=0, ALWAYS_BLOCK=1) --
-    uint64 internal constant ALWAYS_ALLOW = 0;
-    uint64 internal constant ALWAYS_REJECT = 1;
+    // Role identifiers (DEFAULT_ADMIN_ROLE, MINT_ROLE, BURN_ROLE,
+    // BURN_BLOCKED_ROLE, PAUSE_ROLE, UNPAUSE_ROLE, METADATA_ROLE) and
+    // policy-type identifiers (TRANSFER_SENDER, TRANSFER_RECEIVER,
+    // TRANSFER_EXECUTOR, MINT_RECEIVER) are NOT redeclared here.
+    // Tests reference them directly from MockB20 as `MINT_ROLE`
+    // etc. — single source of truth, no drift risk.
+    //
+    // Built-in policy sentinel IDs likewise live on MockPolicyRegistry as
+    // `ALWAYS_ALLOW_ID` / `ALWAYS_BLOCK_ID`.
 
     // -- Token-specific role-holder actors --
     address internal minter = makeAddr("minter");
@@ -123,7 +113,7 @@ contract B20Test is TokenFactoryTest {
     /// @dev Most balance-setup needs in tests reduce to "give this account some
     ///      tokens"; this helper avoids re-asserting the role-grant boilerplate.
     function _mint(address to, uint256 amount) internal {
-        if (!token.hasRole(MINT_ROLE, minter)) _grantRole(MINT_ROLE, minter);
+        if (!token.hasRole(B20Constants.MINT_ROLE, minter)) _grantRole(B20Constants.MINT_ROLE, minter);
         vm.prank(minter);
         token.mint(to, amount);
     }
@@ -140,7 +130,7 @@ contract B20Test is TokenFactoryTest {
     /// @notice Pauses a single `PausableFeature`, lazily granting `PAUSE_ROLE`
     ///         to the `pauser` actor on first call.
     function _pause(IB20.PausableFeature feature) internal {
-        if (!token.hasRole(PAUSE_ROLE, pauser)) _grantRole(PAUSE_ROLE, pauser);
+        if (!token.hasRole(B20Constants.PAUSE_ROLE, pauser)) _grantRole(B20Constants.PAUSE_ROLE, pauser);
         vm.prank(pauser);
         token.pause(_singleFeature(feature));
     }

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -6,6 +6,33 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
 
 import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @notice Canonical B-20 role and policy-type identifier constants.
+///         Declared as a library (not on the contract) so tests and
+///         downstream tooling can reference them at compile time via
+///         `MINT_ROLE` etc. — Solidity's `public constant`
+///         on a contract is only accessible via instance (e.g.
+///         `token.MINT_ROLE()`), which doesn't work where the token
+///         doesn't yet exist (factory creation tests, initCall
+///         construction).
+/// @dev    `MockB20` re-exposes each value as `bytes32 public constant`
+///         to satisfy `IB20`'s view-function ABI; the library is the
+///         single source of truth, the public constants delegate.
+library B20Constants {
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
+    bytes32 internal constant MINT_ROLE = keccak256("MINT_ROLE");
+    bytes32 internal constant BURN_ROLE = keccak256("BURN_ROLE");
+    bytes32 internal constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
+    bytes32 internal constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
+    bytes32 internal constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
+    bytes32 internal constant METADATA_ROLE = keccak256("METADATA_ROLE");
+
+    bytes32 internal constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
+    bytes32 internal constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
+    bytes32 internal constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
+    bytes32 internal constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
+}
 
 /// @title MockB20
 /// @notice Reference implementation of the `IB20` default-token surface.
@@ -61,23 +88,23 @@ contract MockB20 is IB20 {
 
     /// @notice Default top-level admin role. Equal to `bytes32(0)` per
     ///         the OZ AccessControl convention.
-    bytes32 public constant DEFAULT_ADMIN_ROLE = bytes32(0);
+    bytes32 public constant DEFAULT_ADMIN_ROLE = B20Constants.DEFAULT_ADMIN_ROLE;
 
-    /// @notice Role identifiers. Computed as `keccak256` of the role
-    ///         name per the OZ AccessControl convention, so the
-    ///         Rust impl can derive them identically.
-    bytes32 public constant MINT_ROLE = keccak256("MINT_ROLE");
-    bytes32 public constant BURN_ROLE = keccak256("BURN_ROLE");
-    bytes32 public constant BURN_BLOCKED_ROLE = keccak256("BURN_BLOCKED_ROLE");
-    bytes32 public constant PAUSE_ROLE = keccak256("PAUSE_ROLE");
-    bytes32 public constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
-    bytes32 public constant METADATA_ROLE = keccak256("METADATA_ROLE");
+    /// @notice Role identifiers. Values delegate to `B20Constants` so the
+    ///         single-source-of-truth lives in one library; the Rust impl
+    ///         derives the same `keccak256` of each role name.
+    bytes32 public constant MINT_ROLE = B20Constants.MINT_ROLE;
+    bytes32 public constant BURN_ROLE = B20Constants.BURN_ROLE;
+    bytes32 public constant BURN_BLOCKED_ROLE = B20Constants.BURN_BLOCKED_ROLE;
+    bytes32 public constant PAUSE_ROLE = B20Constants.PAUSE_ROLE;
+    bytes32 public constant UNPAUSE_ROLE = B20Constants.UNPAUSE_ROLE;
+    bytes32 public constant METADATA_ROLE = B20Constants.METADATA_ROLE;
 
-    /// @notice Policy-type identifiers. Same `keccak256` convention.
-    bytes32 public constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
-    bytes32 public constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
-    bytes32 public constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
-    bytes32 public constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
+    /// @notice Policy-type identifiers. Same `keccak256` convention as roles.
+    bytes32 public constant TRANSFER_SENDER = B20Constants.TRANSFER_SENDER;
+    bytes32 public constant TRANSFER_RECEIVER = B20Constants.TRANSFER_RECEIVER;
+    bytes32 public constant TRANSFER_EXECUTOR = B20Constants.TRANSFER_EXECUTOR;
+    bytes32 public constant MINT_RECEIVER = B20Constants.MINT_RECEIVER;
 
     // ============================================================
     //                          ERC-20: VIEWS
@@ -122,7 +149,12 @@ contract MockB20 is IB20 {
     function transferFrom(address from, address to, uint256 amount) external returns (bool) {
         if (!_isPrivileged() && msg.sender != from) {
             _consumeAllowance(from, msg.sender, amount);
-            _checkPolicy(TRANSFER_EXECUTOR, msg.sender);
+            // Read the executor policy ID out of the packed slot. Cold
+            // here; warm by the time _transfer reads the same slot.
+            uint64 executorPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 128);
+            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
+                revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
+            }
         }
         _transfer(from, to, amount);
         return true;
@@ -149,7 +181,10 @@ contract MockB20 is IB20 {
     function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool) {
         if (!_isPrivileged() && msg.sender != from) {
             _consumeAllowance(from, msg.sender, amount);
-            _checkPolicy(TRANSFER_EXECUTOR, msg.sender);
+            uint64 executorPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 128);
+            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
+                revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
+            }
         }
         _transfer(from, to, amount);
         emit Memo(memo);
@@ -201,9 +236,12 @@ contract MockB20 is IB20 {
             }
             if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
             // The point of burnBlocked is to seize from policy-blocked
-            // accounts. Calling it on an authorized account is rejected.
-            uint64 senderPolicyId = MockB20Storage.layout().policyIds[TRANSFER_SENDER];
-            if (_policyAuthorized(senderPolicyId, from)) revert AccountNotBlocked(from);
+            // accounts. Read the transfer-sender policy ID out of the
+            // packed slot and reject if the target is currently authorized.
+            uint64 senderPolicyId = uint64(MockB20Storage.layout().packedPolicyIds);
+            if (IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {
+                revert AccountNotBlocked(from);
+            }
         }
         _burnRaw(from, amount);
         emit BurnedBlocked(msg.sender, from, amount);
@@ -323,7 +361,7 @@ contract MockB20 is IB20 {
     // ============================================================
 
     function policyId(bytes32 policyType) external view returns (uint64) {
-        return MockB20Storage.layout().policyIds[policyType];
+        return _readPolicyId(policyType);
     }
 
     function updatePolicy(bytes32 policyType, uint64 newPolicyId) external {
@@ -332,9 +370,43 @@ contract MockB20 is IB20 {
         if (!IPolicyRegistry(POLICY_REGISTRY).policyExists(newPolicyId)) {
             revert PolicyNotFound(newPolicyId);
         }
-        uint64 oldPolicyId = MockB20Storage.layout().policyIds[policyType];
-        MockB20Storage.layout().policyIds[policyType] = newPolicyId;
+        uint64 oldPolicyId = _readPolicyId(policyType);
+        _writePolicyId(policyType, newPolicyId);
         emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
+    }
+
+    /// @dev Reads a policy ID from storage. The four hot-path policy
+    ///      types live in a packed uint256 (one SLOAD, four uint64s);
+    ///      anything else falls through to the variant/user-defined
+    ///      mapping at the cold path.
+    function _readPolicyId(bytes32 policyType) internal view returns (uint64) {
+        uint256 packed = MockB20Storage.layout().packedPolicyIds;
+        if (policyType == TRANSFER_SENDER) return uint64(packed);
+        if (policyType == TRANSFER_RECEIVER) return uint64(packed >> 64);
+        if (policyType == TRANSFER_EXECUTOR) return uint64(packed >> 128);
+        if (policyType == MINT_RECEIVER) return uint64(packed >> 192);
+        return MockB20Storage.layout().extraPolicyIds[policyType];
+    }
+
+    /// @dev Writes a policy ID to storage. Hot-path types update the
+    ///      packed slot in-place (preserving the other three policies);
+    ///      anything else writes to the extra-policies mapping. Done
+    ///      with explicit mask + shift so the Rust impl can replicate
+    ///      the exact bit layout.
+    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal {
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        uint256 mask = uint256(type(uint64).max);
+        if (policyType == TRANSFER_SENDER) {
+            $.packedPolicyIds = ($.packedPolicyIds & ~mask) | uint256(newPolicyId);
+        } else if (policyType == TRANSFER_RECEIVER) {
+            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
+        } else if (policyType == TRANSFER_EXECUTOR) {
+            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
+        } else if (policyType == MINT_RECEIVER) {
+            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 192)) | (uint256(newPolicyId) << 192);
+        } else {
+            $.extraPolicyIds[policyType] = newPolicyId;
+        }
     }
 
     // ============================================================
@@ -473,18 +545,6 @@ contract MockB20 is IB20 {
         return ((MockB20Storage.layout().pausedVectors >> uint8(feature)) & uint256(1)) == 1;
     }
 
-    /// @dev Resolves an authorization check against the policy registry.
-    ///      Reverts with `PolicyForbids` propagated from the caller, not
-    ///      raised here, so callers can include the right policyType.
-    function _policyAuthorized(uint64 _policyId, address account) internal view returns (bool) {
-        return IPolicyRegistry(POLICY_REGISTRY).isAuthorized(_policyId, account);
-    }
-
-    function _checkPolicy(bytes32 policyType, address account) internal view {
-        uint64 _policyId = MockB20Storage.layout().policyIds[policyType];
-        if (!_policyAuthorized(_policyId, account)) revert PolicyForbids(policyType, _policyId);
-    }
-
     function _grantRole(bytes32 role, address account) internal {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         if (!$.roles[role][account]) {
@@ -519,8 +579,18 @@ contract MockB20 is IB20 {
 
         if (!_isPrivileged()) {
             if (_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);
-            _checkPolicy(TRANSFER_SENDER, from);
-            _checkPolicy(TRANSFER_RECEIVER, to);
+            // One SLOAD pulls both policy IDs we need for the transfer
+            // check (and was already warmed if we came in via transferFrom,
+            // which reads the executor slot first).
+            uint256 packed = MockB20Storage.layout().packedPolicyIds;
+            uint64 senderPolicyId = uint64(packed);
+            uint64 receiverPolicyId = uint64(packed >> 64);
+            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {
+                revert PolicyForbids(TRANSFER_SENDER, senderPolicyId);
+            }
+            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(receiverPolicyId, to)) {
+                revert PolicyForbids(TRANSFER_RECEIVER, receiverPolicyId);
+            }
         }
 
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
@@ -539,7 +609,10 @@ contract MockB20 is IB20 {
         if (!_isPrivileged()) {
             if (!hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);
             if (_isPaused(PausableFeature.MINT)) revert ContractPaused(PausableFeature.MINT);
-            _checkPolicy(MINT_RECEIVER, to);
+            uint64 mintReceiverPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 192);
+            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {
+                revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);
+            }
         }
 
         MockB20Storage.Layout storage $ = MockB20Storage.layout();

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -55,8 +55,24 @@ library MockB20Storage {
         // LastAdminCannotRenounce in O(1). Bumped on grant, decremented on
         // revoke / renounce.
         uint256 adminCount;
-        // ---------- Policy slots ----------
-        mapping(bytes32 policyType => uint64 policyId) policyIds;
+        // ---------- Policy slots (PACKED) ----------
+        // The four hot-path policy types (transfer sender / receiver /
+        // executor, mint receiver) are packed into a single 256-bit slot
+        // so the transfer and mint hot paths read all the policy IDs they
+        // need with ONE SLOAD instead of one per policy type. Layout:
+        //   [63:0]    transferSenderPolicyId
+        //   [127:64]  transferReceiverPolicyId
+        //   [191:128] transferExecutorPolicyId
+        //   [255:192] mintReceiverPolicyId
+        // The 64-bit width matches `uint64 policyId` everywhere else in
+        // the system; four IDs fit exactly into the 256-bit slot.
+        uint256 packedPolicyIds;
+        // Variant-defined and user-defined policy types (e.g.
+        // REDEEMER_SENDER on IB20Security, or any keccak256("CUSTOM_*")
+        // a wrapper introduces) live in this mapping. The cold path
+        // (variant-specific operations like `redeem`) pays the standard
+        // one-SLOAD-per-mapping-access cost.
+        mapping(bytes32 policyType => uint64 policyId) extraPolicyIds;
         // ---------- Pause ----------
         // Bitmask: bit i set means PausableFeature(i) is paused. Translated
         // to/from the PausableFeature[] enum array at the IB20 surface
@@ -105,11 +121,12 @@ library MockB20Storage {
     uint256 internal constant ROLES_OFFSET = 6;
     uint256 internal constant ROLE_ADMINS_OFFSET = 7;
     uint256 internal constant ADMIN_COUNT_OFFSET = 8;
-    uint256 internal constant POLICY_IDS_OFFSET = 9;
-    uint256 internal constant PAUSED_VECTORS_OFFSET = 10;
-    uint256 internal constant SUPPLY_CAP_OFFSET = 11;
-    uint256 internal constant NONCES_OFFSET = 12;
-    uint256 internal constant INITIALIZED_OFFSET = 13;
+    uint256 internal constant PACKED_POLICY_IDS_OFFSET = 9;
+    uint256 internal constant EXTRA_POLICY_IDS_OFFSET = 10;
+    uint256 internal constant PAUSED_VECTORS_OFFSET = 11;
+    uint256 internal constant SUPPLY_CAP_OFFSET = 12;
+    uint256 internal constant NONCES_OFFSET = 13;
+    uint256 internal constant INITIALIZED_OFFSET = 14;
 
     /// @notice Absolute slot for a top-level field of `Layout`.
     /// @dev `STORAGE_LOCATION + offset`. The struct never crosses the

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -5,6 +5,22 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
 
+/// @notice Canonical built-in policy ID constants. Declared as a library
+///         so tests can reference them at compile time via
+///         `PolicyRegistryConstants.ALWAYS_ALLOW_ID` — Solidity's
+///         `public constant` on a contract is only accessible via instance
+///         call, which doesn't work for compile-time constant contexts.
+/// @dev    `MockPolicyRegistry` re-exposes each value as `uint64 public
+///         constant` to satisfy the runtime-getter contract; this library
+///         is the single source of truth.
+library PolicyRegistryConstants {
+    /// @notice Built-in policy ID that always authorizes any account.
+    uint64 internal constant ALWAYS_ALLOW_ID = 0;
+
+    /// @notice Built-in policy ID that always rejects any account.
+    uint64 internal constant ALWAYS_BLOCK_ID = 1;
+}
+
 /// @title MockPolicyRegistry
 /// @notice Reference implementation of the `IPolicyRegistry` precompile.
 ///         Etched at the canonical policy-registry address via `vm.etch`
@@ -37,8 +53,18 @@ contract MockPolicyRegistry is IPolicyRegistry {
     //                         CONSTANTS
     // ============================================================
 
-    uint64 internal constant ALWAYS_ALLOW_ID = 0;
-    uint64 internal constant ALWAYS_BLOCK_ID = 1;
+    /// @notice Built-in policy ID that always authorizes any account.
+    /// @dev    The default value for an unconfigured policy slot.
+    uint64 public constant ALWAYS_ALLOW_ID = PolicyRegistryConstants.ALWAYS_ALLOW_ID;
+
+    /// @notice Built-in policy ID that always rejects any account.
+    /// @dev    Useful as an explicit hard-deny on a slot (e.g. disabling
+    ///         redemption by pointing `REDEEMER_SENDER` here).
+    uint64 public constant ALWAYS_BLOCK_ID = PolicyRegistryConstants.ALWAYS_BLOCK_ID;
+
+    /// @notice First counter value handed out to custom policies. Floors
+    ///         `nextCounter` so the low 56 bits of the first custom ID can
+    ///         never collide with the built-in IDs 0 / 1.
     uint56 internal constant INITIAL_CUSTOM_COUNTER = 2;
 
     // Policy ID encoding: top byte = uint8(PolicyType), low 56 bits = counter.

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -29,34 +29,54 @@ import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20St
 ///            `TokenAlreadyExists`).
 ///         4. Etch the variant-appropriate mock token bytecode at
 ///            the computed address.
-///         5. **Write the token's initial storage directly** via
-///            `vm.store` at the slot offsets declared in
-///            `MockB20Storage`. Production Rust precompiles have full
-///            chain-state access and write storage the same way; this
-///            mock reaches for the same pattern via cheatcode so the
-///            Solidity reference and the Rust impl agree on the slot
-///            layout slot-for-slot. The token has NO factory-only
+///         5. **Write the token's initial identity / supply-cap state
+///            directly** via `vm.store` at the slot offsets declared in
+///            `MockB20Storage`. The token has NO factory-only
 ///            entrypoints; its surface is exactly `IB20`.
-///         6. Dispatch each `initCalls[i]` via low-level `.call()`
+///         6. Emit `TokenCreated` (now WITHOUT an `admin` field —
+///            see step 7).
+///         7. Grant the initial admin role via a single low-level
+///            `token.grantRole(DEFAULT_ADMIN_ROLE, admin)` call during
+///            the bootstrap-privileged window (`!initialized`). This is
+///            the canonical role-grant path: the storage write happens
+///            inside `_grantRole` exactly as it would for any later
+///            `grantRole` call, and it emits the standard
+///            `RoleGranted(DEFAULT_ADMIN_ROLE, admin, factory)` from
+///            the token's own context. There is no separate "bootstrap
+///            admin write" or "TokenCreated.admin" field; the canonical
+///            event for role changes is always `RoleGranted` regardless
+///            of when it fires. Skipped when `admin == address(0)`
+///            (the "demonstrate no owner" path).
+///         8. Dispatch each `initCalls[i]` via low-level `.call()`
 ///            so `msg.sender` arrives at the token as `address(this)`
-///            (the factory). During the bootstrap window
-///            (`!initialized`, set via the same `vm.store`), the token
+///            (the factory). During the bootstrap window the token
 ///            bypasses all authorization gates for factory-originated
 ///            calls per the "fully privileged" semantics on
 ///            `ITokenFactory`.
-///         7. Flip the `initialized` flag (also via `vm.store`),
-///            closing the privileged window. After this point the
-///            factory has no special access; all subsequent operations
-///            on the token go through standard role / policy / pause
-///            checks.
-///         8. Emit `TokenCreated` (which includes `admin`, the
-///            canonical signal for the initial role grant since no
-///            `RoleGranted` event is emitted during direct storage
-///            writes).
+///         9. Flip the `initialized` flag (via `vm.store`), closing the
+///            privileged window. After this point the factory has no
+///            special access; all subsequent operations on the token
+///            go through standard role / policy / pause checks.
 ///
 ///         Token invariants (supply-cap math, balance accounting) are
 ///         NOT bypassed during the privileged window: `initCalls` that
 ///         would violate an invariant still revert.
+///
+///         **Why a `grantRole` call for the initial admin instead of a
+///         direct `vm.store`?** The chain Rust impl will write the role
+///         slot directly AND push the corresponding `RoleGranted` log
+///         atomically — it's one operation from the precompile's
+///         perspective. In Solidity we can't push an LOG with a foreign
+///         emitter address; the LOG opcode uses the executing contract's
+///         address. To get the log to appear emitted from the token,
+///         code must execute at the token's address. The factory's
+///         single `token.grantRole(...)` call is the smallest possible
+///         such call: it goes through the privileged-window bypass (no
+///         extra surface on the token), it writes the same storage slot
+///         the Rust impl would, and it emits the same event. The Rust
+///         impl's behavior matches the *observable result* even though
+///         the path differs (atomic slot-write + log-push vs. a single
+///         self-call frame).
 contract MockTokenFactory is ITokenFactory {
     /// @dev Hardcoded forge-std VM address. The factory uses `vm.etch`
     ///      to plant token bytecode at the deterministic address and
@@ -116,38 +136,47 @@ contract MockTokenFactory is ITokenFactory {
             vm.etch(token, type(MockB20Stablecoin).runtimeCode);
         }
 
-        // -- 5. Write initial storage directly via vm.store. No call
-        //       into the token; storage layout is the contract between
-        //       this factory and the Rust impl, which writes the same
-        //       slots the same way.
-        _writeBaseStorage(token, name_, symbol_, admin);
+        // -- 5. Write initial identity / supply-cap state via vm.store.
+        //       The admin role is NOT written here; it goes through the
+        //       canonical grantRole path in step 7 so RoleGranted fires
+        //       from the token.
+        _writeBaseStorage(token, name_, symbol_);
         if (variant == TokenVariant.STABLECOIN) {
             _writeStablecoinStorage(token, currency_);
         }
 
-        // -- 6. Emit creation event BEFORE initCalls dispatch (per
-        //       ITokenFactory natspec) so init-call effects appear
-        //       strictly after the creation event in the log order.
-        //       Includes admin since there's no separate RoleGranted
-        //       at bootstrap.
-        emit TokenCreated(token, variant, name_, symbol_, decimals, admin);
+        // -- 6. Emit TokenCreated. Identity-only signal; admin role
+        //       assignment is announced via the standard RoleGranted
+        //       event from step 7.
+        emit TokenCreated(token, variant, name_, symbol_, decimals);
 
-        // -- 7. Dispatch initCalls. msg.sender at the token is
-        //       address(this) == factory, and `initialized` is still
-        //       false (default zero in the freshly-written storage),
-        //       so the token's _isPrivileged() returns true and gates
-        //       are bypassed. Init-call reverts roll up to abort the
-        //       whole creation.
+        // -- 7. Grant the initial admin role via the canonical path.
+        //       msg.sender at the token is address(this) == factory,
+        //       and `initialized` is still false (default zero from
+        //       fresh storage), so _isPrivileged() returns true and the
+        //       role-admin check is bypassed. The grantRole call writes
+        //       the role slot AND emits RoleGranted from the token.
+        //       Skipped on the zero-admin path.
+        if (admin != address(0)) {
+            MockB20(token).grantRole(DEFAULT_ADMIN_ROLE, admin);
+        }
+
+        // -- 8. Dispatch initCalls. Same privileged-window bypass as
+        //       step 7; init-call reverts roll up to abort the whole
+        //       creation.
         for (uint256 i = 0; i < initCalls.length; i++) {
             (bool ok,) = token.call(initCalls[i]);
             if (!ok) revert InitCallFailed(i);
         }
 
-        // -- 8. Close the bootstrap window by setting initialized=true.
+        // -- 9. Close the bootstrap window by setting initialized=true.
         //       After this, the factory's privilege is gone; only
         //       role / policy / pause holders can mutate state.
         _writeBool(token, MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET), true);
     }
+
+    /// @dev `DEFAULT_ADMIN_ROLE` per OZ AccessControl convention.
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
 
     /// @inheritdoc ITokenFactory
     function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
@@ -208,28 +237,17 @@ contract MockTokenFactory is ITokenFactory {
     // ERC-7201 namespace are the storage-layout contract between the
     // two implementations.
 
-    /// @dev Writes the identity + role + supply-cap state every B-20
-    ///      starts with. Mappings get derived slots via the standard
-    ///      Solidity rule: `keccak256(abi.encode(key, baseSlot))`.
-    function _writeBaseStorage(address token, string memory name_, string memory symbol_, address admin) internal {
+    /// @dev Writes the identity + supply-cap state every B-20 starts
+    ///      with. The admin role is NOT written here — see the
+    ///      `grantRole` call in `createToken` step 7 for why.
+    function _writeBaseStorage(address token, string memory name_, string memory symbol_) internal {
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET), name_);
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.SYMBOL_OFFSET), symbol_);
         _writeUint(token, MockB20Storage.slotOf(MockB20Storage.SUPPLY_CAP_OFFSET), type(uint256).max);
-
-        if (admin != address(0)) {
-            // roles[DEFAULT_ADMIN_ROLE][admin] = true
-            // Mapping slot derivation: m[k] is at keccak256(abi.encode(k, baseSlot)),
-            // where baseSlot is the mapping field's ABSOLUTE storage slot.
-            bytes32 rolesBaseSlot = MockB20Storage.slotOf(MockB20Storage.ROLES_OFFSET);
-            bytes32 outerSlot = keccak256(abi.encode(bytes32(0), rolesBaseSlot));
-            bytes32 innerSlot = keccak256(abi.encode(admin, outerSlot));
-            _writeBool(token, innerSlot, true);
-            // adminCount = 1
-            _writeUint(token, MockB20Storage.slotOf(MockB20Storage.ADMIN_COUNT_OFFSET), 1);
-        }
-        // Everything else (totalSupply, allowances, roleAdmins, policyIds,
-        // pausedVectors, nonces, contractURI, initialized) defaults to the
-        // EVM's zero state, which is correct for a fresh token.
+        // Everything else (totalSupply, allowances, roles, roleAdmins,
+        // adminCount, packedPolicyIds, extraPolicyIds, pausedVectors,
+        // nonces, contractURI, initialized) defaults to the EVM's zero
+        // state, which is correct for a fresh token.
     }
 
     /// @dev Writes the stablecoin variant's `currency` field at its

--- a/test/unit/B20/erc20/name.t.sol
+++ b/test/unit/B20/erc20/name.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20NameTest is B20Test {
     /// @notice Verifies name returns the value passed to the factory at creation
@@ -15,7 +16,7 @@ contract B20NameTest is B20Test {
     /// @dev Mutable-metadata readback; canonical setter test lives in setName.t.sol.
     ///      setName requires METADATA_ROLE, which is held by no one by default.
     function test_name_success_reflectsSetName(string calldata newName) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.setName(newName);
         assertEq(token.name(), newName, "name must reflect setName");

--- a/test/unit/B20/erc20/symbol.t.sol
+++ b/test/unit/B20/erc20/symbol.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SymbolTest is B20Test {
     /// @notice Verifies symbol returns the value passed to the factory at creation
@@ -15,7 +16,7 @@ contract B20SymbolTest is B20Test {
     /// @dev Mutable-metadata readback; canonical setter test lives in setSymbol.t.sol.
     ///      setSymbol requires METADATA_ROLE, which is held by no one by default.
     function test_symbol_success_reflectsSetSymbol(string calldata newSymbol) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.setSymbol(newSymbol);
         assertEq(token.symbol(), newSymbol, "symbol must reflect setSymbol");

--- a/test/unit/B20/erc20/totalSupply.t.sol
+++ b/test/unit/B20/erc20/totalSupply.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20TotalSupplyTest is B20Test {
     /// @notice Verifies totalSupply returns the cumulative minted-minus-burned amount
@@ -15,7 +16,7 @@ contract B20TotalSupplyTest is B20Test {
         assertEq(token.totalSupply(), mintAmount, "totalSupply after mint");
 
         // Grant BURN_ROLE to the recipient so they can burn from their own balance.
-        _grantRole(BURN_ROLE, to);
+        _grantRole(B20Constants.BURN_ROLE, to);
         vm.prank(to);
         token.burn(burnAmount);
         assertEq(token.totalSupply(), mintAmount - burnAmount, "totalSupply after burn");

--- a/test/unit/B20/erc20/transfer.t.sol
+++ b/test/unit/B20/erc20/transfer.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20TransferTest is B20Test {
     /// @notice Verifies transfer reverts when the TRANSFER feature is paused
@@ -23,10 +25,10 @@ contract B20TransferTest is B20Test {
     function test_transfer_revert_senderPolicyForbids(address from, address to, uint256 amount) public {
         _assumeValidActor(from);
         _assumeValidActor(to);
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(from);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_SENDER, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transfer(to, amount);
     }
 
@@ -35,10 +37,10 @@ contract B20TransferTest is B20Test {
     function test_transfer_revert_receiverPolicyForbids(address from, address to, uint256 amount) public {
         _assumeValidActor(from);
         _assumeValidActor(to);
-        _setPolicy(TRANSFER_RECEIVER, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(from);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_RECEIVER, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transfer(to, amount);
     }
 

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20TransferFromTest is B20Test {
     /// @notice Verifies transferFrom reverts when the TRANSFER feature is paused
@@ -41,10 +43,10 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(TRANSFER_EXECUTOR, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_EXECUTOR, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 
@@ -61,10 +63,10 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_SENDER, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 
@@ -81,10 +83,10 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(TRANSFER_RECEIVER, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, TRANSFER_RECEIVER, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 

--- a/test/unit/B20/memo/burnWithMemo.t.sol
+++ b/test/unit/B20/memo/burnWithMemo.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20BurnWithMemoTest is B20Test {
     /// @notice Verifies burnWithMemo inherits all burn guards
@@ -13,7 +14,7 @@ contract B20BurnWithMemoTest is B20Test {
         // alice has no BURN_ROLE.
         vm.prank(alice);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, BURN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, B20Constants.BURN_ROLE)
         );
         token.burnWithMemo(amount, memo);
     }
@@ -21,7 +22,7 @@ contract B20BurnWithMemoTest is B20Test {
     /// @notice Verifies burnWithMemo debits caller and decreases totalSupply
     /// @dev Accounting unchanged from burn; the memo does not alter accounting
     function test_burnWithMemo_success_debitsAndDecreasesSupply(uint256 amount, bytes32 memo) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _mint(burner, amount);
 
         uint256 supplyBefore = token.totalSupply();
@@ -36,7 +37,7 @@ contract B20BurnWithMemoTest is B20Test {
     /// @notice Verifies burnWithMemo emits Transfer(caller, address(0), amount) then Memo(memo)
     /// @dev Event ordering: Memo follows Transfer; canonical Memo test for the burn path
     function test_burnWithMemo_success_emitsTransferThenMemo(uint256 amount, bytes32 memo) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _mint(burner, amount);
 
         vm.expectEmit(true, true, false, true, address(token));

--- a/test/unit/B20/memo/mintWithMemo.t.sol
+++ b/test/unit/B20/memo/mintWithMemo.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20MintWithMemoTest is B20Test {
     /// @notice Verifies mintWithMemo inherits all mint guards
@@ -15,7 +16,7 @@ contract B20MintWithMemoTest is B20Test {
 
         vm.prank(alice);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, MINT_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, alice, B20Constants.MINT_ROLE)
         );
         token.mintWithMemo(to, amount, memo);
     }
@@ -24,7 +25,7 @@ contract B20MintWithMemoTest is B20Test {
     /// @dev Accounting unchanged from mint; the memo does not alter accounting
     function test_mintWithMemo_success_creditsAndUpdatesSupply(address to, uint256 amount, bytes32 memo) public {
         _assumeValidActor(to);
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
 
         uint256 supplyBefore = token.totalSupply();
         uint256 balBefore = token.balanceOf(to);
@@ -40,7 +41,7 @@ contract B20MintWithMemoTest is B20Test {
     /// @dev Event ordering: Memo follows Transfer; canonical Memo test for the mint path
     function test_mintWithMemo_success_emitsTransferThenMemo(address to, uint256 amount, bytes32 memo) public {
         _assumeValidActor(to);
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
 
         vm.expectEmit(true, true, false, true, address(token));
         emit IB20.Transfer(address(0), to, amount);

--- a/test/unit/B20/metadata/setContractURI.t.sol
+++ b/test/unit/B20/metadata/setContractURI.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SetContractURITest is B20Test {
     /// @notice Verifies setContractURI reverts when caller lacks DEFAULT_ADMIN_ROLE
@@ -14,7 +15,7 @@ contract B20SetContractURITest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.setContractURI(newURI);
     }

--- a/test/unit/B20/metadata/setName.t.sol
+++ b/test/unit/B20/metadata/setName.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SetNameTest is B20Test {
     /// @notice Verifies setName reverts when caller lacks METADATA_ROLE
@@ -14,11 +15,11 @@ contract B20SetNameTest is B20Test {
         _assumeValidCaller(caller);
         // Admin doesn't hold METADATA_ROLE by default either; only filter out callers we've
         // explicitly granted the role.
-        vm.assume(!token.hasRole(METADATA_ROLE, caller));
+        vm.assume(!token.hasRole(B20Constants.METADATA_ROLE, caller));
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, METADATA_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.METADATA_ROLE)
         );
         token.setName(newName);
     }
@@ -26,7 +27,7 @@ contract B20SetNameTest is B20Test {
     /// @notice Verifies setName updates name() to the new value
     /// @dev Read-after-write; canonical name readback test lives in name.t.sol
     function test_setName_success_updatesName(string calldata newName) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.setName(newName);
         assertEq(token.name(), newName, "name() must return the new value");
@@ -35,7 +36,7 @@ contract B20SetNameTest is B20Test {
     /// @notice Verifies setName emits NameUpdated(updater, newName)
     /// @dev Event integrity; canonical NameUpdated emission test
     function test_setName_success_emitsNameUpdated(string calldata newName) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.NameUpdated(admin, newName);
         vm.prank(admin);

--- a/test/unit/B20/metadata/setSymbol.t.sol
+++ b/test/unit/B20/metadata/setSymbol.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol reverts when caller lacks METADATA_ROLE
@@ -11,11 +12,11 @@ contract B20SetSymbolTest is B20Test {
     ///      DEFAULT_ADMIN_ROLE per IB20 spec). Checks AccessControlUnauthorizedAccount.
     function test_setSymbol_revert_unauthorized(address caller, string calldata newSymbol) public {
         _assumeValidCaller(caller);
-        vm.assume(!token.hasRole(METADATA_ROLE, caller));
+        vm.assume(!token.hasRole(B20Constants.METADATA_ROLE, caller));
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, METADATA_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.METADATA_ROLE)
         );
         token.setSymbol(newSymbol);
     }
@@ -23,7 +24,7 @@ contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol updates symbol() to the new value
     /// @dev Read-after-write; canonical symbol readback test lives in symbol.t.sol
     function test_setSymbol_success_updatesSymbol(string calldata newSymbol) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.setSymbol(newSymbol);
         assertEq(token.symbol(), newSymbol, "symbol() must return the new value");
@@ -32,7 +33,7 @@ contract B20SetSymbolTest is B20Test {
     /// @notice Verifies setSymbol emits SymbolUpdated(updater, newSymbol)
     /// @dev Event integrity; canonical SymbolUpdated emission test
     function test_setSymbol_success_emitsSymbolUpdated(string calldata newSymbol) public {
-        _grantRole(METADATA_ROLE, admin);
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.SymbolUpdated(admin, newSymbol);
         vm.prank(admin);

--- a/test/unit/B20/pause/isPaused.t.sol
+++ b/test/unit/B20/pause/isPaused.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20IsPausedTest is B20Test {
     /// @notice Verifies isPaused returns false for every feature on a freshly-created token
@@ -28,7 +29,7 @@ contract B20IsPausedTest is B20Test {
     function test_isPaused_success_falseAfterUnpause(uint8 featureInt) public {
         IB20.PausableFeature feature = IB20.PausableFeature(uint8(bound(uint256(featureInt), 0, 3)));
         _pause(feature);
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
         vm.prank(unpauser);
         token.unpause(_singleFeature(feature));
         assertFalse(token.isPaused(feature), "feature must be unpaused after unpause call");

--- a/test/unit/B20/pause/pause.t.sol
+++ b/test/unit/B20/pause/pause.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20PauseTest is B20Test {
     /// @notice Verifies pause reverts when caller lacks PAUSE_ROLE
@@ -15,7 +16,7 @@ contract B20PauseTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, PAUSE_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.PAUSE_ROLE)
         );
         token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
     }
@@ -23,7 +24,7 @@ contract B20PauseTest is B20Test {
     /// @notice Verifies pause reverts for an empty features array
     /// @dev Input validation: empty pause set is meaningless; checks EmptyFeatureSet() error
     function test_pause_revert_emptyFeatureSet() public {
-        _grantRole(PAUSE_ROLE, pauser);
+        _grantRole(B20Constants.PAUSE_ROLE, pauser);
 
         vm.prank(pauser);
         vm.expectRevert(IB20.EmptyFeatureSet.selector);
@@ -33,7 +34,7 @@ contract B20PauseTest is B20Test {
     /// @notice Verifies pause sets each listed feature in pausedFeatures
     /// @dev State transition: each feature becomes observable via isPaused after the call
     function test_pause_success_setsFeatures() public {
-        _grantRole(PAUSE_ROLE, pauser);
+        _grantRole(B20Constants.PAUSE_ROLE, pauser);
 
         IB20.PausableFeature[] memory features = new IB20.PausableFeature[](2);
         features[0] = IB20.PausableFeature.TRANSFER;
@@ -51,7 +52,7 @@ contract B20PauseTest is B20Test {
     /// @notice Verifies pause is additive over multiple calls
     /// @dev Sequential pauses union into the existing set; prior features remain paused
     function test_pause_success_additiveAcrossCalls() public {
-        _grantRole(PAUSE_ROLE, pauser);
+        _grantRole(B20Constants.PAUSE_ROLE, pauser);
 
         vm.prank(pauser);
         token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
@@ -65,7 +66,7 @@ contract B20PauseTest is B20Test {
     /// @notice Verifies pause is idempotent when called with already-paused features
     /// @dev Duplicate entries do not change state and do not revert
     function test_pause_success_idempotent() public {
-        _grantRole(PAUSE_ROLE, pauser);
+        _grantRole(B20Constants.PAUSE_ROLE, pauser);
 
         vm.prank(pauser);
         token.pause(_singleFeature(IB20.PausableFeature.TRANSFER));
@@ -79,7 +80,7 @@ contract B20PauseTest is B20Test {
     /// @notice Verifies pause emits Paused(caller, features) with the call's argument
     /// @dev Event integrity; canonical Paused emission test
     function test_pause_success_emitsPaused() public {
-        _grantRole(PAUSE_ROLE, pauser);
+        _grantRole(B20Constants.PAUSE_ROLE, pauser);
 
         IB20.PausableFeature[] memory features = _singleFeature(IB20.PausableFeature.TRANSFER);
 

--- a/test/unit/B20/pause/pausedFeatures.t.sol
+++ b/test/unit/B20/pause/pausedFeatures.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20PausedFeaturesTest is B20Test {
     /// @notice Verifies pausedFeatures returns an empty array on a freshly-created token
@@ -34,7 +35,7 @@ contract B20PausedFeaturesTest is B20Test {
         _pause(IB20.PausableFeature.MINT);
         _pause(IB20.PausableFeature.BURN);
 
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
         vm.prank(unpauser);
         token.unpause(_singleFeature(IB20.PausableFeature.MINT));
 

--- a/test/unit/B20/pause/unpause.t.sol
+++ b/test/unit/B20/pause/unpause.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause reverts when caller lacks UNPAUSE_ROLE
@@ -14,7 +15,7 @@ contract B20UnpauseTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, UNPAUSE_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.UNPAUSE_ROLE)
         );
         token.unpause(_singleFeature(IB20.PausableFeature.TRANSFER));
     }
@@ -22,7 +23,7 @@ contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause reverts for an empty features array
     /// @dev Input validation: empty unpause set is meaningless; checks EmptyFeatureSet() error
     function test_unpause_revert_emptyFeatureSet() public {
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
 
         vm.prank(unpauser);
         vm.expectRevert(IB20.EmptyFeatureSet.selector);
@@ -32,7 +33,7 @@ contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause clears each listed feature from pausedFeatures
     /// @dev State transition: each feature is removed; non-listed features remain unchanged
     function test_unpause_success_clearsListedFeatures() public {
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
 
         // Pause two features so we have something to unpause.
         _pause(IB20.PausableFeature.TRANSFER);
@@ -49,7 +50,7 @@ contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause is idempotent when called with not-currently-paused features
     /// @dev No state change and no revert for features that are already inactive
     function test_unpause_success_idempotentForUnpaused() public {
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
 
         // BURN is not paused.
         vm.prank(unpauser);
@@ -61,7 +62,7 @@ contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause emits Unpaused(caller, features) with the call's argument
     /// @dev Event integrity; canonical Unpaused emission test
     function test_unpause_success_emitsUnpaused() public {
-        _grantRole(UNPAUSE_ROLE, unpauser);
+        _grantRole(B20Constants.UNPAUSE_ROLE, unpauser);
         _pause(IB20.PausableFeature.TRANSFER);
 
         IB20.PausableFeature[] memory features = _singleFeature(IB20.PausableFeature.TRANSFER);

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -2,19 +2,20 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns 0 (always-allow built-in) for any unconfigured slot
     /// @dev Default state: newly-created tokens are unrestricted across all policy slots
     function test_policyId_success_zeroByDefault(bytes32 policyType) public view {
-        assertEq(token.policyId(policyType), ALWAYS_ALLOW, "unconfigured slot must default to ALWAYS_ALLOW (0)");
+        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "unconfigured slot must default to PolicyRegistryConstants.ALWAYS_ALLOW_ID (0)");
     }
 
     /// @notice Verifies policyId returns the value most recently set via updatePolicy
     /// @dev Read-after-write for the slot mapping
     function test_policyId_success_reflectsUpdatePolicy(bytes32 policyType, uint64 newPolicyId) public {
         // MockPolicyRegistry only knows the two built-in sentinel ids.
-        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
         _setPolicy(policyType, newPolicyId);
         assertEq(token.policyId(policyType), newPolicyId, "slot must reflect updatePolicy");
     }
@@ -22,7 +23,7 @@ contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId accepts arbitrary bytes32 keys, not just the standard constants
     /// @dev User-defined policy types are supported for periphery layering
     function test_policyId_success_arbitraryKeysAllowed(bytes32 customType, uint64 newPolicyId) public {
-        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
         _setPolicy(customType, newPolicyId);
         assertEq(token.policyId(customType), newPolicyId, "arbitrary key must be writable");
     }

--- a/test/unit/B20/policy/policyTypeConstants.t.sol
+++ b/test/unit/B20/policy/policyTypeConstants.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 /// @notice Folds the four trivial policy-type identifier constant readers
 ///         into one file since each is a one-stub assertion against a
@@ -11,28 +12,28 @@ contract B20PolicyTypeConstantsTest is B20Test {
     /// @notice Verifies TRANSFER_SENDER returns keccak256("TRANSFER_SENDER")
     /// @dev Identifier stability for off-chain consumers
     function test_TRANSFER_SENDER_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_SENDER(), keccak256("TRANSFER_SENDER"), "TRANSFER_SENDER digest");
-        assertEq(token.TRANSFER_SENDER(), TRANSFER_SENDER, "must match B20Test's local constant");
+        assertEq(token.TRANSFER_SENDER(), keccak256("TRANSFER_SENDER"), "B20Constants.TRANSFER_SENDER digest");
+        assertEq(token.TRANSFER_SENDER(), B20Constants.TRANSFER_SENDER, "must match B20Test's local constant");
     }
 
     /// @notice Verifies TRANSFER_RECEIVER returns keccak256("TRANSFER_RECEIVER")
     /// @dev Identifier stability for off-chain consumers
     function test_TRANSFER_RECEIVER_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_RECEIVER(), keccak256("TRANSFER_RECEIVER"), "TRANSFER_RECEIVER digest");
-        assertEq(token.TRANSFER_RECEIVER(), TRANSFER_RECEIVER, "must match B20Test's local constant");
+        assertEq(token.TRANSFER_RECEIVER(), keccak256("TRANSFER_RECEIVER"), "B20Constants.TRANSFER_RECEIVER digest");
+        assertEq(token.TRANSFER_RECEIVER(), B20Constants.TRANSFER_RECEIVER, "must match B20Test's local constant");
     }
 
     /// @notice Verifies TRANSFER_EXECUTOR returns keccak256("TRANSFER_EXECUTOR")
     /// @dev Identifier stability for off-chain consumers
     function test_TRANSFER_EXECUTOR_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_EXECUTOR(), keccak256("TRANSFER_EXECUTOR"), "TRANSFER_EXECUTOR digest");
-        assertEq(token.TRANSFER_EXECUTOR(), TRANSFER_EXECUTOR, "must match B20Test's local constant");
+        assertEq(token.TRANSFER_EXECUTOR(), keccak256("TRANSFER_EXECUTOR"), "B20Constants.TRANSFER_EXECUTOR digest");
+        assertEq(token.TRANSFER_EXECUTOR(), B20Constants.TRANSFER_EXECUTOR, "must match B20Test's local constant");
     }
 
     /// @notice Verifies MINT_RECEIVER returns keccak256("MINT_RECEIVER")
     /// @dev Identifier stability for off-chain consumers
     function test_MINT_RECEIVER_success_matchesExpected() public view {
-        assertEq(token.MINT_RECEIVER(), keccak256("MINT_RECEIVER"), "MINT_RECEIVER digest");
-        assertEq(token.MINT_RECEIVER(), MINT_RECEIVER, "must match B20Test's local constant");
+        assertEq(token.MINT_RECEIVER(), keccak256("MINT_RECEIVER"), "B20Constants.MINT_RECEIVER digest");
+        assertEq(token.MINT_RECEIVER(), B20Constants.MINT_RECEIVER, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy reverts when caller lacks DEFAULT_ADMIN_ROLE
@@ -14,7 +16,7 @@ contract B20UpdatePolicyTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.updatePolicy(policyType, newPolicyId);
     }
@@ -23,7 +25,7 @@ contract B20UpdatePolicyTest is B20Test {
     /// @dev Cross-precompile guard; checks PolicyNotFound() error.
     ///      MockPolicyRegistry only knows ids 0 and type(uint64).max; everything else is unknown.
     function test_updatePolicy_revert_policyNotFound(bytes32 policyType, uint64 newPolicyId) public {
-        vm.assume(newPolicyId != ALWAYS_ALLOW && newPolicyId != ALWAYS_REJECT);
+        vm.assume(newPolicyId != PolicyRegistryConstants.ALWAYS_ALLOW_ID && newPolicyId != PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));
@@ -33,34 +35,34 @@ contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
     /// @dev Built-ins are always valid targets
     function test_updatePolicy_success_builtinAllow(bytes32 policyType) public {
-        _setPolicy(policyType, ALWAYS_ALLOW);
-        assertEq(token.policyId(policyType), ALWAYS_ALLOW, "slot must be ALWAYS_ALLOW");
+        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be PolicyRegistryConstants.ALWAYS_ALLOW_ID");
     }
 
     /// @notice Verifies updatePolicy succeeds for built-in id type(uint64).max (always-reject)
     /// @dev Built-ins are always valid targets
     function test_updatePolicy_success_builtinReject(bytes32 policyType) public {
-        _setPolicy(policyType, ALWAYS_REJECT);
-        assertEq(token.policyId(policyType), ALWAYS_REJECT, "slot must be ALWAYS_REJECT");
+        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be PolicyRegistryConstants.ALWAYS_BLOCK_ID");
     }
 
     /// @notice Verifies updatePolicy writes the new id to the slot
     /// @dev Read-after-write: policyId(policyType) returns newPolicyId
     function test_updatePolicy_success_writesSlot(bytes32 policyType, uint64 newPolicyId) public {
         // Bound to a registry-supported id.
-        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
         _setPolicy(policyType, newPolicyId);
         assertEq(token.policyId(policyType), newPolicyId, "slot must equal newPolicyId after write");
     }
 
     /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)
     /// @dev Event integrity; canonical PolicyUpdated emission test.
-    ///      Fresh slot has oldId == ALWAYS_ALLOW (0); the first write transitions from there.
+    ///      Fresh slot has oldId == ALWAYS_ALLOW_ID (0); the first write transitions from there.
     function test_updatePolicy_success_emitsPolicyUpdated(bytes32 policyType, uint64 newPolicyId) public {
-        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.expectEmit(true, false, false, true, address(token));
-        emit IB20.PolicyUpdated(policyType, ALWAYS_ALLOW, newPolicyId);
+        emit IB20.PolicyUpdated(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);
         _setPolicy(policyType, newPolicyId);
     }
 }

--- a/test/unit/B20/roles/getRoleAdmin.t.sol
+++ b/test/unit/B20/roles/getRoleAdmin.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20GetRoleAdminTest is B20Test {
     /// @notice Verifies getRoleAdmin returns DEFAULT_ADMIN_ROLE for any role that hasn't been customized
@@ -9,8 +10,8 @@ contract B20GetRoleAdminTest is B20Test {
     ///      DEFAULT_ADMIN_ROLE itself is its own admin (returns bytes32(0)), so filter that out here;
     ///      that special case is covered implicitly by the setRoleAdmin-emits test.
     function test_getRoleAdmin_success_defaultsToAdminRole(bytes32 role) public view {
-        vm.assume(role != DEFAULT_ADMIN_ROLE);
-        assertEq(token.getRoleAdmin(role), DEFAULT_ADMIN_ROLE, "default admin must be DEFAULT_ADMIN_ROLE");
+        vm.assume(role != B20Constants.DEFAULT_ADMIN_ROLE);
+        assertEq(token.getRoleAdmin(role), B20Constants.DEFAULT_ADMIN_ROLE, "default admin must be B20Constants.DEFAULT_ADMIN_ROLE");
     }
 
     /// @notice Verifies getRoleAdmin returns the new admin role after setRoleAdmin

--- a/test/unit/B20/roles/grantRole.t.sol
+++ b/test/unit/B20/roles/grantRole.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20GrantRoleTest is B20Test {
     /// @notice Verifies grantRole reverts when caller does not hold the role's admin role
@@ -16,7 +17,7 @@ contract B20GrantRoleTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.grantRole(role, account);
     }
@@ -47,7 +48,7 @@ contract B20GrantRoleTest is B20Test {
     /// @dev Event integrity; canonical RoleGranted emission test
     function test_grantRole_success_emitsRoleGranted(bytes32 role, address account) public {
         // Filter the bootstrap admin grant (already held, idempotent → no emit).
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
 
         vm.expectEmit(true, true, true, false, address(token));
         emit IB20.RoleGranted(role, account, admin);

--- a/test/unit/B20/roles/hasRole.t.sol
+++ b/test/unit/B20/roles/hasRole.t.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20HasRoleTest is B20Test {
     /// @notice Verifies hasRole returns false for any (role, account) pair that has never been granted
     /// @dev Default state across the role and address space. Filters out the bootstrap admin grant
     ///      (DEFAULT_ADMIN_ROLE, admin) since that pair IS held after creation.
     function test_hasRole_success_falseByDefault(bytes32 role, address account) public view {
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
         assertFalse(token.hasRole(role, account), "untouched (role, account) pair must be unheld");
     }
 
@@ -24,7 +25,7 @@ contract B20HasRoleTest is B20Test {
     ///      admin (which would underflow adminCount semantics via revoke; the user must use
     ///      renounceLastAdmin for that transition, covered elsewhere).
     function test_hasRole_success_falseAfterRevoke(bytes32 role, address account) public {
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
         _grantRole(role, account);
         vm.prank(admin);
         token.revokeRole(role, account);

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20RenounceLastAdminTest is B20Test {
     /// @notice Verifies renounceLastAdmin reverts when caller does not hold DEFAULT_ADMIN_ROLE
@@ -16,7 +18,7 @@ contract B20RenounceLastAdminTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.renounceLastAdmin();
     }
@@ -30,7 +32,7 @@ contract B20RenounceLastAdminTest is B20Test {
         _assumeValidActor(otherAdmin);
         vm.assume(otherAdmin != admin);
 
-        _grantRole(DEFAULT_ADMIN_ROLE, otherAdmin);
+        _grantRole(B20Constants.DEFAULT_ADMIN_ROLE, otherAdmin);
 
         vm.prank(admin);
         vm.expectRevert(IB20.NotSoleAdmin.selector);
@@ -40,12 +42,12 @@ contract B20RenounceLastAdminTest is B20Test {
     /// @notice Verifies renounceLastAdmin clears DEFAULT_ADMIN_ROLE from the caller
     /// @dev    Read-after-write: hasRole(DEFAULT_ADMIN_ROLE, msg.sender) is false post-call.
     function test_renounceLastAdmin_success_clearsAdminRole() public {
-        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "precondition: admin holds DEFAULT_ADMIN_ROLE");
+        assertTrue(token.hasRole(B20Constants.DEFAULT_ADMIN_ROLE, admin), "precondition: admin holds B20Constants.DEFAULT_ADMIN_ROLE");
 
         vm.prank(admin);
         token.renounceLastAdmin();
 
-        assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "admin no longer holds DEFAULT_ADMIN_ROLE");
+        assertFalse(token.hasRole(B20Constants.DEFAULT_ADMIN_ROLE, admin), "admin no longer holds B20Constants.DEFAULT_ADMIN_ROLE");
     }
 
     /// @notice Verifies admin-gated operations revert after renounceLastAdmin
@@ -57,7 +59,7 @@ contract B20RenounceLastAdminTest is B20Test {
     function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyType, uint64 newPolicyId) public {
         // Use a built-in policy ID so updatePolicy gets past policyExists() and would
         // otherwise succeed; the revert here is from the role check, not policy validation.
-        newPolicyId = newPolicyId % 2 == 0 ? ALWAYS_ALLOW : ALWAYS_REJECT;
+        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.prank(admin);
         token.renounceLastAdmin();
@@ -65,7 +67,7 @@ contract B20RenounceLastAdminTest is B20Test {
         // The original admin is no longer admin and cannot reach the admin-only setter.
         vm.prank(admin);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, admin, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, admin, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.updatePolicy(policyType, newPolicyId);
     }
@@ -82,9 +84,9 @@ contract B20RenounceLastAdminTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
-        token.grantRole(DEFAULT_ADMIN_ROLE, wouldBeNewAdmin);
+        token.grantRole(B20Constants.DEFAULT_ADMIN_ROLE, wouldBeNewAdmin);
     }
 
     /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)

--- a/test/unit/B20/roles/renounceRole.t.sol
+++ b/test/unit/B20/roles/renounceRole.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20RenounceRoleTest is B20Test {
     /// @notice Verifies renounceRole reverts when callerConfirmation does not equal msg.sender
@@ -27,7 +28,7 @@ contract B20RenounceRoleTest is B20Test {
         // Bootstrap admin is the only admin (adminCount == 1).
         vm.prank(admin);
         vm.expectRevert(IB20.LastAdminCannotRenounce.selector);
-        token.renounceRole(DEFAULT_ADMIN_ROLE, admin);
+        token.renounceRole(B20Constants.DEFAULT_ADMIN_ROLE, admin);
     }
 
     /// @notice Verifies renounceRole sets hasRole(role, caller) to false
@@ -36,7 +37,7 @@ contract B20RenounceRoleTest is B20Test {
         _assumeValidCaller(caller);
         // Skip DEFAULT_ADMIN_ROLE here: that path has its own last-admin guard tested above
         // and an "admin with others" success test below.
-        vm.assume(role != DEFAULT_ADMIN_ROLE);
+        vm.assume(role != B20Constants.DEFAULT_ADMIN_ROLE);
 
         _grantRole(role, caller);
         assertTrue(token.hasRole(role, caller), "precondition");
@@ -52,20 +53,20 @@ contract B20RenounceRoleTest is B20Test {
         _assumeValidActor(otherAdmin);
         vm.assume(otherAdmin != admin);
 
-        _grantRole(DEFAULT_ADMIN_ROLE, otherAdmin);
+        _grantRole(B20Constants.DEFAULT_ADMIN_ROLE, otherAdmin);
 
         vm.prank(admin);
-        token.renounceRole(DEFAULT_ADMIN_ROLE, admin);
+        token.renounceRole(B20Constants.DEFAULT_ADMIN_ROLE, admin);
 
-        assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin), "original admin no longer admin");
-        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, otherAdmin), "other admin still admin");
+        assertFalse(token.hasRole(B20Constants.DEFAULT_ADMIN_ROLE, admin), "original admin no longer admin");
+        assertTrue(token.hasRole(B20Constants.DEFAULT_ADMIN_ROLE, otherAdmin), "other admin still admin");
     }
 
     /// @notice Verifies renounceRole emits RoleRevoked(role, caller, caller)
     /// @dev Sender equals account for self-revocation; canonical RoleRevoked test lives in revokeRole.t.sol
     function test_renounceRole_success_emitsRoleRevoked(address caller, bytes32 role) public {
         _assumeValidCaller(caller);
-        vm.assume(role != DEFAULT_ADMIN_ROLE);
+        vm.assume(role != B20Constants.DEFAULT_ADMIN_ROLE);
 
         _grantRole(role, caller);
 

--- a/test/unit/B20/roles/revokeRole.t.sol
+++ b/test/unit/B20/roles/revokeRole.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20RevokeRoleTest is B20Test {
     /// @notice Verifies revokeRole reverts when caller does not hold the role's admin role
@@ -14,7 +15,7 @@ contract B20RevokeRoleTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.revokeRole(role, account);
     }
@@ -24,7 +25,7 @@ contract B20RevokeRoleTest is B20Test {
     ///      Skips revoking DEFAULT_ADMIN_ROLE from the sole bootstrap admin
     ///      (would require renounceLastAdmin instead, covered in that file).
     function test_revokeRole_success_clearsRole(bytes32 role, address account) public {
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
         _grantRole(role, account);
 
         vm.prank(admin);
@@ -35,7 +36,7 @@ contract B20RevokeRoleTest is B20Test {
     /// @notice Verifies revokeRole is idempotent when the account does not hold the role
     /// @dev No-op for not-held accounts; no revert, no duplicate event.
     function test_revokeRole_success_idempotent(bytes32 role, address account) public {
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
         assertFalse(token.hasRole(role, account), "precondition: role not held");
 
         vm.recordLogs();
@@ -49,7 +50,7 @@ contract B20RevokeRoleTest is B20Test {
     /// @notice Verifies revokeRole emits RoleRevoked(role, account, sender) when an actual revoke occurs
     /// @dev Event integrity; canonical RoleRevoked emission test
     function test_revokeRole_success_emitsRoleRevoked(bytes32 role, address account) public {
-        vm.assume(!(role == DEFAULT_ADMIN_ROLE && account == admin));
+        vm.assume(!(role == B20Constants.DEFAULT_ADMIN_ROLE && account == admin));
         _grantRole(role, account);
 
         vm.expectEmit(true, true, true, false, address(token));

--- a/test/unit/B20/roles/roleConstants.t.sol
+++ b/test/unit/B20/roles/roleConstants.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 /// @notice Folds the seven trivial role-identifier constant readers into one
 ///         file since each is a one-stub assertion against a fixed keccak
@@ -11,51 +12,51 @@ contract B20RoleConstantsTest is B20Test {
     /// @notice Verifies DEFAULT_ADMIN_ROLE returns the OZ AccessControl default value (bytes32(0))
     /// @dev Matches OZ's `DEFAULT_ADMIN_ROLE = 0x00` convention
     function test_DEFAULT_ADMIN_ROLE_success_matchesExpected() public view {
-        assertEq(token.DEFAULT_ADMIN_ROLE(), bytes32(0), "DEFAULT_ADMIN_ROLE must be bytes32(0)");
+        assertEq(token.DEFAULT_ADMIN_ROLE(), bytes32(0), "B20Constants.DEFAULT_ADMIN_ROLE must be bytes32(0)");
         // And matches the local constant used across these tests.
-        assertEq(token.DEFAULT_ADMIN_ROLE(), DEFAULT_ADMIN_ROLE, "must match B20Test's local constant");
+        assertEq(token.DEFAULT_ADMIN_ROLE(), B20Constants.DEFAULT_ADMIN_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies MINT_ROLE returns keccak256("MINT_ROLE")
     /// @dev Identifier stability for off-chain consumers
     function test_MINT_ROLE_success_matchesExpected() public view {
-        assertEq(token.MINT_ROLE(), keccak256("MINT_ROLE"), "MINT_ROLE digest");
-        assertEq(token.MINT_ROLE(), MINT_ROLE, "must match B20Test's local constant");
+        assertEq(token.MINT_ROLE(), keccak256("MINT_ROLE"), "B20Constants.MINT_ROLE digest");
+        assertEq(token.MINT_ROLE(), B20Constants.MINT_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies BURN_ROLE returns keccak256("BURN_ROLE")
     /// @dev Identifier stability for off-chain consumers
     function test_BURN_ROLE_success_matchesExpected() public view {
-        assertEq(token.BURN_ROLE(), keccak256("BURN_ROLE"), "BURN_ROLE digest");
-        assertEq(token.BURN_ROLE(), BURN_ROLE, "must match B20Test's local constant");
+        assertEq(token.BURN_ROLE(), keccak256("BURN_ROLE"), "B20Constants.BURN_ROLE digest");
+        assertEq(token.BURN_ROLE(), B20Constants.BURN_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies BURN_BLOCKED_ROLE returns keccak256("BURN_BLOCKED_ROLE")
     /// @dev Identifier stability for off-chain consumers
     function test_BURN_BLOCKED_ROLE_success_matchesExpected() public view {
-        assertEq(token.BURN_BLOCKED_ROLE(), keccak256("BURN_BLOCKED_ROLE"), "BURN_BLOCKED_ROLE digest");
-        assertEq(token.BURN_BLOCKED_ROLE(), BURN_BLOCKED_ROLE, "must match B20Test's local constant");
+        assertEq(token.BURN_BLOCKED_ROLE(), keccak256("BURN_BLOCKED_ROLE"), "B20Constants.BURN_BLOCKED_ROLE digest");
+        assertEq(token.BURN_BLOCKED_ROLE(), B20Constants.BURN_BLOCKED_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies PAUSE_ROLE returns keccak256("PAUSE_ROLE")
     /// @dev Identifier stability for off-chain consumers
     function test_PAUSE_ROLE_success_matchesExpected() public view {
-        assertEq(token.PAUSE_ROLE(), keccak256("PAUSE_ROLE"), "PAUSE_ROLE digest");
-        assertEq(token.PAUSE_ROLE(), PAUSE_ROLE, "must match B20Test's local constant");
+        assertEq(token.PAUSE_ROLE(), keccak256("PAUSE_ROLE"), "B20Constants.PAUSE_ROLE digest");
+        assertEq(token.PAUSE_ROLE(), B20Constants.PAUSE_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies UNPAUSE_ROLE returns keccak256("UNPAUSE_ROLE")
     /// @dev Identifier stability for off-chain consumers
     function test_UNPAUSE_ROLE_success_matchesExpected() public view {
-        assertEq(token.UNPAUSE_ROLE(), keccak256("UNPAUSE_ROLE"), "UNPAUSE_ROLE digest");
-        assertEq(token.UNPAUSE_ROLE(), UNPAUSE_ROLE, "must match B20Test's local constant");
+        assertEq(token.UNPAUSE_ROLE(), keccak256("UNPAUSE_ROLE"), "B20Constants.UNPAUSE_ROLE digest");
+        assertEq(token.UNPAUSE_ROLE(), B20Constants.UNPAUSE_ROLE, "must match B20Test's local constant");
     }
 
     /// @notice Verifies METADATA_ROLE returns keccak256("METADATA_ROLE")
     /// @dev Identifier stability for off-chain consumers. METADATA_ROLE gates `setName`
     ///      and `setSymbol` (separated from DEFAULT_ADMIN_ROLE per IB20 spec).
     function test_METADATA_ROLE_success_matchesExpected() public view {
-        assertEq(token.METADATA_ROLE(), keccak256("METADATA_ROLE"), "METADATA_ROLE digest");
-        assertEq(token.METADATA_ROLE(), METADATA_ROLE, "must match B20Test's local constant");
+        assertEq(token.METADATA_ROLE(), keccak256("METADATA_ROLE"), "B20Constants.METADATA_ROLE digest");
+        assertEq(token.METADATA_ROLE(), B20Constants.METADATA_ROLE, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/roles/setRoleAdmin.t.sol
+++ b/test/unit/B20/roles/setRoleAdmin.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SetRoleAdminTest is B20Test {
     /// @notice Verifies setRoleAdmin reverts when caller does not hold the role's current admin role
@@ -15,7 +16,7 @@ contract B20SetRoleAdminTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.setRoleAdmin(role, newAdminRole);
     }
@@ -33,7 +34,7 @@ contract B20SetRoleAdminTest is B20Test {
     ///      For an unconfigured non-default role, previousAdminRole is the implied
     ///      DEFAULT_ADMIN_ROLE; for DEFAULT_ADMIN_ROLE itself, previous is bytes32(0).
     function test_setRoleAdmin_success_emitsRoleAdminChanged(bytes32 role, bytes32 newAdminRole) public {
-        bytes32 previousAdminRole = role == DEFAULT_ADMIN_ROLE ? bytes32(0) : DEFAULT_ADMIN_ROLE;
+        bytes32 previousAdminRole = role == B20Constants.DEFAULT_ADMIN_ROLE ? bytes32(0) : B20Constants.DEFAULT_ADMIN_ROLE;
 
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.RoleAdminChanged(role, previousAdminRole, newAdminRole);

--- a/test/unit/B20/supply/burn.t.sol
+++ b/test/unit/B20/supply/burn.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20BurnTest is B20Test {
     /// @notice Verifies burn reverts when caller lacks BURN_ROLE
@@ -14,7 +15,7 @@ contract B20BurnTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, BURN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_ROLE)
         );
         token.burn(amount);
     }
@@ -22,7 +23,7 @@ contract B20BurnTest is B20Test {
     /// @notice Verifies burn reverts when BURN feature is paused
     /// @dev Pause guard; checks ContractPaused(BURN) error
     function test_burn_revert_whenBurnPaused(uint256 amount) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _pause(IB20.PausableFeature.BURN);
 
         vm.prank(burner);
@@ -34,7 +35,7 @@ contract B20BurnTest is B20Test {
     /// @dev Balance precondition; checks InsufficientBalance(caller, balance, amount)
     function test_burn_revert_insufficientBalance(uint256 amount) public {
         amount = bound(amount, 1, type(uint256).max);
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         // burner has zero balance; any positive amount exceeds it.
 
         vm.prank(burner);
@@ -45,7 +46,7 @@ contract B20BurnTest is B20Test {
     /// @notice Verifies burn debits the caller's balance by amount
     /// @dev Accounting: balanceOf(caller) decreases by exactly amount
     function test_burn_success_debitsCaller(uint256 amount) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _mint(burner, amount);
 
         vm.prank(burner);
@@ -56,7 +57,7 @@ contract B20BurnTest is B20Test {
     /// @notice Verifies burn decreases totalSupply by amount
     /// @dev Accounting: totalSupply tracks cumulative minted-burned
     function test_burn_success_decreasesTotalSupply(uint256 amount) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _mint(burner, amount);
         uint256 before = token.totalSupply();
 
@@ -68,7 +69,7 @@ contract B20BurnTest is B20Test {
     /// @notice Verifies burn emits Transfer(caller, address(0), amount)
     /// @dev Event integrity for the burn path; burn represented as transfer to the zero address
     function test_burn_success_emitsTransferToZero(uint256 amount) public {
-        _grantRole(BURN_ROLE, burner);
+        _grantRole(B20Constants.BURN_ROLE, burner);
         _mint(burner, amount);
 
         vm.expectEmit(true, true, false, true, address(token));

--- a/test/unit/B20/supply/burnBlocked.t.sol
+++ b/test/unit/B20/supply/burnBlocked.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20BurnBlockedTest is B20Test {
     /// @notice Verifies burnBlocked reverts when caller lacks BURN_BLOCKED_ROLE
@@ -14,7 +16,7 @@ contract B20BurnBlockedTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, BURN_BLOCKED_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
         );
         token.burnBlocked(from, amount);
     }
@@ -23,11 +25,11 @@ contract B20BurnBlockedTest is B20Test {
     /// @dev Pause guard; checks ContractPaused(BURN) error
     function test_burnBlocked_revert_whenBurnPaused(address from, uint256 amount) public {
         _assumeValidActor(from);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
-        // We also need TRANSFER_SENDER set to ALWAYS_REJECT so the from-not-authorized
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        // We also need TRANSFER_SENDER set to ALWAYS_BLOCK_ID so the from-not-authorized
         // path is satisfied; otherwise the policy check inside burnBlocked fires
         // with AccountNotBlocked first.
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
         _pause(IB20.PausableFeature.BURN);
 
         vm.prank(burnBlocker);
@@ -39,8 +41,8 @@ contract B20BurnBlockedTest is B20Test {
     /// @dev Seizure is only permitted against policy-blocked addresses; checks AccountNotBlocked(from)
     function test_burnBlocked_revert_accountNotBlocked(address from, uint256 amount) public {
         _assumeValidActor(from);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
-        // Default TRANSFER_SENDER is ALWAYS_ALLOW (0), so every address is "authorized" → not blocked.
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        // Default TRANSFER_SENDER is ALWAYS_ALLOW_ID (0), so every address is "authorized" → not blocked.
 
         vm.prank(burnBlocker);
         vm.expectRevert(abi.encodeWithSelector(IB20.AccountNotBlocked.selector, from));
@@ -52,8 +54,8 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_revert_insufficientBalance(address from, uint256 amount) public {
         _assumeValidActor(from);
         amount = bound(amount, 1, type(uint256).max);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT); // from is policy-blocked
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID); // from is policy-blocked
 
         // from has zero balance.
         vm.prank(burnBlocker);
@@ -68,8 +70,8 @@ contract B20BurnBlockedTest is B20Test {
         // Mint while no policy is set so the mint isn't blocked.
         _mint(from, amount);
         // Now block from via TRANSFER_SENDER policy, then seize.
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
 
         vm.prank(burnBlocker);
         token.burnBlocked(from, amount);
@@ -81,8 +83,8 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_success_decreasesTotalSupply(address from, uint256 amount) public {
         _assumeValidActor(from);
         _mint(from, amount);
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
         uint256 before = token.totalSupply();
 
         vm.prank(burnBlocker);
@@ -95,8 +97,8 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_success_emitsTransferAndBurnedBlocked(address from, uint256 amount) public {
         _assumeValidActor(from);
         _mint(from, amount);
-        _setPolicy(TRANSFER_SENDER, ALWAYS_REJECT);
-        _grantRole(BURN_BLOCKED_ROLE, burnBlocker);
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
 
         vm.expectEmit(true, true, false, true, address(token));
         emit IB20.Transfer(from, address(0), amount);

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20MintTest is B20Test {
     /// @notice Verifies mint reverts when caller lacks MINT_ROLE
@@ -19,7 +21,7 @@ contract B20MintTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, MINT_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.MINT_ROLE)
         );
         token.mint(to, amount);
     }
@@ -28,7 +30,7 @@ contract B20MintTest is B20Test {
     /// @dev Pause guard; checks ContractPaused(MINT) error
     function test_mint_revert_whenMintPaused(address to, uint256 amount) public {
         _assumeValidActor(to);
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
         _pause(IB20.PausableFeature.MINT);
 
         vm.prank(minter);
@@ -47,7 +49,7 @@ contract B20MintTest is B20Test {
         vm.prank(admin);
         token.setSupplyCap(cap);
 
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
         vm.prank(minter);
         vm.expectRevert(abi.encodeWithSelector(IB20.SupplyCapExceeded.selector, cap, amount));
         token.mint(to, amount);
@@ -57,18 +59,18 @@ contract B20MintTest is B20Test {
     /// @dev Policy guard for issuance; checks PolicyForbids(MINT_RECEIVER, policyId)
     function test_mint_revert_receiverPolicyForbids(address to, uint256 amount) public {
         _assumeValidActor(to);
-        _grantRole(MINT_ROLE, minter);
-        _setPolicy(MINT_RECEIVER, ALWAYS_REJECT);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _setPolicy(B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(minter);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, MINT_RECEIVER, ALWAYS_REJECT));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.mint(to, amount);
     }
 
     /// @notice Verifies mint reverts for the zero recipient address
     /// @dev OZ ERC-6093 invariant; checks InvalidReceiver(address(0)) error
     function test_mint_revert_zeroRecipient(uint256 amount) public {
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
 
         vm.prank(minter);
         vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
@@ -99,7 +101,7 @@ contract B20MintTest is B20Test {
     /// @dev Event integrity for the mint path; mint represented as transfer from the zero address
     function test_mint_success_emitsTransferFromZero(address to, uint256 amount) public {
         _assumeValidActor(to);
-        _grantRole(MINT_ROLE, minter);
+        _grantRole(B20Constants.MINT_ROLE, minter);
 
         vm.expectEmit(true, true, false, true, address(token));
         emit IB20.Transfer(address(0), to, amount);

--- a/test/unit/B20/supply/setSupplyCap.t.sol
+++ b/test/unit/B20/supply/setSupplyCap.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20SetSupplyCapTest is B20Test {
     /// @notice Verifies setSupplyCap reverts when caller lacks DEFAULT_ADMIN_ROLE
@@ -14,7 +15,7 @@ contract B20SetSupplyCapTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.setSupplyCap(newCap);
     }

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -7,15 +7,14 @@ import {IB20} from "src/interfaces/IB20.sol";
 import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
 import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
 
-import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
 
 contract TokenFactoryCreateTokenTest is TokenFactoryTest {
-    // Role identifiers, matching MockB20's keccak256 derivations. Inlined here
-    // because Solidity contract constants are runtime getters, so MockB20(addr).MINT_ROLE()
-    // requires `addr` to have code -- and during createToken setup, the token doesn't exist yet.
-    bytes32 internal constant MINT_ROLE = keccak256("MINT_ROLE");
-    bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
+    // Role identifiers are accessed as `MINT_ROLE` etc. — these are
+    // compile-time constants on the contract type, so they don't require an
+    // instantiated token (relevant during createToken setup where the token
+    // doesn't yet exist).
 
     /*//////////////////////////////////////////////////////////////
                                 REVERTS
@@ -168,7 +167,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     }
 
     /// @notice Verifies createToken emits TokenCreated with the correct identity fields
-    /// @dev Event integrity: token, variant, name, symbol, decimals must match the inputs
+    /// @dev Event integrity: token, variant, name, symbol, decimals must match the inputs.
+    ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
+    ///      see test_createToken_success_emitsRoleGrantedForInitialAdmin for that.
     function test_createToken_success_emitsTokenCreated(address caller, bytes32 salt, uint8 decimals) public {
         _assumeValidCaller(caller);
         decimals = uint8(bound(decimals, 2, 18));
@@ -176,7 +177,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", decimals, admin);
+        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", decimals);
         _createDefault(caller, salt, p, new bytes[](0));
     }
 
@@ -191,13 +192,13 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         // Grant MINT_ROLE to bob during the bootstrap window. This would normally
         // require msg.sender to hold DEFAULT_ADMIN_ROLE, but the factory holds no
         // role; the bypass lets the call through.
-        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, MINT_ROLE, bob);
+        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, B20Constants.MINT_ROLE, bob);
 
         address token = _createDefault(caller, salt, _b20Params(), initCalls);
-        assertTrue(MockB20(token).hasRole(MINT_ROLE, bob), "init call must have granted role");
+        assertTrue(MockB20(token).hasRole(B20Constants.MINT_ROLE, bob), "init call must have granted role");
         // Factory itself was never granted anything.
         assertFalse(
-            MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(factory)),
+            MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, address(factory)),
             "factory must not hold admin role"
         );
     }
@@ -210,7 +211,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         _assumeValidCaller(caller);
         // Use an init call that emits a single, distinctive event we can find: grantRole emits RoleGranted.
         bytes[] memory initCalls = new bytes[](1);
-        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, MINT_ROLE, bob);
+        initCalls[0] = abi.encodeWithSelector(IB20.grantRole.selector, B20Constants.MINT_ROLE, bob);
 
         vm.recordLogs();
         _createDefault(caller, salt, _b20Params(), initCalls);
@@ -244,7 +245,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         // role check, because the bootstrap window is closed.
         vm.prank(address(factory));
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, address(factory), MINT_ROLE)
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, address(factory), B20Constants.MINT_ROLE)
         );
         IB20(token).mint(bob, 1);
     }
@@ -262,9 +263,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         address token = _createDefault(caller, salt, p, new bytes[](0));
 
         // No admin was granted. Any admin-gated call from any account reverts.
-        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
-        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
-        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, admin), "admin actor must not hold admin");
+        assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
+        assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
+        assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, admin), "admin actor must not hold admin");
     }
 
     /// @notice Verifies stablecoin createToken executes with admin == address(0)
@@ -274,8 +275,8 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams("NoOwner USD", "NOUSD", address(0), "USD");
         address token = _createStablecoin(caller, salt, p, new bytes[](0));
 
-        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
-        assertFalse(MockB20(token).hasRole(DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
+        assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
+        assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
         // The stablecoin still got its variant data: currency is set.
         assertEq(IB20Stablecoin(token).currency(), "USD", "stablecoin currency must still be set");
     }


### PR DESCRIPTION
Follow-up to #26 addressing Conner's review feedback. Three atomic commits, each tied to one comment.

## 1. Pack 4 hot-path policy IDs into single slot (c2cded2)

`TRANSFER_SENDER`, `TRANSFER_RECEIVER`, `TRANSFER_EXECUTOR`, `MINT_RECEIVER` now occupy one 256-bit slot (`packedPolicyIds`) in `MockB20Storage` instead of four separate mapping entries. Rare / variant / user-defined policy types overflow to `extraPolicyIds`.

- `_transfer` reads sender + receiver policy IDs in a **single SLOAD** via inline shift+mask extraction
- `transferFrom*` adds the executor extract on top of the same slot
- `_mint`, `burnBlocked` similarly bench against the packed slot
- Layout: `[63:0] sender | [127:64] receiver | [191:128] executor | [255:192] mintReceiver`

## 2. Emit canonical RoleGranted from token on bootstrap; drop `admin` from `TokenCreated` (c1f9143)

The Rust precompile atomically writes the initial admin role slot AND pushes the `RoleGranted` log in the same call frame. The mock now mirrors that: after `vm.etch`'ing the token and `vm.store`'ing name/symbol/cap, the factory calls `token.grantRole(DEFAULT_ADMIN_ROLE, admin)` during the privileged window so `RoleGranted` fires from the token's own context — **no bootstrap surface added to MockB20 itself**.

Order: `vm.etch` → `vm.store` metadata → emit `TokenCreated` → `grantRole` (canonical `RoleGranted`) → `initCalls` → set `initialized = true`.

Drops the `admin` field from `TokenCreated` since `RoleGranted` is now the canonical signal for the initial admin assignment.

## 3. Dedup role + policy constants into libraries (9da65e6)

Tests previously redeclared `MINT_ROLE`, `BURN_ROLE`, etc. inside `B20Test`. Now they import the canonical values from libraries co-located with the mocks (`B20Constants` in `MockB20.sol`, `PolicyRegistryConstants` in `MockPolicyRegistry.sol`).

Solidity contract types don't expose `public constant` members at compile time (you can only call the runtime getter via an instance), so the constants live in libraries; the mock contracts re-expose them as `public constant` delegating to the library values for the `IB20` / `IPolicyRegistry` ABI compliance.

Sweep updates ~30 test files to reference `B20Constants.MINT_ROLE`, `PolicyRegistryConstants.ALWAYS_ALLOW_ID`, etc.

## Test status

300 / 300 tests passing.