### PR TITLE
feat: Mock B20Security

### DIFF
--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -21,21 +21,24 @@ import {IB20} from "./IB20.sol";
 ///         these as-is and do not redeclare them here.
 ///
 ///         **Security-specific additions.** This interface adds:
-///         1. `announce(...)` plus `SECURITY_OPERATOR_ROLE` for posting
-///            holder-impacting disclosures (corporate actions, name
-///            changes, splits, etc.).
+///         1. `announce(bytes[],string,string,string)` plus
+///            `SECURITY_OPERATOR_ROLE`. The single canonical wrapper
+///            for posting a holder-impacting disclosure AND atomically
+///            executing the on-chain calls it discloses; see
+///            "Announcement pairing" below for the topology.
 ///         2. `sharesToTokensRatio()` / `toShares(...)` / `sharesOf(...)`
 ///            plus `updateShareRatio(...)` for split-safe
 ///            DeFi-compatible share accounting.
 ///         3. `batchMint(address[],uint256[])` and
 ///            `batchBurn(address[],uint256[])` for the cold-path
-///            corporate-actions issuance and seizure flows. These are
+///            corporate-actions issuance and clawback flows. These are
 ///            scoped to the security-token surface (not the base
 ///            `IB20`) because batched destruction of third-party
 ///            balances is a compliance-sensitive operation and the
-///            batched issuance path is paired with the announcement
-///            flow above. See the per-function natspec for role
-///            gating; `batchBurn` is held tighter than `batchMint`.
+///            batched issuance path is the natural target of the
+///            announcement bracket above. See the per-function
+///            natspec for role gating; `batchBurn` is held tighter
+///            than `batchMint`.
 ///         4. `redeem(...)` / `redeemWithMemo(...)` plus
 ///            `updateMinimumRedeemable(...)` and `minimumRedeemable()`
 ///            for the holder-initiated off-chain settlement path.
@@ -48,15 +51,45 @@ import {IB20} from "./IB20.sol";
 ///         tokens that want the corporate-actions desk to be the sole
 ///         caller of these functions grant `METADATA_ROLE` only to
 ///         addresses that also hold `SECURITY_OPERATOR_ROLE`. That
-///         pairing is operational, not contract-enforced.
+///         pairing is operational, not contract-enforced. The standard
+///         way to issue a name or symbol change is to wrap the
+///         `setName` / `setSymbol` call as an entry in
+///         `announce(...)`'s `internalCalls`, so the rebrand lands in
+///         the same `Announcement` ↔ `EndAnnouncement` bracket as the
+///         disclosure that explains it.
 ///
