### PR TITLE
Strict policy semantics: per-op packing, supported-types-only, well-formed IDs

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -53,10 +53,15 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         Variants extend this set by adding their own dedicated slots
 ///         (e.g. `IB20Security` adds `REDEEMER_SENDER` for its `redeem`
 ///         path, stored in the variant's own namespaced storage). There
-///         is no generic catch-all mapping: `updatePolicy` on a
-///         `policyType` not supported by the token (or its variant)
-///         reverts `UnsupportedPolicyType`. Reads of unsupported types
-///         return `0` (ALWAYS_ALLOW, the default-zero EVM value).
+///         is no generic catch-all mapping: every `policyType` either
+///         resolves to a real slot or doesn't exist at all. Both reads
+///         (`policyId`) and writes (`updatePolicy`) for a `policyType`
+///         not supported by the token (or its variant) revert
+///         `UnsupportedPolicyType` — an unsupported `policyType` is
+///         nonsense the token can't parse, so the registry never gets
+///         consulted with it. (Reads stay strict, not silent-zero,
+///         because a typo'd query returning `0` would masquerade as
+///         "no restriction" instead of surfacing the bug.)
 ///
 ///         Each policy slot defaults to built-in ID `0` (always-allow) so
 ///         newly created tokens are unrestricted until the admin