-///         **Announcement pairing.** The corporate-actions operator is
-///         expected to post an `announce(...)` alongside each
-///         state-changing operator call (`updateShareRatio`,
-///         `updateSecurityIdentifier`, `setName`, `setSymbol`) so that
-///         indexers can correlate the on-chain change with its
-///         off-chain disclosure. This interface does NOT enforce that
-///         pairing on-chain.
+///         **Announcement pairing.** Every state-changing operator
+///         call that affects holder-visible token semantics
+///         (`updateShareRatio`, `updateSecurityIdentifier`, `setName`,
+///         `setSymbol`, `batchMint`, `batchBurn`, and admin-level
+///         changes such as `updatePolicy` / `setSupplyCap` /
+///         `setContractURI` / `pause` / `unpause`) SHOULD be issued by
+///         encoding the call into the `internalCalls` parameter of
+///         `announce(...)`. The token then:
+///         1. emits `Announcement(caller, id, description, uri)`,
+///         2. `delegatecall`s each entry in `internalCalls` with
+///            `msg.sender` preserved (so the operator's own roles
+///            apply to the inner calls), reverting the entire
+///            announce if any inner call reverts, and
+///         3. emits `EndAnnouncement(id)`.
+///         This binds every change to its off-chain disclosure
+///         atomically: indexers never see a `Transfer`, a
+///         `ShareRatioUpdated`, or any other state-mutation event
+///         from a wrapped call without the surrounding bracket, and
+///         they never see a half-applied bracket because any inner
+///         revert unwinds the entire transaction including the
+///         `Announcement` event.
+///
+///         The bare functions remain individually callable by their
+///         role holders for emergency operator override, but
+///         unwrapped invocations produce no bracket events and so are
+///         indistinguishable from any other state mutation in the log
+///         stream. Production corporate-actions flows are expected to
+///         go through `announce(...)`; standalone calls are an escape
+///         hatch, not the standard path. Recursion (an inner call
+///         re-invoking `announce`) reverts with
+///         `AnnouncementInProgress` so the bracket is always exactly
+///         one level deep.
 interface IB20Security is IB20 {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
@@ -95,6 +128,30 @@ interface IB20Security is IB20 {
     ///         always rejected, regardless of `minimumRedeemable`).
     error BelowMinimumRedeemable(uint256 shares, uint256 minimum);
 
+    /// @notice Reverted by `announce` when one of its `internalCalls`
+    ///         tries to invoke `announce` itself. The recursion guard
+    ///         keeps the bracketing topology one level deep:
+    ///         exactly one `Announcement` and one matching
+    ///         `EndAnnouncement` per outer call, with no nesting.
+    ///         Indexers can therefore treat every `Announcement` log
+    ///         as the unambiguous start of a single bracket pairing.
+    error AnnouncementInProgress();
+
+    /// @notice Reverted by `announce` when one of its `internalCalls`
+    ///         is malformed (shorter than four bytes, no function
+    ///         selector to validate). Carries the offending raw
+    ///         calldata blob.
+    error InternalCallMalformed(bytes call);
+
+    /// @notice Reverted by `announce` when one of its `internalCalls`
+    ///         reverts during the inner `delegatecall`. Carries the
+    ///         offending raw calldata blob; the inner revert reason
+    ///         is intentionally not bubbled through so this error
+    ///         identifies the wrapped call deterministically. To debug
+    ///         a failing inner call, replay it as a direct invocation
+    ///         and read its native revert.
+    error InternalCallFailed(bytes call);
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -122,6 +179,18 @@ interface IB20Security is IB20 {
     ///         is posted. Indexers join this with subsequent
     ///         security-token state changes via `id`.
     event Announcement(address indexed caller, string id, string description, string uri);
+
+    /// @notice Emitted by `announce` immediately after every entry in
+    ///         `internalCalls` has executed successfully (or
+    ///         immediately after `Announcement` itself for a pure
+    ///         announcement with `internalCalls.length == 0`).
+    ///         Carries the same `id` as the paired `Announcement` so
+    ///         indexers can join start ↔ end on the id even when
+    ///         scanning logs in isolation. The recursion guard
+    ///         (`AnnouncementInProgress`) makes the pairing
+    ///         within-tx unambiguous; the `id` field hardens cross-tx
+    ///         indexing as well.
+    event EndAnnouncement(string id);
 
     /*//////////////////////////////////////////////////////////////
                             ROLE IDENTIFIERS
@@ -174,18 +243,78 @@ interface IB20Security is IB20 {
                               ANNOUNCEMENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Posts a holder-impacting announcement. Each `id` may be
+    /// @notice Posts a holder-impacting announcement and, in the same
+    ///         transaction, atomically executes the on-chain calls
+    ///         that the announcement describes. Each `id` may be
     ///         consumed at most once over the lifetime of the token;
     ///         subsequent calls that reuse `id` revert with
     ///         `AnnouncementIdAlreadyUsed`.
     ///
-    /// @dev    Requires `SECURITY_OPERATOR_ROLE`. Emits `Announcement`.
+    ///         Pass `internalCalls` as an empty array for a pure
+    ///         disclosure (no on-chain change to bracket); pass one
+    ///         or more ABI-encoded calldata blobs to bracket the
+    ///         corresponding state changes inside the announcement.
+    ///         For example, to disclose and execute a 2-for-1 split
+    ///         in one transaction:
     ///
-    /// @param  id          Caller-chosen announcement identifier.
-    /// @param  description Human-readable summary of the announcement.
-    /// @param  uri         Off-chain URI containing the full
-    ///                     announcement contents.
-    function announce(string calldata id, string calldata description, string calldata uri) external;
+    ///             announce({
+    ///                 internalCalls: [
+    ///                     abi.encodeCall(this.updateShareRatio, (newRatio))
+    ///                 ],
+    ///                 id: "2026-Q3-split",
+    ///                 description: "2-for-1 forward stock split",
+    ///                 uri: "https://disclosures.example.com/...",
+    ///             });
+    ///
+    /// @dev    Requires `SECURITY_OPERATOR_ROLE`. Topology:
+    ///         1. Marks `id` consumed and emits
+    ///            `Announcement(msg.sender, id, description, uri)`.
+    ///         2. For each `internalCalls[i]`:
+    ///            a. Validates the embedded function selector. Calls
+    ///               shorter than four bytes revert with
+    ///               `InternalCallMalformed(internalCalls[i])`. Calls
+    ///               whose selector is `announce` itself revert with
+    ///               `AnnouncementInProgress` so the bracket cannot
+    ///               nest.
+    ///            b. Issues `address(this).delegatecall(internalCalls[i])`,
+    ///               which preserves `msg.sender` so role checks on
+    ///               the inner function see the operator (not the
+    ///               token contract). On failure, reverts with
+    ///               `InternalCallFailed(internalCalls[i])`; the
+    ///               inner revert reason is intentionally not bubbled
+    ///               (replay the call directly to debug).
+    ///         3. Emits `EndAnnouncement(id)`.
+    ///
+    ///         Atomicity: any inner-call revert (including
+    ///         `InternalCallFailed`, `InternalCallMalformed`, or
+    ///         `AnnouncementInProgress`) unwinds the entire
+    ///         transaction, so no `Announcement` event is observable
+    ///         without its matching `EndAnnouncement`.
+    ///
+    ///         The inner functions invoked through `internalCalls`
+    ///         are subject to their normal authorization gates (role
+    ///         checks, policy checks, pause vectors); the announcement
+    ///         wrapper does not add or relax any of them. The
+    ///         operator therefore needs both `SECURITY_OPERATOR_ROLE`
+    ///         (to call `announce`) and whatever role each inner
+    ///         function requires (e.g. `MINT_ROLE` for `batchMint`,
+    ///         `METADATA_ROLE` for `setName`).
+    ///
+    /// @param  internalCalls ABI-encoded calldata blobs executed
+    ///                       in-order via self-`delegatecall`. May
+    ///                       be empty (pure disclosure).
+    /// @param  id            Caller-chosen announcement identifier;
+    ///                       single-use over the token's lifetime.
+    /// @param  description   Human-readable summary of the
+    ///                       announcement.
+    /// @param  uri           Off-chain URI containing the full
+    ///                       announcement contents.
+    function announce(
+        bytes[] calldata internalCalls,
+        string calldata id,
+        string calldata description,
+        string calldata uri
+    ) external;
 
     /// @notice Returns true if `id` has previously been consumed by
     ///         `announce`.
@@ -213,17 +342,20 @@ interface IB20Security is IB20 {
     ///         new ratio at read time, preserving DeFi composability.
     ///
     /// @dev    Requires `SECURITY_OPERATOR_ROLE`. Emits
-    ///         `ShareRatioUpdated`. Operators should pair this with a
-    ///         separate `announce(...)` call so the change is
-    ///         discoverable to indexers; this interface does not
-    ///         enforce the pairing on-chain.
+    ///         `ShareRatioUpdated`. Standard usage is to invoke this
+    ///         through `announce(...)`'s `internalCalls`, which
+    ///         brackets the ratio change with a matching disclosure
+    ///         atomically (see the contract-level "Announcement
+    ///         pairing" notes). Direct invocation by a role holder
+    ///         remains permitted for emergency override but produces
+    ///         no `Announcement` / `EndAnnouncement` bracket.
     ///
     /// @param  newSharesToTokensRatio The new ratio scaled to
     ///                                `WAD_PRECISION`.
     function updateShareRatio(uint256 newSharesToTokensRatio) external;
 
     /*//////////////////////////////////////////////////////////////
-                  BATCHED ISSUANCE AND CORP-ACTION SEIZURE
+                  BATCHED ISSUANCE AND CORP-ACTION CLAWBACK
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Mints `amounts[i]` tokens to `recipients[i]`. The
@@ -244,10 +376,13 @@ interface IB20Security is IB20 {
     ///         policy-blocked recipient), the entire transaction
     ///         reverts and no partial state is committed. Emits
     ///         `Transfer(address(0), recipients[i], amounts[i])` per
-    ///         element. Operators should pair this with a separate
-    ///         `announce(...)` call so the issuance is discoverable to
-    ///         indexers; this interface does not enforce the pairing
-    ///         on-chain.
+    ///         element. Standard usage is to invoke this through
+    ///         `announce(...)`'s `internalCalls`, which brackets the
+    ///         issuance with a matching disclosure atomically (see
+    ///         the contract-level "Announcement pairing" notes).
+    ///         Direct invocation by a role holder remains permitted
+    ///         for emergency override but produces no `Announcement` /
+    ///         `EndAnnouncement` bracket.
     ///
     /// @param  recipients Accounts receiving the minted tokens.
     /// @param  amounts    Per-recipient amounts, parallel to
@@ -279,10 +414,13 @@ interface IB20Security is IB20 {
     ///         committed. Emits `Transfer(accounts[i], address(0),
     ///         amounts[i])` per element; does NOT emit `BurnedBlocked`
     ///         (that event is reserved for `burnBlocked`'s sanctions
-    ///         semantics). Operators should pair this with a separate
-    ///         `announce(...)` call so the destruction is discoverable
-    ///         to indexers; this interface does not enforce the
-    ///         pairing on-chain.
+    ///         semantics). Standard usage is to invoke this through
+    ///         `announce(...)`'s `internalCalls`, which brackets the
+    ///         clawback with a matching disclosure atomically (see the
+    ///         contract-level "Announcement pairing" notes). Direct
+    ///         invocation by a role holder remains permitted for
+    ///         emergency override but produces no `Announcement` /
+    ///         `EndAnnouncement` bracket.
     ///
     /// @param  accounts Accounts whose balances will be debited.
     /// @param  amounts  Per-account amounts, parallel to `accounts`.
@@ -344,9 +482,14 @@ interface IB20Security is IB20 {
     ///
     /// @dev    Requires `SECURITY_OPERATOR_ROLE`. Emits
     ///         `IdentifierUpdated`. Reverts with `InvalidIdentifierType`
-    ///         if `identifierType` is the empty string. Operators
-    ///         should pair this with a separate `announce(...)` call;
-    ///         this interface does not enforce the pairing on-chain.
+    ///         if `identifierType` is the empty string. Standard
+    ///         usage is to invoke this through `announce(...)`'s
+    ///         `internalCalls`, which brackets the identifier change
+    ///         with a matching disclosure atomically (see the
+    ///         contract-level "Announcement pairing" notes). Direct
+    ///         invocation by a role holder remains permitted for
+    ///         emergency override but produces no `Announcement` /
+    ///         `EndAnnouncement` bracket.
     ///
     /// @param  identifierType Identifier category (e.g. "ISIN").
     /// @param  value          New value, or empty string to remove.

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -73,6 +73,28 @@ interface IB20Security is IB20 {
     ///         entry instead.
     error InvalidIdentifierType();
 
+    /// @notice A batched function (`batchMint`, `batchBurn`) was called
+    ///         with parallel arrays of differing lengths. The two
+    ///         lengths are reported verbatim in the order the function
+    ///         declares them (`recipients`/`amounts` for `batchMint`;
+    ///         `accounts`/`amounts` for `batchBurn`).
+    error LengthMismatch(uint256 leftLen, uint256 rightLen);
+
+    /// @notice A batched function (`batchMint`, `batchBurn`) was called
+    ///         with empty arrays. Empty batches are rejected so the
+    ///         caller cannot accidentally emit a no-op corp-actions
+    ///         transaction.
+    error EmptyBatch();
+
+    /// @notice `redeem` / `redeemWithMemo` was called with an `amount`
+    ///         that resolves to a share count below the active redemption
+    ///         floor. `shares` is the computed share count
+    ///         (`amount * sharesToTokensRatio / WAD_PRECISION`);
+    ///         `minimum` is the configured `minimumRedeemable`. Also
+    ///         emitted when the resulting share count is zero (which is
+    ///         always rejected, regardless of `minimumRedeemable`).
+    error BelowMinimumRedeemable(uint256 shares, uint256 minimum);
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -115,6 +137,29 @@ interface IB20Security is IB20 {
     ///         See the contract-level notes for the recommended
     ///         operational pairing.
     function SECURITY_OPERATOR_ROLE() external view returns (bytes32);
+
+    /// @notice Required to call `batchBurn`. Held separately from
+    ///         `BURN_ROLE` (which gates burn-of-self) and from
+    ///         `BURN_BLOCKED_ROLE` (which gates seizure of
+    ///         policy-blocked accounts) so the authority to destroy
+    ///         third-party balances WITHOUT a blocked-status precondition
+    ///         can be delegated narrowly to the corporate-actions desk
+    ///         for clawbacks, consolidations, and similar batched
+    ///         destructions. Tokens that do not need a batched-clawback
+    ///         path simply never grant this role.
+    function BURN_FROM_ROLE() external view returns (bytes32);
+
+    /*//////////////////////////////////////////////////////////////
+                              PRECISION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Fixed-point precision used to scale `sharesToTokensRatio`.
+    ///         Equal to `1e18` (one WAD). Exposed on the ABI so callers
+    ///         that read `sharesToTokensRatio()` directly can interpret
+    ///         the value without hardcoding the constant; typical
+    ///         callers should prefer `toShares(...)` / `sharesOf(...)`,
+    ///         which apply the precision internally.
+    function WAD_PRECISION() external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                           POLICY TYPE IDENTIFIERS
@@ -190,36 +235,56 @@ interface IB20Security is IB20 {
     ///
     /// @dev    Requires `MINT_ROLE`. Subject to the `MINT_RECEIVER_POLICY`
     ///         policy per recipient and to the `MINT` pause vector.
-    ///         Reverts on length mismatch or empty arrays. Operators
-    ///         should pair this with a separate `announce(...)` call
-    ///         so the issuance is discoverable to indexers; this
-    ///         interface does not enforce the pairing on-chain.
+    ///         Reverts with `LengthMismatch(recipients.length,
+    ///         amounts.length)` if the parallel arrays disagree, and
+    ///         with `EmptyBatch()` if either array is empty.
+    ///         All-or-nothing: if any element reverts (e.g.
+    ///         `SupplyCapExceeded` after a partial accumulation, or
+    ///         `PolicyForbids(MINT_RECEIVER_POLICY, ...)` for a
+    ///         policy-blocked recipient), the entire transaction
+    ///         reverts and no partial state is committed. Emits
+    ///         `Transfer(address(0), recipients[i], amounts[i])` per
+    ///         element. Operators should pair this with a separate
+    ///         `announce(...)` call so the issuance is discoverable to
+    ///         indexers; this interface does not enforce the pairing
+    ///         on-chain.
     ///
     /// @param  recipients Accounts receiving the minted tokens.
     /// @param  amounts    Per-recipient amounts, parallel to
     ///                    `recipients`.
     function batchMint(address[] calldata recipients, uint256[] calldata amounts) external;
 
-    /// @notice Burns `amounts[i]` tokens from `accounts[i]`. The
-    ///         batched sibling of the inherited
-    ///         `IB20.burnBlocked(address,uint256)`; supports cold-path
-    ///         compliance seizures (court-ordered claw-backs, sanctions
-    ///         enforcement against multiple addresses, etc.) that need
-    ///         to land many destructions in one transaction.
+    /// @notice Burns `amounts[i]` tokens from `accounts[i]`. Distinct
+    ///         from the inherited `IB20.burnBlocked(address,uint256)`:
+    ///         where `burnBlocked` exists for sanctions-style seizure
+    ///         and refuses to operate against accounts that are still
+    ///         authorized under `TRANSFER_SENDER_POLICY`, `batchBurn` is the
+    ///         general corporate-actions clawback path and operates
+    ///         unconditionally on the supplied accounts. Supports
+    ///         cold-path consolidations, redemptions-in-kind, and
+    ///         court-ordered destructions that need to land many
+    ///         debits in one transaction without first arranging for
+    ///         each account to be policy-blocked.
     ///
-    /// @dev    Requires `BURN_ROLE`. Each `accounts[i]` MUST
-    ///         currently be unauthorized under the active
-    ///         `TRANSFER_SENDER_POLICY` policy; otherwise reverts with
-    ///         `AccountNotBlocked(accounts[i])`. Subject to the `BURN`
-    ///         pause vector. Reverts on length mismatch or empty
-    ///         arrays. Emits `Transfer(accounts[i], address(0),
-    ///         amounts[i])` per element, Operators should pair this with
-    ///         a separate `announce(...)` call so the seizure is
-    ///         discoverable to indexers; this interface does not
-    ///         enforce the pairing on-chain.
+    /// @dev    Requires `BURN_FROM_ROLE`. NOT gated by any policy:
+    ///         the corporate-actions desk is trusted to pick the right
+    ///         set of accounts off-chain, and the role grant is the
+    ///         on-chain authorization. Subject to the `BURN` pause
+    ///         vector. Reverts with `LengthMismatch(accounts.length,
+    ///         amounts.length)` if the parallel arrays disagree, and
+    ///         with `EmptyBatch()` if either array is empty.
+    ///         All-or-nothing: if any element reverts (e.g.
+    ///         `InsufficientBalance(accounts[k], balance, amounts[k])`),
+    ///         the entire transaction reverts and no partial state is
+    ///         committed. Emits `Transfer(accounts[i], address(0),
+    ///         amounts[i])` per element; does NOT emit `BurnedBlocked`
+    ///         (that event is reserved for `burnBlocked`'s sanctions
+    ///         semantics). Operators should pair this with a separate
+    ///         `announce(...)` call so the destruction is discoverable
+    ///         to indexers; this interface does not enforce the
+    ///         pairing on-chain.
     ///
-    /// @param  accounts Accounts whose balances will be debited. Each
-    ///                  MUST be unauthorized under `TRANSFER_SENDER_POLICY`.
+    /// @param  accounts Accounts whose balances will be debited.
     /// @param  amounts  Per-account amounts, parallel to `accounts`.
     function batchBurn(address[] calldata accounts, uint256[] calldata amounts) external;
 
@@ -231,16 +296,22 @@ interface IB20Security is IB20 {
     ///         to settle off-chain.
     ///
     /// @dev    Subject to the `REDEEMER_SENDER_POLICY` policy and to the
-    ///         `REDEEM` pause vector. Reverts when the corresponding
-    ///         share amount (`amount * sharesToTokensRatio /
-    ///         WAD_PRECISION`) is below `minimumRedeemable`. Emits
-    ///         `Redeemed`.
+    ///         `REDEEM` pause vector. Reverts with
+    ///         `BelowMinimumRedeemable(shares, minimumRedeemable)` if
+    ///         the corresponding share amount (`amount *
+    ///         sharesToTokensRatio / WAD_PRECISION`) is zero OR is
+    ///         strictly less than `minimumRedeemable`. Zero-share
+    ///         redemptions are always rejected, regardless of
+    ///         `minimumRedeemable`'s configured value, so a holder
+    ///         cannot burn token dust that resolves to no shares.
+    ///         Emits `Transfer(caller, address(0), amount)` followed by
+    ///         `Redeemed(caller, amount, sharesToTokensRatio)`.
     ///
     /// @param  amount Token amount to redeem from the caller's balance.
     function redeem(uint256 amount) external;
 
     /// @notice Same as `redeem`, with a memo. Emits `Memo(memo)`
-    ///         immediately after `Transfer()` and before `Redeemed`. 
+    ///         immediately after `Transfer()` and before `Redeemed`.
     ///         See `IB20.transferWithMemo` for the memo convention; a memo
     ///         of `bytes32(0)` is permitted.
     function redeemWithMemo(uint256 amount, bytes32 memo) external;

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -173,7 +173,7 @@ interface IB20Security is IB20 {
     /// @notice Emitted by `updateSecurityIdentifier` when an identifier
     ///         entry is set, updated, or removed. An empty `value`
     ///         indicates removal.
-    event IdentifierUpdated(string identifierType, string value);
+    event SecurityIdentifierUpdated(string identifierType, string value);
 
     /// @notice Emitted by `announce` when a holder-impacting disclosure
     ///         is posted. Indexers join this with subsequent
@@ -481,7 +481,7 @@ interface IB20Security is IB20 {
     ///         `value` sets or overwrites it.
     ///
     /// @dev    Requires `SECURITY_OPERATOR_ROLE`. Emits
-    ///         `IdentifierUpdated`. Reverts with `InvalidIdentifierType`
+    ///         `SecurityIdentifierUpdated`. Reverts with `InvalidIdentifierType`
     ///         if `identifierType` is the empty string. Standard
     ///         usage is to invoke this through `announce(...)`'s
     ///         `internalCalls`, which brackets the identifier change

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -195,13 +195,7 @@ interface ITokenFactory {
     ///         `TokenCreated` is the token-identity signal only. The
     ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
     ///         skips the grant and emits no `RoleGranted` at bootstrap.
-    event TokenCreated(
-        address indexed token,
-        TokenVariant indexed variant,
-        string name,
-        string symbol,
-        uint8 decimals
-    );
+    event TokenCreated(address indexed token, TokenVariant indexed variant, string name, string symbol, uint8 decimals);
 
     /*//////////////////////////////////////////////////////////////
                                  CREATE
@@ -248,12 +242,9 @@ interface ITokenFactory {
     ///                   token-side authorization checks are bypassed
     ///                   for this window only.
     /// @return token     The address of the newly created token.
-    function createToken(
-        TokenVariant variant,
-        bytes32 salt,
-        bytes calldata params,
-        bytes[] calldata initCalls
-    ) external returns (address token);
+    function createToken(TokenVariant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
+        external
+        returns (address token);
 
     /*//////////////////////////////////////////////////////////////
                             ADDRESS QUERIES

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -211,7 +211,7 @@ contract MockB20Security is MockB20, IB20Security {
         _requireRole(SECURITY_OPERATOR_ROLE);
         if (bytes(identifierType).length == 0) revert InvalidIdentifierType();
         MockB20SecurityStorage.layout().identifiers[identifierType] = value;
-        emit IdentifierUpdated(identifierType, value);
+        emit SecurityIdentifierUpdated(identifierType, value);
     }
 
     // ============================================================

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -39,7 +39,7 @@ import {MockB20RedeemStorage} from "test/lib/mocks/MockB20Storage.sol";
 ///         would change `msg.sender` to the contract address and
 ///         break the inner role checks.
 ///
-///         **Policy override.** `REDEEMER_SENDER` lives in this
+///         **Policy override.** `REDEEMER_SENDER_POLICY` lives in this
 ///         variant's own `redeemPolicyIds` packed slot, mirroring the
 ///         per-operation packed-slot layout the base uses for
 ///         `transferPolicyIds` / `mintPolicyIds`. `_readPolicyId` and
@@ -76,7 +76,7 @@ contract MockB20Security is MockB20, IB20Security {
     bytes32 public constant SECURITY_OPERATOR_ROLE = keccak256("SECURITY_OPERATOR_ROLE");
     bytes32 public constant BURN_FROM_ROLE = keccak256("BURN_FROM_ROLE");
 
-    bytes32 public constant REDEEMER_SENDER = keccak256("REDEEMER_SENDER");
+    bytes32 public constant REDEEMER_SENDER_POLICY = keccak256("REDEEMER_SENDER_POLICY");
 
     /// @notice Fixed-point precision for the share ratio. `1e18` (one
     ///         WAD) is the standard DeFi convention; `toShares` and
@@ -149,7 +149,7 @@ contract MockB20Security is MockB20, IB20Security {
         if (recipients.length != amounts.length) revert LengthMismatch(recipients.length, amounts.length);
         if (recipients.length == 0) revert EmptyBatch();
         // Per-element call into _mint: role / pause checks repeat (idempotent),
-        // but MINT_RECEIVER policy and supply-cap accumulation are correctly
+        // but MINT_RECEIVER_POLICY policy and supply-cap accumulation are correctly
         // applied per recipient. Cleaner than re-deriving the per-element body.
         for (uint256 i = 0; i < recipients.length; i++) {
             _mint(recipients[i], amounts[i]);
@@ -213,19 +213,19 @@ contract MockB20Security is MockB20, IB20Security {
     //                       POLICY OVERRIDES
     // ============================================================
 
-    /// @dev Variant-first policy resolution: REDEEMER_SENDER lives in
+    /// @dev Variant-first policy resolution: REDEEMER_SENDER_POLICY lives in
     ///      this variant's own packed slot; everything else falls
     ///      through to the base. The base's UnsupportedPolicyType
     ///      revert is the terminal case.
     function _readPolicyId(bytes32 policyType) internal view virtual override returns (uint64) {
-        if (policyType == REDEEMER_SENDER) {
+        if (policyType == REDEEMER_SENDER_POLICY) {
             return uint64(MockB20RedeemStorage.layout().redeemPolicyIds);
         }
         return super._readPolicyId(policyType);
     }
 
     function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual override {
-        if (policyType == REDEEMER_SENDER) {
+        if (policyType == REDEEMER_SENDER_POLICY) {
             MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
             uint256 mask = uint256(type(uint64).max);
             $.redeemPolicyIds = ($.redeemPolicyIds & ~mask) | uint256(newPolicyId);
@@ -256,7 +256,7 @@ contract MockB20Security is MockB20, IB20Security {
         MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
         uint64 redeemerSenderPolicyId = uint64($.redeemPolicyIds);
         if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(redeemerSenderPolicyId, msg.sender)) {
-            revert PolicyForbids(REDEEMER_SENDER, redeemerSenderPolicyId);
+            revert PolicyForbids(REDEEMER_SENDER_POLICY, redeemerSenderPolicyId);
         }
         ratio = _sharesToTokensRatio();
         uint256 shares = (amount * ratio) / WAD_PRECISION;

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -83,12 +83,6 @@ contract MockB20Security is MockB20, IB20Security {
     ///         stored ratio.
     uint256 public constant WAD_PRECISION = 1e18;
 
-    /// @dev Selector for the announce function itself. Used by
-    ///      `_checkSelector` to deny recursive `announce` invocations
-    ///      from inside `internalCalls`, keeping the bracket exactly
-    ///      one level deep.
-    bytes4 internal constant ANNOUNCE_SELECTOR = IB20Security.announce.selector;
-
     // ============================================================
     //                        ANNOUNCEMENTS
     // ============================================================
@@ -295,6 +289,6 @@ contract MockB20Security is MockB20, IB20Security {
     function _checkSelector(bytes calldata call) internal pure {
         if (call.length < 4) revert InternalCallMalformed(call);
         bytes4 sel = bytes4(call[:4]);
-        if (sel == ANNOUNCE_SELECTOR) revert AnnouncementInProgress();
+        if (sel == IB20Security.announce.selector) revert AnnouncementInProgress();
     }
 }

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -6,6 +6,7 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {MockB20} from "test/lib/mocks/MockB20.sol";
 import {MockB20SecurityStorage, MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20RedeemStorage} from "test/lib/mocks/MockB20Storage.sol";
 
 /// @title MockB20Security
 /// @author Coinbase
@@ -185,12 +186,12 @@ contract MockB20Security is MockB20, IB20Security {
 
     function updateMinimumRedeemable(uint256 newMinimumRedeemable) external {
         _requireAdmin();
-        MockB20SecurityStorage.layout().minimumRedeemable = newMinimumRedeemable;
+        MockB20RedeemStorage.layout().minimumRedeemable = newMinimumRedeemable;
         emit MinimumRedeemableUpdated(newMinimumRedeemable);
     }
 
     function minimumRedeemable() external view returns (uint256) {
-        return MockB20SecurityStorage.layout().minimumRedeemable;
+        return MockB20RedeemStorage.layout().minimumRedeemable;
     }
 
     // ============================================================
@@ -218,14 +219,14 @@ contract MockB20Security is MockB20, IB20Security {
     ///      revert is the terminal case.
     function _readPolicyId(bytes32 policyType) internal view virtual override returns (uint64) {
         if (policyType == REDEEMER_SENDER) {
-            return uint64(MockB20SecurityStorage.layout().redeemPolicyIds);
+            return uint64(MockB20RedeemStorage.layout().redeemPolicyIds);
         }
         return super._readPolicyId(policyType);
     }
 
     function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual override {
         if (policyType == REDEEMER_SENDER) {
-            MockB20SecurityStorage.Layout storage $ = MockB20SecurityStorage.layout();
+            MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
             uint256 mask = uint256(type(uint64).max);
             $.redeemPolicyIds = ($.redeemPolicyIds & ~mask) | uint256(newPolicyId);
             return;
@@ -252,13 +253,14 @@ contract MockB20Security is MockB20, IB20Security {
     ///      during bootstrap, so the bypass is omitted by design.
     function _redeemBurn(uint256 amount) internal returns (uint256 ratio) {
         if (_isPaused(PausableFeature.REDEEM)) revert ContractPaused(PausableFeature.REDEEM);
-        uint64 redeemerSenderPolicyId = uint64(MockB20SecurityStorage.layout().redeemPolicyIds);
+        MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
+        uint64 redeemerSenderPolicyId = uint64($.redeemPolicyIds);
         if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(redeemerSenderPolicyId, msg.sender)) {
             revert PolicyForbids(REDEEMER_SENDER, redeemerSenderPolicyId);
         }
         ratio = _sharesToTokensRatio();
         uint256 shares = (amount * ratio) / WAD_PRECISION;
-        uint256 minimum = MockB20SecurityStorage.layout().minimumRedeemable;
+        uint256 minimum = $.minimumRedeemable;
         // Always reject zero-share redemptions, even if the configured
         // minimum is 0 — burning token dust that resolves to no shares
         // is never the holder's intent.

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {MockB20SecurityStorage, MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+
+/// @title MockB20Security
+/// @author Coinbase
+/// @notice Reference implementation of the `IB20Security` variant.
+///         Extends `MockB20` with announcement, share-ratio,
+///         batched-issuance / batched-clawback, redemption, and
+///         security-identifier surfaces; all base behavior is
+///         inherited unchanged.
+///
+/// @dev    Variant-specific state lives in `MockB20SecurityStorage`'s
+///         own ERC-7201 namespace (`base.b20.security`), disjoint from
+///         the base `MockB20Storage` namespace (`base.b20`), so the
+///         variant composes additively without touching the base's
+///         slot layout. The Rust precompile mirrors both namespaces
+///         the same way.
+///
+///         **Policy override.** `REDEEMER_SENDER` lives in this
+///         variant's own `redeemPolicyIds` packed slot, mirroring the
+///         per-operation packed-slot layout the base uses for
+///         `transferPolicyIds` / `mintPolicyIds`. `_readPolicyId` and
+///         `_writePolicyId` are overridden to handle that slot first
+///         and fall through to `super` for everything else, which is
+///         the pattern `MockB20Storage`'s natspec explicitly
+///         anticipates.
+///
+///         **Share ratio default.** A stored `sharesToTokensRatio` of
+///         zero is interpreted by the read surface as `WAD_PRECISION`,
+///         so a freshly-etched token reports a 1:1 ratio without
+///         requiring the factory to write the default. The Rust impl
+///         applies the same fallback so on-chain reads agree.
+///
+///         **Factory bootstrap.** Operator and admin gates honor
+///         `_isPrivileged()` so the factory can stage initial
+///         announcements, batched issuance, ratios, identifiers, and
+///         minimum-redeemable values during the bootstrap window
+///         without first granting itself roles. The two paths that
+///         the factory will never legitimately call during bootstrap
+///         (`redeem` / `redeemWithMemo`, which are holder-initiated,
+///         and `batchBurn`, which is a corporate-actions clawback
+///         against existing balances) deliberately do NOT bypass
+///         their authorization checks: there is no init-time use case
+///         for them, so the bypass would be dead code that widens the
+///         attack surface without buying anything. Token invariants
+///         (supply-cap math, balance accounting, share-amount floor
+///         on `redeem`) are NOT bypassed anywhere.
+contract MockB20Security is MockB20, IB20Security {
+    // ============================================================
+    //                          CONSTANTS
+    // ============================================================
+
+    bytes32 public constant SECURITY_OPERATOR_ROLE = keccak256("SECURITY_OPERATOR_ROLE");
+    bytes32 public constant BURN_FROM_ROLE = keccak256("BURN_FROM_ROLE");
+
+    bytes32 public constant REDEEMER_SENDER = keccak256("REDEEMER_SENDER");
+
+    /// @notice Fixed-point precision for the share ratio. `1e18` (one
+    ///         WAD) is the standard DeFi convention; `toShares` and
+    ///         `sharesOf` divide by this after multiplying by the
+    ///         stored ratio.
+    uint256 public constant WAD_PRECISION = 1e18;
+
+    // ============================================================
+    //                        ANNOUNCEMENTS
+    // ============================================================
+
+    function announce(string calldata id, string calldata description, string calldata uri) external {
+        _requireRole(SECURITY_OPERATOR_ROLE);
+        MockB20SecurityStorage.Layout storage $ = MockB20SecurityStorage.layout();
+        if ($.usedAnnouncementIds[id]) revert AnnouncementIdAlreadyUsed(id);
+        $.usedAnnouncementIds[id] = true;
+        emit Announcement(msg.sender, id, description, uri);
+    }
+
+    function isAnnouncementIdUsed(string calldata id) external view returns (bool) {
+        return MockB20SecurityStorage.layout().usedAnnouncementIds[id];
+    }
+
+    // ============================================================
+    //                         SHARE RATIO
+    // ============================================================
+
+    function sharesToTokensRatio() external view returns (uint256) {
+        return _sharesToTokensRatio();
+    }
+
+    function toShares(uint256 balance) external view returns (uint256) {
+        return (balance * _sharesToTokensRatio()) / WAD_PRECISION;
+    }
+
+    function sharesOf(address account) external view returns (uint256) {
+        return (MockB20Storage.layout().balances[account] * _sharesToTokensRatio()) / WAD_PRECISION;
+    }
+
+    function updateShareRatio(uint256 newSharesToTokensRatio) external {
+        _requireRole(SECURITY_OPERATOR_ROLE);
+        MockB20SecurityStorage.layout().sharesToTokensRatio = newSharesToTokensRatio;
+        emit ShareRatioUpdated(newSharesToTokensRatio);
+    }
+
+    // ============================================================
+    //                  BATCHED ISSUANCE / CLAWBACK
+    // ============================================================
+
+    function batchMint(address[] calldata recipients, uint256[] calldata amounts) external {
+        if (recipients.length != amounts.length) revert LengthMismatch(recipients.length, amounts.length);
+        if (recipients.length == 0) revert EmptyBatch();
+        // Per-element call into _mint: role / pause checks repeat (idempotent),
+        // but MINT_RECEIVER policy and supply-cap accumulation are correctly
+        // applied per recipient. Cleaner than re-deriving the per-element body.
+        for (uint256 i = 0; i < recipients.length; i++) {
+            _mint(recipients[i], amounts[i]);
+        }
+    }
+
+    function batchBurn(address[] calldata accounts, uint256[] calldata amounts) external {
+        if (accounts.length != amounts.length) revert LengthMismatch(accounts.length, amounts.length);
+        if (accounts.length == 0) revert EmptyBatch();
+        if (!hasRole(BURN_FROM_ROLE, msg.sender)) {
+            revert AccessControlUnauthorizedAccount(msg.sender, BURN_FROM_ROLE);
+        }
+        if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
+        for (uint256 i = 0; i < accounts.length; i++) {
+            _burnRaw(accounts[i], amounts[i]);
+        }
+    }
+
+    // ============================================================
+    //                          REDEMPTION
+    // ============================================================
+
+    function redeem(uint256 amount) external {
+        uint256 ratio = _redeemBurn(amount);
+        emit Redeemed(msg.sender, amount, ratio);
+    }
+
+    function redeemWithMemo(uint256 amount, bytes32 memo) external {
+        uint256 ratio = _redeemBurn(amount);
+        // Order matters: Transfer (in _redeemBurn), then Memo, then Redeemed.
+        emit Memo(memo);
+        emit Redeemed(msg.sender, amount, ratio);
+    }
+
+    function updateMinimumRedeemable(uint256 newMinimumRedeemable) external {
+        _requireAdmin();
+        MockB20SecurityStorage.layout().minimumRedeemable = newMinimumRedeemable;
+        emit MinimumRedeemableUpdated(newMinimumRedeemable);
+    }
+
+    function minimumRedeemable() external view returns (uint256) {
+        return MockB20SecurityStorage.layout().minimumRedeemable;
+    }
+
+    // ============================================================
+    //                     SECURITY IDENTIFIERS
+    // ============================================================
+
+    function securityIdentifier(string calldata identifierType) external view returns (string memory) {
+        return MockB20SecurityStorage.layout().identifiers[identifierType];
+    }
+
+    function updateSecurityIdentifier(string calldata identifierType, string calldata value) external {
+        _requireRole(SECURITY_OPERATOR_ROLE);
+        if (bytes(identifierType).length == 0) revert InvalidIdentifierType();
+        MockB20SecurityStorage.layout().identifiers[identifierType] = value;
+        emit IdentifierUpdated(identifierType, value);
+    }
+
+    // ============================================================
+    //                       POLICY OVERRIDES
+    // ============================================================
+
+    /// @dev Variant-first policy resolution: REDEEMER_SENDER lives in
+    ///      this variant's own packed slot; everything else falls
+    ///      through to the base. The base's UnsupportedPolicyType
+    ///      revert is the terminal case.
+    function _readPolicyId(bytes32 policyType) internal view virtual override returns (uint64) {
+        if (policyType == REDEEMER_SENDER) {
+            return uint64(MockB20SecurityStorage.layout().redeemPolicyIds);
+        }
+        return super._readPolicyId(policyType);
+    }
+
+    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual override {
+        if (policyType == REDEEMER_SENDER) {
+            MockB20SecurityStorage.Layout storage $ = MockB20SecurityStorage.layout();
+            uint256 mask = uint256(type(uint64).max);
+            $.redeemPolicyIds = ($.redeemPolicyIds & ~mask) | uint256(newPolicyId);
+            return;
+        }
+        super._writePolicyId(policyType, newPolicyId);
+    }
+
+    // ============================================================
+    //                       INTERNAL HELPERS
+    // ============================================================
+
+    /// @dev Stored `0` resolves to `WAD_PRECISION` so a freshly-etched
+    ///      token (no factory write yet) reports a 1:1 ratio.
+    function _sharesToTokensRatio() internal view returns (uint256) {
+        uint256 stored = MockB20SecurityStorage.layout().sharesToTokensRatio;
+        return stored == 0 ? WAD_PRECISION : stored;
+    }
+
+    /// @dev Burn the caller's balance for redemption. Returns the
+    ///      ratio used for the share-amount math so callers can emit
+    ///      `Redeemed` with the same value the floor was checked
+    ///      against. No factory bypass: redeem is a holder-initiated
+    ///      path that the factory has no legitimate reason to invoke
+    ///      during bootstrap, so the bypass is omitted by design.
+    function _redeemBurn(uint256 amount) internal returns (uint256 ratio) {
+        if (_isPaused(PausableFeature.REDEEM)) revert ContractPaused(PausableFeature.REDEEM);
+        uint64 redeemerSenderPolicyId = uint64(MockB20SecurityStorage.layout().redeemPolicyIds);
+        if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(redeemerSenderPolicyId, msg.sender)) {
+            revert PolicyForbids(REDEEMER_SENDER, redeemerSenderPolicyId);
+        }
+        ratio = _sharesToTokensRatio();
+        uint256 shares = (amount * ratio) / WAD_PRECISION;
+        uint256 minimum = MockB20SecurityStorage.layout().minimumRedeemable;
+        // Always reject zero-share redemptions, even if the configured
+        // minimum is 0 — burning token dust that resolves to no shares
+        // is never the holder's intent.
+        if (shares == 0 || shares < minimum) revert BelowMinimumRedeemable(shares, minimum);
+        _burnRaw(msg.sender, amount);
+    }
+}

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -10,10 +10,10 @@ import {MockB20SecurityStorage, MockB20Storage} from "test/lib/mocks/MockB20Stor
 /// @title MockB20Security
 /// @author Coinbase
 /// @notice Reference implementation of the `IB20Security` variant.
-///         Extends `MockB20` with announcement, share-ratio,
-///         batched-issuance / batched-clawback, redemption, and
-///         security-identifier surfaces; all base behavior is
-///         inherited unchanged.
+///         Extends `MockB20` with the announcement bracket,
+///         share-ratio accounting, batched issuance / clawback,
+///         redemption, and security-identifier surfaces; all base
+///         behavior is inherited unchanged.
 ///
 /// @dev    Variant-specific state lives in `MockB20SecurityStorage`'s
 ///         own ERC-7201 namespace (`base.b20.security`), disjoint from
@@ -21,6 +21,22 @@ import {MockB20SecurityStorage, MockB20Storage} from "test/lib/mocks/MockB20Stor
 ///         variant composes additively without touching the base's
 ///         slot layout. The Rust precompile mirrors both namespaces
 ///         the same way.
+///
+///         **Announcement bracketing.** `announce(...)` is the
+///         canonical disclosure-and-execute primitive: it emits
+///         `Announcement(...)`, runs the operator's `internalCalls`
+///         in-order via self-`delegatecall` (so `msg.sender` stays
+///         the operator and the inner functions' role checks pass
+///         normally), and emits `EndAnnouncement(id)`. Any inner
+///         revert unwinds the entire transaction, so an
+///         `Announcement` log is never observable without its
+///         matching `EndAnnouncement`. `_checkSelector` rejects
+///         recursive `announce` invocations (`AnnouncementInProgress`)
+///         to keep the bracket exactly one level deep. The Rust impl
+///         needs to mirror EVM `delegatecall` semantics exactly
+///         (caller and storage preserved); a plain `call` to self
+///         would change `msg.sender` to the contract address and
+///         break the inner role checks.
 ///
 ///         **Policy override.** `REDEEMER_SENDER` lives in this
 ///         variant's own `redeemPolicyIds` packed slot, mirroring the
@@ -67,16 +83,41 @@ contract MockB20Security is MockB20, IB20Security {
     ///         stored ratio.
     uint256 public constant WAD_PRECISION = 1e18;
 
+    /// @dev Selector for the announce function itself. Used by
+    ///      `_checkSelector` to deny recursive `announce` invocations
+    ///      from inside `internalCalls`, keeping the bracket exactly
+    ///      one level deep.
+    bytes4 internal constant ANNOUNCE_SELECTOR = IB20Security.announce.selector;
+
     // ============================================================
     //                        ANNOUNCEMENTS
     // ============================================================
 
-    function announce(string calldata id, string calldata description, string calldata uri) external {
+    function announce(
+        bytes[] calldata internalCalls,
+        string calldata id,
+        string calldata description,
+        string calldata uri
+    ) external {
         _requireRole(SECURITY_OPERATOR_ROLE);
+
         MockB20SecurityStorage.Layout storage $ = MockB20SecurityStorage.layout();
         if ($.usedAnnouncementIds[id]) revert AnnouncementIdAlreadyUsed(id);
+        // Mark consumed BEFORE the emit and BEFORE any inner calls so
+        // a delegatecall back into `announce` (defended-against by
+        // `_checkSelector`) would fail this guard even if the
+        // selector check were ever weakened.
         $.usedAnnouncementIds[id] = true;
+
         emit Announcement(msg.sender, id, description, uri);
+
+        for (uint256 i = 0; i < internalCalls.length; i++) {
+            _checkSelector(internalCalls[i]);
+            (bool success,) = address(this).delegatecall(internalCalls[i]);
+            if (!success) revert InternalCallFailed(internalCalls[i]);
+        }
+
+        emit EndAnnouncement(id);
     }
 
     function isAnnouncementIdUsed(string calldata id) external view returns (bool) {
@@ -229,5 +270,31 @@ contract MockB20Security is MockB20, IB20Security {
         // is never the holder's intent.
         if (shares == 0 || shares < minimum) revert BelowMinimumRedeemable(shares, minimum);
         _burnRaw(msg.sender, amount);
+    }
+
+    /// @dev Validates a single `internalCalls[i]` blob before
+    ///      `announce` issues the inner `delegatecall`. Two checks:
+    ///      (1) the blob carries at least four bytes (a function
+    ///      selector), else `InternalCallMalformed` — a too-short
+    ///      payload would otherwise hit the contract's fallback
+    ///      surface, which is not what an "internal call" is supposed
+    ///      to mean; (2) the selector is not `announce` itself, else
+    ///      `AnnouncementInProgress` — keeps the bracket one level
+    ///      deep so indexers can rely on `Announcement` /
+    ///      `EndAnnouncement` pairing without nesting.
+    ///
+    ///      The check is a denylist (only `announce` is blocked), not
+    ///      an allowlist of approved corp-action functions: the
+    ///      operator already needs both `SECURITY_OPERATOR_ROLE` to
+    ///      call `announce` AND whatever role each inner function
+    ///      requires (e.g. `MINT_ROLE` for `batchMint`), so the
+    ///      authorization story is already enforced by the inner
+    ///      functions' own gates. The recursion guard exists to
+    ///      protect the EVENT topology (no nested brackets), not the
+    ///      authorization topology.
+    function _checkSelector(bytes calldata call) internal pure {
+        if (call.length < 4) revert InternalCallMalformed(call);
+        bytes4 sel = bytes4(call[:4]);
+        if (sel == ANNOUNCE_SELECTOR) revert AnnouncementInProgress();
     }
 }

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -187,7 +187,7 @@ library MockB20Storage {
 ///           verbatim; subsequent reads return the stored value as-is.
 ///         - `redeemPolicyIds` is a per-operation packed slot,
 ///           mirroring base's `transferPolicyIds` / `mintPolicyIds`
-///           layout: only `REDEEMER_SENDER` is defined today, with
+///           layout: only `REDEEMER_SENDER_POLICY` is defined today, with
 ///           three reserved lanes for future redeem-side granularity
 ///           (e.g. `REDEEMER_RECEIVER` if and when off-chain
 ///           settlement counterparties get policy gating).

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -203,17 +203,6 @@ library MockB20SecurityStorage {
         // Scaled by WAD_PRECISION (1e18). Stored value of 0 is
         // interpreted as WAD by the read surface.
         uint256 sharesToTokensRatio;
-        // ---------- Redemption ----------
-        // Floor on `redeem` / `redeemWithMemo`, expressed in shares.
-        // Defaults to 0 (no floor); admin sets via updateMinimumRedeemable.
-        uint256 minimumRedeemable;
-        // ---------- Redeem-side policies (PACKED) ----------
-        // Layout:
-        //   [63:0]    redeemerSenderPolicyId
-        //   [127:64]  reserved
-        //   [191:128] reserved
-        //   [255:192] reserved
-        uint256 redeemPolicyIds;
         // ---------- Announcements ----------
         // Tracks consumed announcement IDs; flips to true on first
         // `announce` for a given id, and remains true forever.
@@ -236,10 +225,8 @@ library MockB20SecurityStorage {
     // deriving member slots via `keccak256(abi.encode(key, baseSlot))`.
 
     uint256 internal constant SHARES_TO_TOKENS_RATIO_OFFSET = 0;
-    uint256 internal constant MINIMUM_REDEEMABLE_OFFSET = 1;
-    uint256 internal constant REDEEM_POLICY_IDS_OFFSET = 2;
-    uint256 internal constant USED_ANNOUNCEMENT_IDS_OFFSET = 3;
-    uint256 internal constant IDENTIFIERS_OFFSET = 4;
+    uint256 internal constant USED_ANNOUNCEMENT_IDS_OFFSET = 1;
+    uint256 internal constant IDENTIFIERS_OFFSET = 2;
 
     /// @notice Absolute slot for a top-level field of `Layout`.
     function slotOf(uint256 offset) internal pure returns (bytes32) {
@@ -257,6 +244,49 @@ library MockB20SecurityStorage {
     ///         hardcoded `STORAGE_LOCATION` constant matches the formula.
     function derivedLocation() internal pure returns (bytes32) {
         return keccak256(abi.encode(uint256(keccak256("base.b20.security")) - 1)) & ~bytes32(uint256(0xff));
+    }
+}
+
+library MockB20RedeemStorage {
+    // keccak256(abi.encode(uint256(keccak256("base.b20.redeem")) - 1)) & ~bytes32(uint256(0xff))
+    // Verified against the computation in derivedLocation() below.
+    bytes32 internal constant STORAGE_LOCATION = 0xc95c24ab0255f9fb9fcdcd524f71c4fe0437265856b7e5e6d0801df0e6cf5100;
+
+    uint256 internal constant MINIMUM_REDEEMABLE_OFFSET = 0;
+    uint256 internal constant REDEEM_POLICY_IDS_OFFSET = 1;
+
+    /// @notice Absolute slot for a top-level field of `Layout`.
+    function slotOf(uint256 offset) internal pure returns (bytes32) {
+        return bytes32(uint256(STORAGE_LOCATION) + offset);
+    }
+
+    function layout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_LOCATION
+        }
+    }
+    
+    /// @custom:storage-location erc7201:base.b20.redeem
+    struct Layout {
+        // ---------- Redemption ----------
+        // Floor on `redeem` / `redeemWithMemo`, expressed in shares.
+        // Defaults to 0 (no floor); admin sets via updateMinimumRedeemable.
+        uint256 minimumRedeemable;
+
+        // ---------- Redeem-side policies (PACKED) ----------
+        // Layout:
+        //   [63:0]    redeemerSenderPolicyId
+        //   [127:64]  reserved
+        //   [191:128] reserved
+        //   [255:192] reserved
+        uint256 redeemPolicyIds;
+    }
+
+    /// @notice Returns the storage location derived per the ERC-7201 formula
+    ///         from the namespace string. Used in tests to assert the
+    ///         hardcoded `STORAGE_LOCATION` constant matches the formula.
+    function derivedLocation() internal pure returns (bytes32) {
+        return keccak256(abi.encode(uint256(keccak256("base.b20.redeem")) - 1)) & ~bytes32(uint256(0xff));
     }
 }
 

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -165,6 +165,101 @@ library MockB20Storage {
     }
 }
 
+/// @title MockB20SecurityStorage
+/// @notice Slot-layout library for the `MockB20Security` variant's
+///         variant-specific state. Disjoint namespace from
+///         `MockB20Storage` so the variant composes additively
+///         without touching the base token's slot layout, mirroring
+///         how `MockB20StablecoinStorage` adds `currency` for the
+///         stablecoin variant.
+///
+/// @dev    **Namespace:** `base.b20.security`. The ERC-7201 location
+///         is `keccak256(abi.encode(uint256(keccak256("base.b20.security")) - 1)) & ~bytes32(uint256(0xff))`.
+///
+///         **Storage notes.**
+///         - `sharesToTokensRatio` stores the WAD-scaled
+///           share-to-tokens ratio. A stored value of `0` is
+///           interpreted by the read surface (`sharesToTokensRatio()`,
+///           `toShares(...)`, `sharesOf(...)`) as `WAD_PRECISION`, so a
+///           freshly-etched token reports a 1:1 ratio without
+///           requiring the factory to write the default value during
+///           bootstrap. `updateShareRatio` writes the new ratio
+///           verbatim; subsequent reads return the stored value as-is.
+///         - `redeemPolicyIds` is a per-operation packed slot,
+///           mirroring base's `transferPolicyIds` / `mintPolicyIds`
+///           layout: only `REDEEMER_SENDER` is defined today, with
+///           three reserved lanes for future redeem-side granularity
+///           (e.g. `REDEEMER_RECEIVER` if and when off-chain
+///           settlement counterparties get policy gating).
+///         - `usedAnnouncementIds` keys directly on the raw `string id`
+///           that callers pass to `announce` / `isAnnouncementIdUsed`,
+///           not on a hash, so the on-chain query mirrors the API.
+///         - `identifiers` keys directly on the raw `identifierType`
+///           string (e.g. `"ISIN"`); empty value means unset/removed.
+library MockB20SecurityStorage {
+    /// @custom:storage-location erc7201:base.b20.security
+    struct Layout {
+        // ---------- Share ratio ----------
+        // Scaled by WAD_PRECISION (1e18). Stored value of 0 is
+        // interpreted as WAD by the read surface.
+        uint256 sharesToTokensRatio;
+        // ---------- Redemption ----------
+        // Floor on `redeem` / `redeemWithMemo`, expressed in shares.
+        // Defaults to 0 (no floor); admin sets via updateMinimumRedeemable.
+        uint256 minimumRedeemable;
+        // ---------- Redeem-side policies (PACKED) ----------
+        // Layout:
+        //   [63:0]    redeemerSenderPolicyId
+        //   [127:64]  reserved
+        //   [191:128] reserved
+        //   [255:192] reserved
+        uint256 redeemPolicyIds;
+        // ---------- Announcements ----------
+        // Tracks consumed announcement IDs; flips to true on first
+        // `announce` for a given id, and remains true forever.
+        mapping(string id => bool used) usedAnnouncementIds;
+        // ---------- Security identifiers ----------
+        // ISIN, CUSIP, FIGI, etc. Empty string means unset/removed.
+        mapping(string identifierType => string value) identifiers;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("base.b20.security")) - 1)) & ~bytes32(uint256(0xff))
+    // Verified against the computation in derivedLocation() below.
+    bytes32 internal constant STORAGE_LOCATION = 0x4a21e1b7f963e21baf0daffe6bab858a1e5fecef1144f3aca3c0c4534c7ac600;
+
+    // ============================================================
+    //                     SLOT OFFSETS WITHIN LAYOUT
+    // ============================================================
+    // Sequential allocation matches `Layout` field order top-to-
+    // bottom. Mappings consume one slot each (their VALUES hash to
+    // unrelated locations); the factory uses these as base slots when
+    // deriving member slots via `keccak256(abi.encode(key, baseSlot))`.
+
+    uint256 internal constant SHARES_TO_TOKENS_RATIO_OFFSET = 0;
+    uint256 internal constant MINIMUM_REDEEMABLE_OFFSET = 1;
+    uint256 internal constant REDEEM_POLICY_IDS_OFFSET = 2;
+    uint256 internal constant USED_ANNOUNCEMENT_IDS_OFFSET = 3;
+    uint256 internal constant IDENTIFIERS_OFFSET = 4;
+
+    /// @notice Absolute slot for a top-level field of `Layout`.
+    function slotOf(uint256 offset) internal pure returns (bytes32) {
+        return bytes32(uint256(STORAGE_LOCATION) + offset);
+    }
+
+    function layout() internal pure returns (Layout storage $) {
+        assembly {
+            $.slot := STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Returns the storage location derived per the ERC-7201 formula
+    ///         from the namespace string. Used in tests to assert the
+    ///         hardcoded `STORAGE_LOCATION` constant matches the formula.
+    function derivedLocation() internal pure returns (bytes32) {
+        return keccak256(abi.encode(uint256(keccak256("base.b20.security")) - 1)) & ~bytes32(uint256(0xff));
+    }
+}
+
 /// @title MockB20StablecoinStorage
 /// @notice Slot-layout library for the `MockB20Stablecoin` variant's
 ///         variant-specific state. Disjoint namespace from `MockB20Storage`


### PR DESCRIPTION
Adds a complete reference implementation for the IB20Security variant under test/lib/mocks/ and, in the process, evolves the interface itself most substantially around `announce`, which becomes the canonical "disclosure-and-execute" primitive instead of an unenforced indexer-pairing convention.

The interface changes are deliberate ABI/semantic shifts, not just docs: see the announce signature change, new errors, new role, redesigned batchBurn, and tightened redeem below. All changes should be back-ported to the spec doc by EoD.