@@ -176,14 +181,14 @@ interface IB20 {
     ///         registry.
     error PolicyNotFound(uint64 policyId);
 
-    /// @notice `updatePolicy` was called with a `policyType` that this
-    ///         token (and its variant, if any) does not recognize. Each
-    ///         token implementation defines a fixed set of supported
-    ///         policy types; writes to anything else revert here.
-    /// @dev    Reads via `policyId(policyType)` for an unsupported type
-    ///         return `0` (ALWAYS_ALLOW) rather than reverting, since the
-    ///         absence of a slot is observably equivalent to the slot's
-    ///         default value.
+    /// @notice `policyId` or `updatePolicy` was called with a
+    ///         `policyType` that this token (and its variant, if any)
+    ///         does not recognize. Each token implementation defines a
+    ///         fixed set of supported policy types; both reads and
+    ///         writes for anything outside that set revert here so a
+    ///         typo'd query can never be silently interpreted as
+    ///         "no restriction", and an admin can never assign a policy
+    ///         to a slot that doesn't exist.
     error UnsupportedPolicyType(bytes32 policyType);
 
     /// @notice `burnBlocked` was called against a `from` address that is

--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -41,21 +41,22 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         detail; the public surface speaks only in `PausableFeature`
 ///         values.
 ///
-///         **Policy model.** The token holds a generic `policyId` mapping
-///         keyed by `bytes32 policyType`, where each standard policy type
-///         is the `keccak256` hash of its name. Four standard types are
-///         exposed as constants on this base surface:
+///         **Policy model.** Each supported `bytes32 policyType` resolves
+///         to a dedicated storage slot on the token. The policy-type
+///         identifier is the `keccak256` hash of its name. Four standard
+///         types are exposed as constants on this base surface:
 ///         - `TRANSFER_SENDER`   — checked against `from` on every transfer
 ///         - `TRANSFER_RECEIVER` — checked against `to`   on every transfer
 ///         - `TRANSFER_EXECUTOR` — checked against `msg.sender` on `transferFrom`
 ///                                  (when distinct from `from`)
 ///         - `MINT_RECEIVER`     — checked against `to`   on every mint
-///         Variants may introduce additional policy-type constants for
-///         variant-specific operations (e.g. `IB20Security` adds
-///         `REDEEMER_SENDER` for its `redeem` path). The underlying
-///         `policyId` mapping accepts any `bytes32` key, so the
-///         variant-side additions are pure interface additions with no
-///         change to the storage shape.
+///         Variants extend this set by adding their own dedicated slots
+///         (e.g. `IB20Security` adds `REDEEMER_SENDER` for its `redeem`
+///         path, stored in the variant's own namespaced storage). There
+///         is no generic catch-all mapping: `updatePolicy` on a
+///         `policyType` not supported by the token (or its variant)
+///         reverts `UnsupportedPolicyType`. Reads of unsupported types
+///         return `0` (ALWAYS_ALLOW, the default-zero EVM value).
 ///
 ///         Each policy slot defaults to built-in ID `0` (always-allow) so
 ///         newly created tokens are unrestricted until the admin
@@ -174,6 +175,16 @@ interface IB20 {
     /// @notice The provided policy ID does not exist in the policy
     ///         registry.
     error PolicyNotFound(uint64 policyId);
+
+    /// @notice `updatePolicy` was called with a `policyType` that this
+    ///         token (and its variant, if any) does not recognize. Each
+    ///         token implementation defines a fixed set of supported
+    ///         policy types; writes to anything else revert here.
+    /// @dev    Reads via `policyId(policyType)` for an unsupported type
+    ///         return `0` (ALWAYS_ALLOW) rather than reverting, since the
+    ///         absence of a slot is observably equivalent to the slot's
+    ///         default value.
+    error UnsupportedPolicyType(bytes32 policyType);
 
     /// @notice `burnBlocked` was called against a `from` address that is
     ///         currently authorized under the active `TRANSFER_SENDER`

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -116,6 +116,15 @@ interface IPolicyRegistry {
     /// @notice The referenced policy ID does not exist (and is not built-in).
     error PolicyNotFound();
 
+    /// @notice The provided `uint64 policyId` is malformed: its top byte
+    ///         (the `PolicyType` discriminator) is outside the
+    ///         `PolicyType` enum range (i.e. greater than
+    ///         `uint8(type(PolicyType).max)`). Reverted by every entry
+    ///         point that accepts a `policyId`, distinct from
+    ///         `PolicyNotFound` (which fires for well-formed IDs that
+    ///         simply haven't been created).
+    error MalformedPolicyId(uint64 policyId);
+
     /// @notice The operation is incompatible with the policy's type. For
     ///         example, calling `updateAllowlist` on a BLOCKLIST policy.
     error IncompatiblePolicyType();

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -127,6 +127,32 @@ contract B20Test is TokenFactoryTest {
         token.updatePolicy(policyType, policyId);
     }
 
+    /// @notice Maps a fuzzed `uint8` to one of the four base-token policy
+    ///         types. Tests that exercise `policyId` / `updatePolicy`
+    ///         must fuzz over the supported set; writes to an
+    ///         unsupported `bytes32` revert `UnsupportedPolicyType`.
+    /// @dev    Variant tests can wrap this with their own indexer that
+    ///         extends the codomain (e.g. a Security test that also
+    ///         covers `REDEEMER_SENDER`).
+    function _knownPolicyType(uint8 idx) internal pure returns (bytes32) {
+        uint8 i = idx % 4;
+        if (i == 0) return B20Constants.TRANSFER_SENDER;
+        if (i == 1) return B20Constants.TRANSFER_RECEIVER;
+        if (i == 2) return B20Constants.TRANSFER_EXECUTOR;
+        return B20Constants.MINT_RECEIVER;
+    }
+
+    /// @notice True iff `policyType` is one of the four base-token
+    ///         supported policy types. Used by tests that fuzz arbitrary
+    ///         `bytes32` and need to filter to the supported / unsupported
+    ///         partition.
+    function _isKnownPolicyType(bytes32 policyType) internal pure returns (bool) {
+        return policyType == B20Constants.TRANSFER_SENDER
+            || policyType == B20Constants.TRANSFER_RECEIVER
+            || policyType == B20Constants.TRANSFER_EXECUTOR
+            || policyType == B20Constants.MINT_RECEIVER;
+    }
+
     /// @notice Pauses a single `PausableFeature`, lazily granting `PAUSE_ROLE`
     ///         to the `pauser` actor on first call.
     function _pause(IB20.PausableFeature feature) internal {

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -7,6 +7,7 @@ import {MockActivationRegistry} from "test/lib/mocks/MockActivationRegistry.sol"
 import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {MockTokenFactory} from "test/lib/mocks/MockTokenFactory.sol";
 
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
 
 /// @notice Common base for every test contract in this suite.
@@ -101,5 +102,44 @@ abstract contract BaseTest is Test {
         vm.assume(caller != StdPrecompiles.TOKEN_FACTORY_ADDRESS);
         vm.assume(caller != StdPrecompiles.POLICY_REGISTRY_ADDRESS);
         vm.assume(caller != StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS);
+    }
+
+    // ============================================================
+    //                  POLICY-ID ENCODING HELPERS
+    // ============================================================
+    // The registry validates the policyId encoding (top byte must be
+    // a valid `PolicyType` discriminator) before any other check, so
+    // tests fuzzing arbitrary uint64s need to partition their inputs
+    // into well-formed and malformed regions to assert the right error.
+
+    /// @notice True iff `policyId`'s top byte (the PolicyType
+    ///         discriminator) is in the valid `PolicyType` enum range.
+    function _isWellFormedPolicyId(uint64 policyId) internal pure returns (bool) {
+        return uint8(policyId >> 56) <= uint8(IPolicyRegistry.PolicyType.BLOCKLIST);
+    }
+
+    /// @notice Maps a fuzz seed to a well-formed but uncreated `policyId`.
+    ///         Top byte is forced into `{ALLOWLIST, BLOCKLIST}` (custom
+    ///         range, never sentinel) and low 56 bits are forced strictly
+    ///         above the sentinel range so the ID can never collide with
+    ///         a sentinel or with any policy a registry could create from
+    ///         a fresh state.
+    function _wellFormedUncreatedPolicyId(uint64 seed) internal pure returns (uint64) {
+        uint8 typeByte = uint8(IPolicyRegistry.PolicyType.ALLOWLIST) + uint8(seed % 2);
+        // Use bits [62:8] as the counter source so the top byte and the
+        // counter selection are independent. Force counter >= 2 to skip
+        // both sentinel IDs (0 and 1).
+        uint56 counter = uint56((seed >> 8) | 2);
+        return (uint64(typeByte) << 56) | uint64(counter);
+    }
+
+    /// @notice Maps a fuzz seed to a MALFORMED `policyId`: top byte is
+    ///         forced strictly above the `PolicyType` enum range so the
+    ///         registry rejects it with `MalformedPolicyId`.
+    function _malformedPolicyId(uint64 seed) internal pure returns (uint64) {
+        uint8 maxValidType = uint8(IPolicyRegistry.PolicyType.BLOCKLIST);
+        uint8 invalidRange = type(uint8).max - maxValidType;
+        uint8 typeByte = maxValidType + 1 + uint8(seed % invalidRange);
+        return (uint64(typeByte) << 56) | uint64(seed & ((1 << 56) - 1));
     }
 }

--- a/test/lib/PolicyRegistryTest.sol
+++ b/test/lib/PolicyRegistryTest.sol
@@ -37,4 +37,5 @@ contract PolicyRegistryTest is BaseTest {
     function _createBlocklist() internal returns (uint64 policyId) {
         policyId = policyRegistry.createPolicy(admin, IPolicyRegistry.PolicyType.BLOCKLIST);
     }
+
 }

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -149,9 +149,10 @@ contract MockB20 is IB20 {
     function transferFrom(address from, address to, uint256 amount) external returns (bool) {
         if (!_isPrivileged() && msg.sender != from) {
             _consumeAllowance(from, msg.sender, amount);
-            // Read the executor policy ID out of the packed slot. Cold
-            // here; warm by the time _transfer reads the same slot.
-            uint64 executorPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 128);
+            // Read the executor policy ID out of the transfer-side packed
+            // slot. Cold here; warm by the time _transfer reads the same
+            // slot for sender + receiver.
+            uint64 executorPolicyId = uint64(MockB20Storage.layout().transferPolicyIds >> 128);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
                 revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
             }
@@ -181,7 +182,7 @@ contract MockB20 is IB20 {
     function transferFromWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool) {
         if (!_isPrivileged() && msg.sender != from) {
             _consumeAllowance(from, msg.sender, amount);
-            uint64 executorPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 128);
+            uint64 executorPolicyId = uint64(MockB20Storage.layout().transferPolicyIds >> 128);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
                 revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
             }
@@ -237,8 +238,9 @@ contract MockB20 is IB20 {
             if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
             // The point of burnBlocked is to seize from policy-blocked
             // accounts. Read the transfer-sender policy ID out of the
-            // packed slot and reject if the target is currently authorized.
-            uint64 senderPolicyId = uint64(MockB20Storage.layout().packedPolicyIds);
+            // transfer-side packed slot and reject if the target is
+            // currently authorized.
+            uint64 senderPolicyId = uint64(MockB20Storage.layout().transferPolicyIds);
             if (IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {
                 revert AccountNotBlocked(from);
             }
@@ -375,35 +377,35 @@ contract MockB20 is IB20 {
         emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
     }
 
-    /// @dev Reads a policy ID from storage. The four hot-path policy
-    ///      types live in a packed uint256 (one SLOAD, four uint64s);
-    ///      anything else falls through to the variant/user-defined
-    ///      mapping at the cold path.
+    /// @dev Reads a policy ID from storage. Hot-path types are routed to
+    ///      a per-operation packed slot (one SLOAD per op, four uint64s
+    ///      per slot); anything else falls through to the
+    ///      variant/user-defined mapping at the cold path.
     function _readPolicyId(bytes32 policyType) internal view returns (uint64) {
-        uint256 packed = MockB20Storage.layout().packedPolicyIds;
-        if (policyType == TRANSFER_SENDER) return uint64(packed);
-        if (policyType == TRANSFER_RECEIVER) return uint64(packed >> 64);
-        if (policyType == TRANSFER_EXECUTOR) return uint64(packed >> 128);
-        if (policyType == MINT_RECEIVER) return uint64(packed >> 192);
-        return MockB20Storage.layout().extraPolicyIds[policyType];
+        MockB20Storage.Layout storage $ = MockB20Storage.layout();
+        if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds);
+        if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 64);
+        if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds >> 128);
+        if (policyType == MINT_RECEIVER) return uint64($.mintPolicyIds);
+        return $.extraPolicyIds[policyType];
     }
 
-    /// @dev Writes a policy ID to storage. Hot-path types update the
-    ///      packed slot in-place (preserving the other three policies);
-    ///      anything else writes to the extra-policies mapping. Done
-    ///      with explicit mask + shift so the Rust impl can replicate
-    ///      the exact bit layout.
+    /// @dev Writes a policy ID to storage. Hot-path types update their
+    ///      per-operation packed slot in-place (preserving the other
+    ///      three packed lanes); anything else writes to the
+    ///      extra-policies mapping. Done with explicit mask + shift so
+    ///      the Rust impl can replicate the exact bit layout.
     function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         uint256 mask = uint256(type(uint64).max);
         if (policyType == TRANSFER_SENDER) {
-            $.packedPolicyIds = ($.packedPolicyIds & ~mask) | uint256(newPolicyId);
+            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);
         } else if (policyType == TRANSFER_RECEIVER) {
-            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
+            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
         } else if (policyType == TRANSFER_EXECUTOR) {
-            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
+            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
         } else if (policyType == MINT_RECEIVER) {
-            $.packedPolicyIds = ($.packedPolicyIds & ~(mask << 192)) | (uint256(newPolicyId) << 192);
+            $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);
         } else {
             $.extraPolicyIds[policyType] = newPolicyId;
         }
@@ -581,8 +583,8 @@ contract MockB20 is IB20 {
             if (_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);
             // One SLOAD pulls both policy IDs we need for the transfer
             // check (and was already warmed if we came in via transferFrom,
-            // which reads the executor slot first).
-            uint256 packed = MockB20Storage.layout().packedPolicyIds;
+            // which reads the executor lane of the same slot first).
+            uint256 packed = MockB20Storage.layout().transferPolicyIds;
             uint64 senderPolicyId = uint64(packed);
             uint64 receiverPolicyId = uint64(packed >> 64);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {
@@ -609,7 +611,7 @@ contract MockB20 is IB20 {
         if (!_isPrivileged()) {
             if (!hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);
             if (_isPaused(PausableFeature.MINT)) revert ContractPaused(PausableFeature.MINT);
-            uint64 mintReceiverPolicyId = uint64(MockB20Storage.layout().packedPolicyIds >> 192);
+            uint64 mintReceiverPolicyId = uint64(MockB20Storage.layout().mintPolicyIds);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {
                 revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);
             }

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -377,25 +377,30 @@ contract MockB20 is IB20 {
         emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
     }
 
-    /// @dev Reads a policy ID from storage. Hot-path types are routed to
-    ///      a per-operation packed slot (one SLOAD per op, four uint64s
-    ///      per slot); anything else falls through to the
-    ///      variant/user-defined mapping at the cold path.
-    function _readPolicyId(bytes32 policyType) internal view returns (uint64) {
+    /// @dev Reads a policy ID from storage. Each supported policy type
+    ///      is routed to its per-operation packed slot (one SLOAD per op,
+    ///      four uint64s per slot). Unsupported types return 0
+    ///      (ALWAYS_ALLOW) — there is no fallback storage, so the
+    ///      "absent" state is observably equivalent to "unconfigured".
+    ///      Variants that add their own policy types override this to
+    ///      check their own slots before falling through to `super`.
+    function _readPolicyId(bytes32 policyType) internal view virtual returns (uint64) {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds);
         if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 64);
         if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds >> 128);
         if (policyType == MINT_RECEIVER) return uint64($.mintPolicyIds);
-        return $.extraPolicyIds[policyType];
+        return 0;
     }
 
     /// @dev Writes a policy ID to storage. Hot-path types update their
     ///      per-operation packed slot in-place (preserving the other
-    ///      three packed lanes); anything else writes to the
-    ///      extra-policies mapping. Done with explicit mask + shift so
+    ///      three packed lanes); anything else reverts
+    ///      `UnsupportedPolicyType` — the token has no slot for it.
+    ///      Variants override to handle their own policy types before
+    ///      falling through to `super`. Mask + shift are explicit so
     ///      the Rust impl can replicate the exact bit layout.
-    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal {
+    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         uint256 mask = uint256(type(uint64).max);
         if (policyType == TRANSFER_SENDER) {
@@ -407,7 +412,7 @@ contract MockB20 is IB20 {
         } else if (policyType == MINT_RECEIVER) {
             $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);
         } else {
-            $.extraPolicyIds[policyType] = newPolicyId;
+            revert UnsupportedPolicyType(policyType);
         }
     }
 

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -368,29 +368,36 @@ contract MockB20 is IB20 {
 
     function updatePolicy(bytes32 policyType, uint64 newPolicyId) external {
         _requireAdmin();
+        // Read the old ID first: this both supplies the value for the
+        // event and validates that `policyType` is supported (reverts
+        // UnsupportedPolicyType cheaply, before the cross-contract
+        // registry call).
+        uint64 oldPolicyId = _readPolicyId(policyType);
         // Verify the target policy exists in the registry (or is built-in).
+        // Registry rejects malformed IDs (top byte outside PolicyType
+        // enum range) with its own MalformedPolicyId revert.
         if (!IPolicyRegistry(POLICY_REGISTRY).policyExists(newPolicyId)) {
             revert PolicyNotFound(newPolicyId);
         }
-        uint64 oldPolicyId = _readPolicyId(policyType);
         _writePolicyId(policyType, newPolicyId);
         emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
     }
 
     /// @dev Reads a policy ID from storage. Each supported policy type
     ///      is routed to its per-operation packed slot (one SLOAD per op,
-    ///      four uint64s per slot). Unsupported types return 0
-    ///      (ALWAYS_ALLOW) — there is no fallback storage, so the
-    ///      "absent" state is observably equivalent to "unconfigured".
-    ///      Variants that add their own policy types override this to
-    ///      check their own slots before falling through to `super`.
+    ///      four uint64s per slot). Unsupported types REVERT
+    ///      `UnsupportedPolicyType` — there is no fallback storage, and
+    ///      silently returning 0 (ALWAYS_ALLOW) would let a typo'd query
+    ///      masquerade as "no restriction". Variants that add their own
+    ///      policy types override this to check their own slots before
+    ///      falling through to `super`.
     function _readPolicyId(bytes32 policyType) internal view virtual returns (uint64) {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds);
         if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 64);
         if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds >> 128);
         if (policyType == MINT_RECEIVER) return uint64($.mintPolicyIds);
-        return 0;
+        revert UnsupportedPolicyType(policyType);
     }
 
     /// @dev Writes a policy ID to storage. Hot-path types update their

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -55,22 +55,37 @@ library MockB20Storage {
         // LastAdminCannotRenounce in O(1). Bumped on grant, decremented on
         // revoke / renounce.
         uint256 adminCount;
-        // ---------- Policy slots (PACKED) ----------
-        // The four hot-path policy types (transfer sender / receiver /
-        // executor, mint receiver) are packed into a single 256-bit slot
-        // so the transfer and mint hot paths read all the policy IDs they
-        // need with ONE SLOAD instead of one per policy type. Layout:
+        // ---------- Policy slots (PACKED, per-operation) ----------
+        // Hot-path policy IDs live in per-operation packed slots so each
+        // op reads exactly one slot, AND so adding granularity to one op
+        // (e.g. future MINT_AUTHORIZER) doesn't push other ops' IDs into
+        // a second SLOAD. Each slot holds four uint64s; the 64-bit width
+        // matches `uint64 policyId` everywhere else in the system, and
+        // four IDs fit exactly into the 256-bit slot.
+        //
+        // Transfer-side policies (read by `_transfer`, `transferFrom*`,
+        // and the seize check in `burnBlocked`). Layout:
         //   [63:0]    transferSenderPolicyId
         //   [127:64]  transferReceiverPolicyId
         //   [191:128] transferExecutorPolicyId
-        //   [255:192] mintReceiverPolicyId
-        // The 64-bit width matches `uint64 policyId` everywhere else in
-        // the system; four IDs fit exactly into the 256-bit slot.
-        uint256 packedPolicyIds;
-        // Variant-defined and user-defined policy types (e.g.
-        // REDEEMER_SENDER on IB20Security, or any keccak256("CUSTOM_*")
-        // a wrapper introduces) live in this mapping. The cold path
-        // (variant-specific operations like `redeem`) pays the standard
+        //   [255:192] reserved (for future transfer-side granularity)
+        uint256 transferPolicyIds;
+        // Mint-side policies (read by `_mint`). Only `MINT_RECEIVER` is
+        // defined today; the remaining three uint64 slots are reserved
+        // for future granular mint-side policy types (e.g.
+        // MINT_AUTHORIZER) so adding one doesn't force a second SLOAD.
+        // Layout:
+        //   [63:0]    mintReceiverPolicyId
+        //   [127:64]  reserved
+        //   [191:128] reserved
+        //   [255:192] reserved
+        uint256 mintPolicyIds;
+        // Variant-defined and user-defined policy types live in this
+        // mapping. Variants that want a packed hot-path slot for their
+        // own operation (e.g. `redeem` on `IB20Security`) add their own
+        // namespaced storage library with a `redeemPolicyIds` slot, the
+        // same way `MockB20StablecoinStorage` adds the `currency` field.
+        // The cold path (everything else) pays the standard
         // one-SLOAD-per-mapping-access cost.
         mapping(bytes32 policyType => uint64 policyId) extraPolicyIds;
         // ---------- Pause ----------
@@ -121,12 +136,13 @@ library MockB20Storage {
     uint256 internal constant ROLES_OFFSET = 6;
     uint256 internal constant ROLE_ADMINS_OFFSET = 7;
     uint256 internal constant ADMIN_COUNT_OFFSET = 8;
-    uint256 internal constant PACKED_POLICY_IDS_OFFSET = 9;
-    uint256 internal constant EXTRA_POLICY_IDS_OFFSET = 10;
-    uint256 internal constant PAUSED_VECTORS_OFFSET = 11;
-    uint256 internal constant SUPPLY_CAP_OFFSET = 12;
-    uint256 internal constant NONCES_OFFSET = 13;
-    uint256 internal constant INITIALIZED_OFFSET = 14;
+    uint256 internal constant TRANSFER_POLICY_IDS_OFFSET = 9;
+    uint256 internal constant MINT_POLICY_IDS_OFFSET = 10;
+    uint256 internal constant EXTRA_POLICY_IDS_OFFSET = 11;
+    uint256 internal constant PAUSED_VECTORS_OFFSET = 12;
+    uint256 internal constant SUPPLY_CAP_OFFSET = 13;
+    uint256 internal constant NONCES_OFFSET = 14;
+    uint256 internal constant INITIALIZED_OFFSET = 15;
 
     /// @notice Absolute slot for a top-level field of `Layout`.
     /// @dev `STORAGE_LOCATION + offset`. The struct never crosses the

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -80,14 +80,14 @@ library MockB20Storage {
         //   [191:128] reserved
         //   [255:192] reserved
         uint256 mintPolicyIds;
-        // Variant-defined and user-defined policy types live in this
-        // mapping. Variants that want a packed hot-path slot for their
-        // own operation (e.g. `redeem` on `IB20Security`) add their own
-        // namespaced storage library with a `redeemPolicyIds` slot, the
-        // same way `MockB20StablecoinStorage` adds the `currency` field.
-        // The cold path (everything else) pays the standard
-        // one-SLOAD-per-mapping-access cost.
-        mapping(bytes32 policyType => uint64 policyId) extraPolicyIds;
+        // There is no generic fallback mapping for "other" policy
+        // types. Each supported `policyType` lives in a fixed slot on
+        // this struct (or, for variant-specific operations, in the
+        // variant's own namespaced storage library — e.g. a future
+        // `MockB20SecurityStorage` adds `redeemPolicyIds` at namespace
+        // `base.b20.security`, mirroring how `MockB20StablecoinStorage`
+        // adds `currency` at `base.b20.stablecoin`). `updatePolicy` on
+        // an unsupported `policyType` reverts `UnsupportedPolicyType`.
         // ---------- Pause ----------
         // Bitmask: bit i set means PausableFeature(i) is paused. Translated
         // to/from the PausableFeature[] enum array at the IB20 surface
@@ -138,11 +138,10 @@ library MockB20Storage {
     uint256 internal constant ADMIN_COUNT_OFFSET = 8;
     uint256 internal constant TRANSFER_POLICY_IDS_OFFSET = 9;
     uint256 internal constant MINT_POLICY_IDS_OFFSET = 10;
-    uint256 internal constant EXTRA_POLICY_IDS_OFFSET = 11;
-    uint256 internal constant PAUSED_VECTORS_OFFSET = 12;
-    uint256 internal constant SUPPLY_CAP_OFFSET = 13;
-    uint256 internal constant NONCES_OFFSET = 14;
-    uint256 internal constant INITIALIZED_OFFSET = 15;
+    uint256 internal constant PAUSED_VECTORS_OFFSET = 11;
+    uint256 internal constant SUPPLY_CAP_OFFSET = 12;
+    uint256 internal constant NONCES_OFFSET = 13;
+    uint256 internal constant INITIALIZED_OFFSET = 14;
 
     /// @notice Absolute slot for a top-level field of `Layout`.
     /// @dev `STORAGE_LOCATION + offset`. The struct never crosses the

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -151,6 +151,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function isAuthorized(uint64 policyId, address account) external view returns (bool) {
+        _requireWellFormed(policyId);
         // Built-in short-circuits MUST precede any storage read: IDs 0 and 1
         // have no entry in storage and must never reach the storage path.
         if (policyId == ALWAYS_ALLOW_ID) return true;
@@ -175,12 +176,14 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function policyExists(uint64 policyId) external view returns (bool) {
+        _requireWellFormed(policyId);
         if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return true;
         return MockPolicyRegistryStorage.layout().policies[policyId] != 0;
     }
 
     /// @inheritdoc IPolicyRegistry
     function policyType(uint64 policyId) external view returns (PolicyType) {
+        _requireWellFormed(policyId);
         if (policyId == ALWAYS_ALLOW_ID) return PolicyType.ALWAYS_ALLOW;
         if (policyId == ALWAYS_BLOCK_ID) return PolicyType.ALWAYS_BLOCK;
         uint256 packed = MockPolicyRegistryStorage.layout().policies[policyId];
@@ -190,6 +193,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function policyAdmin(uint64 policyId) external view returns (address) {
+        _requireWellFormed(policyId);
         if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return address(0);
         uint256 packed = MockPolicyRegistryStorage.layout().policies[policyId];
         if (packed == 0) revert PolicyNotFound();
@@ -198,6 +202,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function pendingPolicyAdmin(uint64 policyId) external view returns (address) {
+        _requireWellFormed(policyId);
         if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return address(0);
         return MockPolicyRegistryStorage.layout().pendingAdmins[policyId];
     }
@@ -256,5 +261,17 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     function _decodeAdmin(uint256 packed) internal pure returns (address) {
         return address(uint160(packed >> PACKED_ADMIN_SHIFT));
+    }
+
+    /// @dev Reverts `MalformedPolicyId` if `policyId`'s top byte (the
+    ///      `PolicyType` discriminator) is outside the enum range. Every
+    ///      entry point that accepts a `policyId` calls this first, so
+    ///      malformed IDs are rejected distinctly from well-formed
+    ///      IDs that simply haven't been created (which still revert
+    ///      `PolicyNotFound`).
+    function _requireWellFormed(uint64 policyId) internal pure {
+        if (uint8(policyId >> POLICY_ID_TYPE_SHIFT) > uint8(type(PolicyType).max)) {
+            revert MalformedPolicyId(policyId);
+        }
     }
 }

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -245,9 +245,9 @@ contract MockTokenFactory is ITokenFactory {
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.SYMBOL_OFFSET), symbol_);
         _writeUint(token, MockB20Storage.slotOf(MockB20Storage.SUPPLY_CAP_OFFSET), type(uint256).max);
         // Everything else (totalSupply, allowances, roles, roleAdmins,
-        // adminCount, transferPolicyIds, mintPolicyIds, extraPolicyIds,
-        // pausedVectors, nonces, contractURI, initialized) defaults to
-        // the EVM's zero state, which is correct for a fresh token.
+        // adminCount, transferPolicyIds, mintPolicyIds, pausedVectors,
+        // nonces, contractURI, initialized) defaults to the EVM's zero
+        // state, which is correct for a fresh token.
     }
 
     /// @dev Writes the stablecoin variant's `currency` field at its

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -245,9 +245,9 @@ contract MockTokenFactory is ITokenFactory {
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.SYMBOL_OFFSET), symbol_);
         _writeUint(token, MockB20Storage.slotOf(MockB20Storage.SUPPLY_CAP_OFFSET), type(uint256).max);
         // Everything else (totalSupply, allowances, roles, roleAdmins,
-        // adminCount, packedPolicyIds, extraPolicyIds, pausedVectors,
-        // nonces, contractURI, initialized) defaults to the EVM's zero
-        // state, which is correct for a fresh token.
+        // adminCount, transferPolicyIds, mintPolicyIds, extraPolicyIds,
+        // pausedVectors, nonces, contractURI, initialized) defaults to
+        // the EVM's zero state, which is correct for a fresh token.
     }
 
     /// @dev Writes the stablecoin variant's `currency` field at its

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IB20} from "src/interfaces/IB20.sol";
+
 import {B20Test} from "test/lib/B20Test.sol";
 import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
@@ -27,16 +29,14 @@ contract B20PolicyIdTest is B20Test {
         assertEq(token.policyId(policyType), newPolicyId, "slot must reflect updatePolicy");
     }
 
-    /// @notice Verifies policyId returns 0 for an unsupported policyType (no fallback storage).
-    /// @dev Reading an unsupported type is observably equivalent to reading an unconfigured
-    ///      supported type — both return ALWAYS_ALLOW_ID. Writes are the strict operation
-    ///      (they revert UnsupportedPolicyType); reads stay silent.
-    function test_policyId_success_zeroForUnknownType(bytes32 policyType) public view {
+    /// @notice Verifies policyId reverts UnsupportedPolicyType for any policyType
+    ///         outside the token's supported set.
+    /// @dev Reads are strict: there is no fallback storage, and silently returning
+    ///      0 (ALWAYS_ALLOW) for an unsupported type would let a typo'd query
+    ///      masquerade as "no restriction". Both reads and writes revert symmetrically.
+    function test_policyId_revert_unsupportedPolicyType(bytes32 policyType) public {
         vm.assume(!_isKnownPolicyType(policyType));
-        assertEq(
-            token.policyId(policyType),
-            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
-            "unsupported policyType read must return 0"
-        );
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyType));
+        token.policyId(policyType);
     }
 }

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -5,26 +5,38 @@ import {B20Test} from "test/lib/B20Test.sol";
 import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20PolicyIdTest is B20Test {
-    /// @notice Verifies policyId returns 0 (always-allow built-in) for any unconfigured slot
-    /// @dev Default state: newly-created tokens are unrestricted across all policy slots
-    function test_policyId_success_zeroByDefault(bytes32 policyType) public view {
-        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "unconfigured slot must default to PolicyRegistryConstants.ALWAYS_ALLOW_ID (0)");
+    /// @notice Verifies policyId returns 0 (always-allow built-in) for any supported slot before configuration
+    /// @dev Default state: newly-created tokens are unrestricted across all supported policy slots
+    function test_policyId_success_zeroByDefault(uint8 typeIdx) public view {
+        bytes32 policyType = _knownPolicyType(typeIdx);
+        assertEq(
+            token.policyId(policyType),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "unconfigured supported slot must default to ALWAYS_ALLOW_ID (0)"
+        );
     }
 
     /// @notice Verifies policyId returns the value most recently set via updatePolicy
-    /// @dev Read-after-write for the slot mapping
-    function test_policyId_success_reflectsUpdatePolicy(bytes32 policyType, uint64 newPolicyId) public {
+    /// @dev Read-after-write across all supported policy types
+    function test_policyId_success_reflectsUpdatePolicy(uint8 typeIdx, uint64 newPolicyId) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
         // MockPolicyRegistry only knows the two built-in sentinel ids.
-        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
+        newPolicyId =
+            newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
         _setPolicy(policyType, newPolicyId);
         assertEq(token.policyId(policyType), newPolicyId, "slot must reflect updatePolicy");
     }
 
-    /// @notice Verifies policyId accepts arbitrary bytes32 keys, not just the standard constants
-    /// @dev User-defined policy types are supported for periphery layering
-    function test_policyId_success_arbitraryKeysAllowed(bytes32 customType, uint64 newPolicyId) public {
-        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
-        _setPolicy(customType, newPolicyId);
-        assertEq(token.policyId(customType), newPolicyId, "arbitrary key must be writable");
+    /// @notice Verifies policyId returns 0 for an unsupported policyType (no fallback storage).
+    /// @dev Reading an unsupported type is observably equivalent to reading an unconfigured
+    ///      supported type — both return ALWAYS_ALLOW_ID. Writes are the strict operation
+    ///      (they revert UnsupportedPolicyType); reads stay silent.
+    function test_policyId_success_zeroForUnknownType(bytes32 policyType) public view {
+        vm.assume(!_isKnownPolicyType(policyType));
+        assertEq(
+            token.policyId(policyType),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "unsupported policyType read must return 0"
+        );
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -25,14 +25,12 @@ contract B20UpdatePolicyTest is B20Test {
     }
 
     /// @notice Verifies updatePolicy reverts when the target policy id does not exist in the registry
-    /// @dev Cross-precompile guard; checks PolicyNotFound() error.
-    ///      MockPolicyRegistry only knows ids 0 and 1; everything else is unknown.
-    function test_updatePolicy_revert_policyNotFound(uint8 typeIdx, uint64 newPolicyId) public {
+    /// @dev Cross-precompile guard; checks PolicyNotFound() error. Fuzzes well-formed but
+    ///      uncreated registry IDs so the registry-side malformed check passes and the
+    ///      not-found path fires from MockB20.
+    function test_updatePolicy_revert_policyNotFound(uint8 typeIdx, uint64 seed) public {
         bytes32 policyType = _knownPolicyType(typeIdx);
-        vm.assume(
-            newPolicyId != PolicyRegistryConstants.ALWAYS_ALLOW_ID
-                && newPolicyId != PolicyRegistryConstants.ALWAYS_BLOCK_ID
-        );
+        uint64 newPolicyId = _wellFormedUncreatedPolicyId(seed);
 
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -9,48 +9,75 @@ import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPo
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy reverts when caller lacks DEFAULT_ADMIN_ROLE
-    /// @dev Access control: only the admin may reassign policy slots; checks AccessControlUnauthorizedAccount
+    /// @dev Access control: only the admin may reassign policy slots; checks AccessControlUnauthorizedAccount.
+    ///      Auth fires before policy-type / registry checks, so any bytes32 fuzz is fine here.
     function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyType, uint64 newPolicyId) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
         );
         token.updatePolicy(policyType, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy reverts when the target policy id does not exist in the registry
     /// @dev Cross-precompile guard; checks PolicyNotFound() error.
-    ///      MockPolicyRegistry only knows ids 0 and type(uint64).max; everything else is unknown.
-    function test_updatePolicy_revert_policyNotFound(bytes32 policyType, uint64 newPolicyId) public {
-        vm.assume(newPolicyId != PolicyRegistryConstants.ALWAYS_ALLOW_ID && newPolicyId != PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+    ///      MockPolicyRegistry only knows ids 0 and 1; everything else is unknown.
+    function test_updatePolicy_revert_policyNotFound(uint8 typeIdx, uint64 newPolicyId) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
+        vm.assume(
+            newPolicyId != PolicyRegistryConstants.ALWAYS_ALLOW_ID
+                && newPolicyId != PolicyRegistryConstants.ALWAYS_BLOCK_ID
+        );
 
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));
         token.updatePolicy(policyType, newPolicyId);
     }
 
-    /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
-    /// @dev Built-ins are always valid targets
-    function test_updatePolicy_success_builtinAllow(bytes32 policyType) public {
-        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
-        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be PolicyRegistryConstants.ALWAYS_ALLOW_ID");
+    /// @notice Verifies updatePolicy reverts when the policyType is not one of the base-token's
+    ///         four supported types and is not added by a variant.
+    /// @dev Strictness on writes: there is no fallback mapping, so unsupported policyTypes are
+    ///      rejected explicitly. Uses a built-in policy id so the registry check passes; the
+    ///      revert must come from `_writePolicyId`'s UnsupportedPolicyType branch.
+    function test_updatePolicy_revert_unsupportedPolicyType(bytes32 policyType, uint64 newPolicyIdSeed) public {
+        vm.assume(!_isKnownPolicyType(policyType));
+        uint64 newPolicyId = newPolicyIdSeed % 2 == 0
+            ? PolicyRegistryConstants.ALWAYS_ALLOW_ID
+            : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyType));
+        token.updatePolicy(policyType, newPolicyId);
     }
 
-    /// @notice Verifies updatePolicy succeeds for built-in id type(uint64).max (always-reject)
-    /// @dev Built-ins are always valid targets
-    function test_updatePolicy_success_builtinReject(bytes32 policyType) public {
+    /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
+    /// @dev Built-ins are always valid targets across all supported policy types
+    function test_updatePolicy_success_builtinAllow(uint8 typeIdx) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
+        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be ALWAYS_ALLOW_ID");
+    }
+
+    /// @notice Verifies updatePolicy succeeds for built-in id 1 (always-reject)
+    /// @dev Built-ins are always valid targets across all supported policy types
+    function test_updatePolicy_success_builtinReject(uint8 typeIdx) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
         _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be PolicyRegistryConstants.ALWAYS_BLOCK_ID");
+        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be ALWAYS_BLOCK_ID");
     }
 
     /// @notice Verifies updatePolicy writes the new id to the slot
     /// @dev Read-after-write: policyId(policyType) returns newPolicyId
-    function test_updatePolicy_success_writesSlot(bytes32 policyType, uint64 newPolicyId) public {
+    function test_updatePolicy_success_writesSlot(uint8 typeIdx, uint64 newPolicyId) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
         // Bound to a registry-supported id.
-        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
+        newPolicyId =
+            newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
         _setPolicy(policyType, newPolicyId);
         assertEq(token.policyId(policyType), newPolicyId, "slot must equal newPolicyId after write");
     }
@@ -58,8 +85,10 @@ contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)
     /// @dev Event integrity; canonical PolicyUpdated emission test.
     ///      Fresh slot has oldId == ALWAYS_ALLOW_ID (0); the first write transitions from there.
-    function test_updatePolicy_success_emitsPolicyUpdated(bytes32 policyType, uint64 newPolicyId) public {
-        newPolicyId = newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
+    function test_updatePolicy_success_emitsPolicyUpdated(uint8 typeIdx, uint64 newPolicyId) public {
+        bytes32 policyType = _knownPolicyType(typeIdx);
+        newPolicyId =
+            newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.expectEmit(true, false, false, true, address(token));
         emit IB20.PolicyUpdated(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);

--- a/test/unit/PolicyRegistry/isAuthorized.t.sol
+++ b/test/unit/PolicyRegistry/isAuthorized.t.sol
@@ -6,11 +6,21 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
 contract PolicyRegistryIsAuthorizedTest is PolicyRegistryTest {
-    /// @notice Verifies isAuthorized reverts for an unknown policy id
-    /// @dev Lookup guard for non-existent ids; checks PolicyNotFound() error
-    function test_isAuthorized_revert_policyNotFound(uint64 policyId, address account) public {
-        vm.assume(policyId > 1);
+    /// @notice Verifies isAuthorized reverts PolicyNotFound for a well-formed but uncreated id
+    /// @dev Lookup guard for non-existent ids; uses a well-formed id so the malformed
+    ///      check passes and the storage-lookup miss fires.
+    function test_isAuthorized_revert_policyNotFound(uint64 seed, address account) public {
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.isAuthorized(policyId, account);
+    }
+
+    /// @notice Verifies isAuthorized reverts MalformedPolicyId for any id whose top byte
+    ///         is outside the PolicyType enum range.
+    /// @dev Encoding invariant on the registry surface.
+    function test_isAuthorized_revert_malformedPolicyId(uint64 seed, address account) public {
+        uint64 policyId = _malformedPolicyId(seed);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.MalformedPolicyId.selector, policyId));
         policyRegistry.isAuthorized(policyId, account);
     }
 

--- a/test/unit/PolicyRegistry/policyAdmin.t.sol
+++ b/test/unit/PolicyRegistry/policyAdmin.t.sol
@@ -6,11 +6,21 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
 contract PolicyRegistryPolicyAdminTest is PolicyRegistryTest {
-    /// @notice Verifies policyAdmin reverts for an unknown policy id
-    /// @dev Lookup guard for non-existent ids; checks PolicyNotFound() error
-    function test_policyAdmin_revert_policyNotFound(uint64 policyId) public {
-        vm.assume(policyId > 1);
+    /// @notice Verifies policyAdmin reverts PolicyNotFound for a well-formed but uncreated id
+    /// @dev Lookup guard for non-existent ids; uses a well-formed id so the malformed
+    ///      check passes and the storage-lookup miss fires.
+    function test_policyAdmin_revert_policyNotFound(uint64 seed) public {
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.policyAdmin(policyId);
+    }
+
+    /// @notice Verifies policyAdmin reverts MalformedPolicyId for any id whose top byte
+    ///         is outside the PolicyType enum range.
+    /// @dev Encoding invariant on the registry surface.
+    function test_policyAdmin_revert_malformedPolicyId(uint64 seed) public {
+        uint64 policyId = _malformedPolicyId(seed);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.MalformedPolicyId.selector, policyId));
         policyRegistry.policyAdmin(policyId);
     }
 

--- a/test/unit/PolicyRegistry/policyExists.t.sol
+++ b/test/unit/PolicyRegistry/policyExists.t.sol
@@ -14,9 +14,21 @@ contract PolicyRegistryPolicyExistsTest is PolicyRegistryTest {
         assertTrue(policyRegistry.policyExists(1));
     }
 
-    function test_policyExists_success_falseForUncreated(uint64 policyId) public view {
-        vm.assume(policyId > 1);
+    /// @notice policyExists returns false for a well-formed but uncreated id.
+    /// @dev Uses a well-formed id (top byte in PolicyType range) so the malformed
+    ///      check passes and the storage-lookup miss returns false.
+    function test_policyExists_success_falseForUncreated(uint64 seed) public view {
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
         assertFalse(policyRegistry.policyExists(policyId));
+    }
+
+    /// @notice policyExists reverts MalformedPolicyId for any id whose top byte is
+    ///         outside the PolicyType enum range.
+    /// @dev Encoding invariant on the registry surface.
+    function test_policyExists_revert_malformedPolicyId(uint64 seed) public {
+        uint64 policyId = _malformedPolicyId(seed);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.MalformedPolicyId.selector, policyId));
+        policyRegistry.policyExists(policyId);
     }
 
     function test_policyExists_success_trueAfterCreate(uint8 policyTypeInt) public {

--- a/test/unit/PolicyRegistry/policyType.t.sol
+++ b/test/unit/PolicyRegistry/policyType.t.sol
@@ -6,11 +6,21 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
 contract PolicyRegistryPolicyTypeTest is PolicyRegistryTest {
-    /// @notice Verifies policyType reverts for an unknown policy id
-    /// @dev Lookup guard for non-existent ids; checks PolicyNotFound() error
-    function test_policyType_revert_policyNotFound(uint64 policyId) public {
-        vm.assume(policyId > 1);
+    /// @notice Verifies policyType reverts PolicyNotFound for a well-formed but uncreated id
+    /// @dev Lookup guard for non-existent ids; uses a well-formed (top byte in PolicyType range)
+    ///      id so the malformed check passes and the storage-lookup miss fires.
+    function test_policyType_revert_policyNotFound(uint64 seed) public {
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.policyType(policyId);
+    }
+
+    /// @notice Verifies policyType reverts MalformedPolicyId for any id whose top byte
+    ///         is outside the PolicyType enum range.
+    /// @dev Encoding invariant on the registry surface.
+    function test_policyType_revert_malformedPolicyId(uint64 seed) public {
+        uint64 policyId = _malformedPolicyId(seed);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.MalformedPolicyId.selector, policyId));
         policyRegistry.policyType(policyId);
     }
 


### PR DESCRIPTION
Four commits that lock down the `MockB20` ↔ `MockPolicyRegistry` policy interface so that the only things that work are: (a) supported `bytes32 policyType` slots on the token, and (b) well-formed `uint64 policyId`s on the registry. Everything else reverts with a specific error.

## Commits

| # | SHA | Title |
|---|---|---|
| 1 | f8767ec | Split packed policy slot into transferPolicyIds + mintPolicyIds |
| 2 | 552ece5 | Drop extraPolicyIds fallback; require known policy types on write |
| 3 | 8c9b914 | Make policyId(unsupportedType) revert too; symmetric strictness |
| 4 | c075aa4 | Reject malformed policyIds at the registry surface |

## Final semantics (token side)

| Operation | Supported `policyType` | Unsupported `policyType` |
|---|---|---|
| `policyId(type)` (read) | configured ID (default 0 = `ALWAYS_ALLOW`) | **reverts** `IB20.UnsupportedPolicyType(bytes32)` |
| `updatePolicy(type, id)` (write) | writes packed slot | **reverts** `IB20.UnsupportedPolicyType(bytes32)` |

An unsupported `policyType` is nonsense the token can't parse, so the registry never gets consulted with it.

## Final semantics (registry side)

A `uint64 policyId` encodes `(PolicyType discriminator in top byte, counter in low 56 bits)`. The discriminator must be a valid `PolicyType` enum value: `0=ALWAYS_ALLOW`, `1=ALWAYS_BLOCK`, `2=ALLOWLIST`, `3=BLOCKLIST`.

| Operation | Well-formed + exists | Well-formed + uncreated | Malformed |
|---|---|---|---|
| `isAuthorized` / `policyType` / `policyAdmin` / `pendingPolicyAdmin` | normal return | **reverts** `PolicyNotFound` | **reverts** `MalformedPolicyId(uint64)` |
| `policyExists` | `true` | `false` | **reverts** `MalformedPolicyId(uint64)` |

`policyExists(malformed)` reverts rather than returning `false` so the failure mode is diagnostic instead of buried under "doesn't exist".

## Slot packing

Per-operation packed slots in `MockB20Storage`:

| Slot | Lanes |
|---|---|
| `transferPolicyIds` | `TRANSFER_SENDER` (0-63), `TRANSFER_RECEIVER` (64-127), `TRANSFER_EXECUTOR` (128-191), reserved (192-255) |
| `mintPolicyIds` | `MINT_RECEIVER` (0-63), reserved × 3 |

`_readPolicyId` / `_writePolicyId` are `virtual`; a future `MockB20Security` overrides both to route `REDEEMER_SENDER` to its own namespaced `redeemPolicyIds` slot in `base.b20.security`.

Hot path: zero SLOAD regression vs main.

## Interface changes

- IB20: new `error UnsupportedPolicyType(bytes32 policyType);`; policy-model natspec rewritten.
- IPolicyRegistry: new `error MalformedPolicyId(uint64 policyId);`.

## Tests

- `B20Test`: `_knownPolicyType(uint8)` + `_isKnownPolicyType(bytes32)` for bounded fuzzing of supported policyTypes.
- `BaseTest`: `_isWellFormedPolicyId(uint64)` + `_wellFormedUncreatedPolicyId(uint64)` + `_malformedPolicyId(uint64)` for partitioning fuzzed registry IDs.
- New tests: `test_policyId_revert_unsupportedPolicyType`, `test_updatePolicy_revert_unsupportedPolicyType`, `test_isAuthorized_revert_malformedPolicyId`, `test_policyExists_revert_malformedPolicyId`, `test_policyType_revert_malformedPolicyId`, `test_policyAdmin_revert_malformedPolicyId`.

## Test status

305 / 305 tests passing.