### PR TITLE
Fix decimals to be variant-fixed and remove address encoding

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -219,9 +219,9 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_FACTORY,
-        "(uint160(decimals) << 64)",
-        "(uint160(decimals) << 56)",
-        "_computeAddress: decimals byte shifted to wrong position (overlaps tail bytes)",
+        "| uint160(uint64(tail));",
+        "| (uint160(uint64(tail)) << 8);",
+        "_computeAddress: tail shifted into reserved byte [11] (breaks deterministic addressing)",
     ),
     Mutation(
         MOCK_FACTORY,
@@ -266,19 +266,6 @@ MUTATIONS: list[Mutation] = [
         "uint256 chunks = (data.length + 31) / 32;",
         "uint256 chunks = (data.length + 30) / 32;",
         "_writeString: chunk count off-by-one (loses trailing bytes for non-aligned lengths)",
-    ),
-    # === Factory decimals validation boundaries ===
-    Mutation(
-        MOCK_FACTORY,
-        "if (p.decimals < 2 || p.decimals > 18) revert InvalidDecimals(p.decimals);",
-        "if (p.decimals <= 2 || p.decimals > 18) revert InvalidDecimals(p.decimals);",
-        "createToken: rejects decimals == 2 (lower bound off-by-one)",
-    ),
-    Mutation(
-        MOCK_FACTORY,
-        "if (p.decimals < 2 || p.decimals > 18) revert InvalidDecimals(p.decimals);",
-        "if (p.decimals < 2 || p.decimals >= 18) revert InvalidDecimals(p.decimals);",
-        "createToken: rejects decimals == 18 (upper bound off-by-one)",
     ),
     # === Factory TokenAlreadyExists check ===
     Mutation(

--- a/script/mutate.py
+++ b/script/mutate.py
@@ -219,9 +219,9 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_FACTORY,
-        "| uint160(uint64(tail));",
-        "| (uint160(uint64(tail)) << 8);",
-        "_computeAddress: tail shifted into reserved byte [11] (breaks deterministic addressing)",
+        "| uint160(uint72(tail));",
+        "| (uint160(uint72(tail)) << 8);",
+        "_computeAddress: tail shifted left by 8 bits (truncates entropy and breaks deterministic addressing)",
     ),
     Mutation(
         MOCK_FACTORY,
@@ -231,8 +231,8 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_FACTORY,
-        "bytes8 tail = bytes8(keccak256(abi.encode(sender, salt)));",
-        "bytes8 tail = bytes8(keccak256(abi.encodePacked(sender, salt)));",
+        "bytes9 tail = bytes9(keccak256(abi.encode(sender, salt)));",
+        "bytes9 tail = bytes9(keccak256(abi.encodePacked(sender, salt)));",
         "_computeAddress: encode vs encodePacked (different hash, breaks determinism contract)",
     ),
     # === Address prefix check ===

--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -419,10 +419,9 @@ interface IB20 {
     /// @notice Token symbol. Set at creation, mutable via `setSymbol`.
     function symbol() external view returns (string memory);
 
-    /// @notice Number of decimal places. Set at creation, immutable
-    ///         thereafter. The factory determines whether `decimals` is
-    ///         a per-token parameter or a fixed value (the choice is a
-    ///         factory concern, not a token concern).
+    /// @notice Number of decimal places. Immutable per token variant.
+    /// @dev    Current variant defaults are fixed by the factory:
+    ///         Default = 18, Stablecoin = 6, Security = 6.
     function decimals() external view returns (uint8);
 
     /// @notice Total token supply currently in circulation.

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -20,8 +20,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         - `[0:10]`  — `bytes10(0xB200000000000000000000)` shared
 ///                       prefix identifying a factory-created B-20.
 ///         - `[10]`    — `bytes1(variant)` (matches `TokenVariant`).
-///         - `[11]`    — reserved for future use (currently `0x00`).
-///         - `[12:20]` — `bytes8(keccak256(abi.encode(msg.sender, salt)))`.
+///         - `[11:20]` — `bytes9(keccak256(abi.encode(msg.sender, salt)))`.
 ///
 ///         **Variant evolution.** Adding new required fields to an
 ///         existing variant after launch is NOT supported: the factory is

--- a/src/interfaces/ITokenFactory.sol
+++ b/src/interfaces/ITokenFactory.sol
@@ -20,13 +20,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         - `[0:10]`  — `bytes10(0xB200000000000000000000)` shared
 ///                       prefix identifying a factory-created B-20.
 ///         - `[10]`    — `bytes1(variant)` (matches `TokenVariant`).
-///         - `[11]`    — `bytes1(decimals)` — encoded in the address so
-///                       `decimals()` is recoverable statelessly from the
-///                       token address alone, avoiding a storage read on
-///                       hot integration paths (AMMs, lending markets,
-///                       wallets). For variants that hardcode decimals
-///                       (Stablecoin, Security: 6), this byte is fixed
-///                       at `0x06`.
+///         - `[11]`    — reserved for future use (currently `0x00`).
 ///         - `[12:20]` — `bytes8(keccak256(abi.encode(msg.sender, salt)))`.
 ///
 ///         **Variant evolution.** Adding new required fields to an
@@ -107,15 +101,11 @@ interface ITokenFactory {
     ///                      `renounceLastAdmin` path is the alternative
     ///                      for tokens that need an admin during setup
     ///                      and then want to evolve to admin-less.
-    /// @param decimals      ERC-20 decimals. MUST be in `[2, 18]`.
-    ///                      Encoded into address byte `[11]` for
-    ///                      stateless retrieval.
     struct B20CreateParams {
         uint8 version;
         string name;
         string symbol;
         address initialAdmin;
-        uint8 decimals;
     }
 
     /// @notice Creation parameters for a Stablecoin-variant B-20 token.
@@ -127,9 +117,8 @@ interface ITokenFactory {
     ///                      "EUR", "XAU"). Required: empty string
     ///                      reverts. See `IB20Stablecoin.currency` for
     ///                      the convention.
-    /// @dev    Decimals are fixed at `6` (the SPL stablecoin convention)
-    ///         and encoded as `0x06` in address byte `[11]`. There is no
-    ///         decimals field on this struct.
+    /// @dev    Decimals are fixed at `6` (the SPL stablecoin convention).
+    ///         There is no decimals field on this struct.
     struct B20StablecoinCreateParams {
         uint8 version;
         string name;
@@ -150,8 +139,7 @@ interface ITokenFactory {
     ///                           via `IB20Security.updateSecurityIdentifier`.
     /// @param minimumRedeemable  Initial value of `minimumRedeemable`.
     ///                           Use `0` to allow any non-zero redemption.
-    /// @dev    Decimals are fixed at `6` and encoded as `0x06` in address
-    ///         byte `[11]`. Security tokens have no `initialSupply`
+    /// @dev    Decimals are fixed at `6`. Security tokens have no `initialSupply`
     ///         parameter: all issuance flows through `create`
     ///         (rate-limited compliant path) or `adminMint` (cold-path
     ///         batch with announcement coupling) after deployment.
@@ -169,7 +157,7 @@ interface ITokenFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice A token already exists at the deterministic address
-    ///         derived from `(variant, decimals, msg.sender, salt)`.
+    ///         derived from `(variant, msg.sender, salt)`.
     ///         Caller must use a different salt.
     error TokenAlreadyExists(address token);
 
@@ -180,12 +168,6 @@ interface ITokenFactory {
     /// @notice The leading `version` byte in `params` does not match
     ///         any known encoding for the requested variant.
     error UnsupportedVersion(uint8 version);
-
-    /// @notice The provided decimals value is outside the variant's
-    ///         allowed range. Default tokens require `[2, 18]`;
-    ///         Stablecoin and Security tokens hardcode `6` and do not
-    ///         accept a caller-supplied value.
-    error InvalidDecimals(uint8 decimals);
 
     /// @notice A required string argument was the empty string (e.g.
     ///         stablecoin `currency`, security `isin`).
@@ -227,8 +209,8 @@ interface ITokenFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Creates a B-20 token of the given `variant` at the
-    ///         deterministic address derived from `(variant, decimals,
-    ///         msg.sender, salt)`. `params` MUST be the ABI-encoded
+    ///         deterministic address derived from `(variant, msg.sender, salt)`.
+    ///         `params` MUST be the ABI-encoded
     ///         variant-specific struct (`B20CreateParams`,
     ///         `B20StablecoinCreateParams`, or `B20SecurityCreateParams`),
     ///         leading with a `version` byte the factory uses to select
@@ -279,13 +261,11 @@ interface ITokenFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Returns the deterministic address `createToken` would
-    ///         assign for `(variant, decimals, sender, salt)`. Address
-    ///         derivation depends only on these four inputs; the
-    ///         remaining `params` fields do not affect the address.
-    /// @dev    `variant` and `decimals` are both required because both
-    ///         are encoded into the address (bytes `[10]` and `[11]`).
-    ///         For Stablecoin and Security variants, pass `decimals = 6`.
-    function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
+    ///         assign for `(variant, sender, salt)`. Address derivation
+    ///         depends only on these inputs; the remaining `params`
+    ///         fields (including decimals, which are fixed by variant)
+    ///         do not affect the address.
+    function getTokenAddress(TokenVariant variant, address sender, bytes32 salt)
         external
         view
         returns (address);

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -14,7 +14,7 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 /// without the factory: `setUp` calls `super.setUp()` to etch every
 /// precompile mock (via `BaseTest`) and pick up the factory create
 /// helpers, then deploys a default-variant token here so the token's
-/// identity bytes (variant byte at address `[10]`, decimals byte at
+/// identity bytes (variant byte at address `[10]`, reserved byte at
 /// `[11]`) match the real address schema. In live mode under
 /// `--fork-url`, the same flow hits the real precompile factory.
 ///

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -14,8 +14,8 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 /// without the factory: `setUp` calls `super.setUp()` to etch every
 /// precompile mock (via `BaseTest`) and pick up the factory create
 /// helpers, then deploys a default-variant token here so the token's
-/// identity bytes (variant byte at address `[10]`, reserved byte at
-/// `[11]`) match the real address schema. In live mode under
+/// identity byte (variant at address `[10]`) matches the real address
+/// schema. In live mode under
 /// `--fork-url`, the same flow hits the real precompile factory.
 ///
 /// On top of the inherited factory actors, this contract adds the

--- a/test/lib/TokenFactoryTest.sol
+++ b/test/lib/TokenFactoryTest.sol
@@ -21,23 +21,17 @@ contract TokenFactoryTest is BaseTest {
     // -- Param builders --
 
     /// @notice Build a `B20CreateParams` with explicit fields.
-    function _b20Params(string memory name_, string memory symbol_, address initialAdmin_, uint8 decimals_)
+    function _b20Params(string memory name_, string memory symbol_, address initialAdmin_)
         internal
         pure
         returns (ITokenFactory.B20CreateParams memory)
     {
-        return ITokenFactory.B20CreateParams({
-            version: 1,
-            name: name_,
-            symbol: symbol_,
-            initialAdmin: initialAdmin_,
-            decimals: decimals_
-        });
+        return ITokenFactory.B20CreateParams({version: 1, name: name_, symbol: symbol_, initialAdmin: initialAdmin_});
     }
 
-    /// @notice Build a default `B20CreateParams` (`Test`/`TST`, admin, 18 decimals).
+    /// @notice Build a default `B20CreateParams` (`Test`/`TST`, admin).
     function _b20Params() internal view returns (ITokenFactory.B20CreateParams memory) {
-        return _b20Params("Test", "TST", admin, 18);
+        return _b20Params("Test", "TST", admin);
     }
 
     /// @notice Build a `B20StablecoinCreateParams` with explicit fields.

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -47,8 +47,8 @@ library B20Constants {
 ///           single ERC-7201 namespaced root. The struct field order IS
 ///           the slot layout the Rust impl mirrors; slot offsets are
 ///           named constants on `MockB20Storage`.
-///         - `decimals()` is decoded from address byte `[11]` — no
-///           storage slot. The Rust impl does the same.
+///         - `decimals()` is a fixed `18` on the default variant — no
+///           storage slot.
 ///         - **No factory-only entrypoints exist on this contract.**
 ///           Initial storage state (name, symbol, supply cap, admin
 ///           role, `initialized` flag) is written directly by the
@@ -118,11 +118,9 @@ contract MockB20 is IB20 {
         return MockB20Storage.layout().symbol;
     }
 
-    /// @notice Decimals are encoded in address byte `[11]` by the
-    ///         factory. Stateless retrieval; no storage slot.
-    function decimals() external view returns (uint8) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return uint8(uint160(address(this)) >> 64);
+    /// @notice Default-variant decimals are fixed at 18.
+    function decimals() external pure virtual returns (uint8) {
+        return 18;
     }
 
     function totalSupply() external view returns (uint256) {

--- a/test/lib/mocks/MockB20Stablecoin.sol
+++ b/test/lib/mocks/MockB20Stablecoin.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+import {IB20} from "src/interfaces/IB20.sol";
 
 import {MockB20} from "test/lib/mocks/MockB20.sol";
 import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
@@ -21,6 +22,11 @@ import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
 ///         (via `vm.store` at the variant namespace's `CURRENCY_OFFSET`)
 ///         during creation; there is no init function and no mutator.
 contract MockB20Stablecoin is MockB20, IB20Stablecoin {
+    /// @notice Stablecoin-variant decimals are fixed at 6.
+    function decimals() external pure override(MockB20, IB20) returns (uint8) {
+        return 6;
+    }
+
     /// @notice The immutable currency identifier (e.g. "USD", "EUR",
     ///         "XAU"). Written by the factory at creation.
     function currency() external view returns (string memory) {

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -34,9 +34,9 @@ pragma solidity ^0.8.20;
 ///
 ///         Identity state (`name`, `symbol`) is kept in this struct rather
 ///         than encoded into the address because mutability is required
-///         (`setName` / `setSymbol` on the IB20 surface). `decimals` IS
-///         encoded into the address (byte `[11]`) and is retrieved via pure
-///         address-decode in `MockB20.decimals()` — no storage slot.
+///         (`setName` / `setSymbol` on the IB20 surface). `decimals` is
+///         variant-fixed (`18` for default, `6` for stablecoin/security)
+///         and read from code, not storage.
 library MockB20Storage {
     /// @custom:storage-location erc7201:base.b20
     struct Layout {

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -23,7 +23,7 @@ import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20St
 ///            byte and required-field invariants).
 ///         2. Compute the deterministic token address per the
 ///            documented schema (`[0:10]` shared prefix, `[10]` variant
-///            byte, `[11]` reserved, `[12:20]` derived from
+///            byte, `[11:20]` derived from
 ///            `(msg.sender, salt)`).
 ///         3. Refuse to overwrite an existing token (revert
 ///            `TokenAlreadyExists`).
@@ -223,15 +223,14 @@ contract MockTokenFactory is ITokenFactory {
     ///        byte [0]      = 0xB2
     ///        bytes [1:10]  = 0x00 (9 zero bytes)
     ///        byte [10]     = variant
-    ///        byte [11]     = 0x00 (reserved)
-    ///        bytes [12:20] = keccak256(sender, salt)[0:8]
+    ///        bytes [11:20] = keccak256(sender, salt)[0:9]
     function _computeAddress(TokenVariant variant, address sender, bytes32 salt)
         internal
         pure
         returns (address)
     {
-        bytes8 tail = bytes8(keccak256(abi.encode(sender, salt)));
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(uint8(variant)) << 72) | uint160(uint64(tail));
+        bytes9 tail = bytes9(keccak256(abi.encode(sender, salt)));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(uint8(variant)) << 72) | uint160(uint72(tail));
         return address(addr);
     }
 

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -23,7 +23,7 @@ import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20St
 ///            byte and required-field invariants).
 ///         2. Compute the deterministic token address per the
 ///            documented schema (`[0:10]` shared prefix, `[10]` variant
-///            byte, `[11]` decimals byte, `[12:20]` derived from
+///            byte, `[11]` reserved, `[12:20]` derived from
 ///            `(msg.sender, salt)`).
 ///         3. Refuse to overwrite an existing token (revert
 ///            `TokenAlreadyExists`).
@@ -90,7 +90,7 @@ contract MockTokenFactory is ITokenFactory {
         external
         returns (address token)
     {
-        // -- 1. Decode + validate, get the four params every variant needs --
+        // -- 1. Decode + validate, get the common params --
         string memory name_;
         string memory symbol_;
         address admin;
@@ -100,11 +100,10 @@ contract MockTokenFactory is ITokenFactory {
         if (variant == TokenVariant.DEFAULT) {
             B20CreateParams memory p = abi.decode(params, (B20CreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
-            if (p.decimals < 2 || p.decimals > 18) revert InvalidDecimals(p.decimals);
             name_ = p.name;
             symbol_ = p.symbol;
             admin = p.initialAdmin;
-            decimals = p.decimals;
+            decimals = 18;
         } else if (variant == TokenVariant.STABLECOIN) {
             B20StablecoinCreateParams memory p = abi.decode(params, (B20StablecoinCreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
@@ -125,7 +124,7 @@ contract MockTokenFactory is ITokenFactory {
         }
 
         // -- 2-3. Compute address; refuse to overwrite --
-        token = _computeAddress(variant, decimals, msg.sender, salt);
+        token = _computeAddress(variant, msg.sender, salt);
         if (token.code.length != 0) revert TokenAlreadyExists(token);
 
         // -- 4. Etch the variant-appropriate runtime bytecode --
@@ -193,12 +192,12 @@ contract MockTokenFactory is ITokenFactory {
     bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
 
     /// @inheritdoc ITokenFactory
-    function getTokenAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
+    function getTokenAddress(TokenVariant variant, address sender, bytes32 salt)
         external
         pure
         returns (address)
     {
-        return _computeAddress(variant, decimals, sender, salt);
+        return _computeAddress(variant, sender, salt);
     }
 
     /// @inheritdoc ITokenFactory
@@ -219,21 +218,20 @@ contract MockTokenFactory is ITokenFactory {
     //                     ADDRESS SCHEMA HELPERS
     // ============================================================
 
-    /// @dev Encodes (variant, decimals, sender, salt) into the canonical
+    /// @dev Encodes (variant, sender, salt) into the canonical
     ///      B-20 address layout:
     ///        byte [0]      = 0xB2
     ///        bytes [1:10]  = 0x00 (9 zero bytes)
     ///        byte [10]     = variant
-    ///        byte [11]     = decimals
+    ///        byte [11]     = 0x00 (reserved)
     ///        bytes [12:20] = keccak256(sender, salt)[0:8]
-    function _computeAddress(TokenVariant variant, uint8 decimals, address sender, bytes32 salt)
+    function _computeAddress(TokenVariant variant, address sender, bytes32 salt)
         internal
         pure
         returns (address)
     {
         bytes8 tail = bytes8(keccak256(abi.encode(sender, salt)));
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(uint8(variant)) << 72) | (uint160(decimals) << 64)
-            | uint160(uint64(tail));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(uint8(variant)) << 72) | uint160(uint64(tail));
         return address(addr);
     }
 

--- a/test/unit/B20/erc20/decimals.t.sol
+++ b/test/unit/B20/erc20/decimals.t.sol
@@ -4,18 +4,16 @@ pragma solidity ^0.8.20;
 import {B20Test} from "test/lib/B20Test.sol";
 
 contract B20DecimalsTest is B20Test {
-    /// @notice Verifies decimals returns the value passed to the factory at creation
-    /// @dev Immutable after creation; should match address byte [11]
+    /// @notice Verifies default-token decimals are fixed at 18
     function test_decimals_success_returnsCreationDecimals() public view {
-        // The default _b20Params() helper creates a token with decimals 18.
-        assertEq(token.decimals(), 18, "decimals must match creation value");
+        assertEq(token.decimals(), 18, "default token decimals must be 18");
     }
 
-    /// @notice Verifies decimals matches byte [11] of the token's own address
-    /// @dev Address-schema invariant: stateless decimals() lookup must agree with storage
-    function test_decimals_success_matchesAddressByte() public view {
+    /// @notice Verifies address byte [11] is reserved and no longer drives decimals
+    function test_decimals_success_reservedByteIgnored() public view {
         // forge-lint: disable-next-line(unsafe-typecast)
         uint8 byteAt11 = uint8(uint160(address(token)) >> 64);
-        assertEq(token.decimals(), byteAt11, "decimals() must equal address byte [11]");
+        assertEq(byteAt11, 0, "address byte [11] is reserved and must be zero");
+        assertEq(token.decimals(), 18, "decimals() must remain fixed at 18");
     }
 }

--- a/test/unit/B20/erc20/decimals.t.sol
+++ b/test/unit/B20/erc20/decimals.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {IB20} from "src/interfaces/IB20.sol";
 
 contract B20DecimalsTest is B20Test {
     /// @notice Verifies default-token decimals are fixed at 18
@@ -9,11 +10,10 @@ contract B20DecimalsTest is B20Test {
         assertEq(token.decimals(), 18, "default token decimals must be 18");
     }
 
-    /// @notice Verifies address byte [11] is reserved and no longer drives decimals
-    function test_decimals_success_reservedByteIgnored() public view {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        uint8 byteAt11 = uint8(uint160(address(token)) >> 64);
-        assertEq(byteAt11, 0, "address byte [11] is reserved and must be zero");
-        assertEq(token.decimals(), 18, "decimals() must remain fixed at 18");
+    /// @notice Verifies decimals are fixed independent of per-token address entropy
+    function test_decimals_success_fixedAcrossDifferentTokenAddresses() public {
+        address token2 = _createDefault(alice, keccak256("different-salt"), _b20Params(), new bytes[](0));
+        assertEq(token.decimals(), 18, "first default token decimals must be 18");
+        assertEq(IB20(token2).decimals(), 18, "second default token decimals must be 18");
     }
 }

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -367,9 +367,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      abi.encode specifically; this test recomputes the address externally using
     ///      abi.encode and asserts the factory returns the same value.
     function test_getTokenAddress_pinsDownAbiEncoding(address sender, bytes32 salt) public view {
-        bytes8 expectedTail = bytes8(keccak256(abi.encode(sender, salt)));
+        bytes9 expectedTail = bytes9(keccak256(abi.encode(sender, salt)));
         uint160 expectedAddr = (uint160(0xB2) << 152) | (uint160(uint8(ITokenFactory.TokenVariant.DEFAULT)) << 72)
-            | uint160(uint64(expectedTail));
+            | uint160(uint72(expectedTail));
 
         address actual = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, sender, salt);
         assertEq(actual, address(expectedAddr), "factory must derive address via abi.encode of (sender, salt)");
@@ -416,8 +416,8 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         assertEq(MockB20(tokenAddr).symbol(), "", "empty symbol must round-trip as empty");
     }
 
-    /// @notice Verifies decimals are fixed by variant and not by address encoding
-    /// @dev Default tokens return 18, stablecoin tokens return 6, and address byte [11] stays reserved.
+    /// @notice Verifies decimals are fixed by variant and not encoded in address bytes
+    /// @dev Default tokens return 18, stablecoin tokens return 6.
     function test_createToken_success_decimalsFixedByVariant(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         address defaultToken = _createDefault(caller, salt, _b20Params("Test", "TST", admin), new bytes[](0));
@@ -425,9 +425,5 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
         assertEq(MockB20(defaultToken).decimals(), 18, "default decimals must be fixed at 18");
         assertEq(MockB20(stablecoinToken).decimals(), 6, "stablecoin decimals must be fixed at 6");
-        // forge-lint: disable-next-line(unsafe-typecast)
-        assertEq(uint8(uint160(defaultToken) >> 64), 0, "address byte [11] is reserved and must be zero");
-        // forge-lint: disable-next-line(unsafe-typecast)
-        assertEq(uint8(uint160(stablecoinToken) >> 64), 0, "address byte [11] is reserved and must be zero");
     }
 }

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -56,17 +56,6 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
-    /// @notice Verifies createToken reverts for default-variant decimals outside [2, 18]
-    /// @dev Fuzz confirms the per-variant decimals range is enforced; checks InvalidDecimals(decimals) error
-    function test_createToken_revert_invalidDecimals(address caller, uint8 decimals, bytes32 salt) public {
-        _assumeValidCaller(caller);
-        vm.assume(decimals < 2 || decimals > 18);
-        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
-        vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InvalidDecimals.selector, decimals));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), new bytes[](0));
-    }
-
     /// @notice Verifies stablecoin createToken reverts when currency is the empty string
     /// @dev Per-variant required-field check; checks MissingRequiredField() error
     function test_createToken_revert_missingCurrency(address caller, bytes32 salt) public {
@@ -93,7 +82,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         );
     }
 
-    /// @notice Verifies createToken reverts when (variant, decimals, sender, salt) collides
+    /// @notice Verifies createToken reverts when (variant, sender, salt) collides
     /// @dev Deterministic-address uniqueness; checks TokenAlreadyExists(token) error
     function test_createToken_revert_tokenAlreadyExists(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -157,14 +146,13 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Verifies a failing initCall leaves the deterministic address empty
     /// @dev Atomicity at the storage level: a revert in initCalls means no bytecode was
     ///      committed at the predicted address, so a subsequent createToken with the same
-    ///      (variant, decimals, sender, salt) succeeds. After L-01 the revert reason is
+    ///      (variant, sender, salt) succeeds. After L-01 the revert reason is
     ///      bubbled (InvalidReceiver) rather than wrapped (InitCallFailed), but atomicity
     ///      is unchanged.
     function test_createToken_revert_initCallFailed_revertsWholeCreation(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         ITokenFactory.B20CreateParams memory p = _b20Params();
-        address predicted =
-            factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, p.decimals, caller, salt);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
 
         bytes[] memory initCalls = new bytes[](1);
         initCalls[0] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
@@ -185,37 +173,35 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Verifies createToken returns the predicted address for the default variant
-    /// @dev Address determinism: returned address must equal getTokenAddress(DEFAULT, decimals, sender, salt)
-    function test_createToken_success_defaultMatchesPrediction(address caller, bytes32 salt, uint8 decimals) public {
+    /// @dev Address determinism: returned address must equal getTokenAddress(DEFAULT, sender, salt)
+    function test_createToken_success_defaultMatchesPrediction(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        decimals = uint8(bound(decimals, 2, 18));
-        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, caller, salt);
+        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
         address actual = _createDefault(caller, salt, p, new bytes[](0));
         assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken returns the predicted address for the stablecoin variant
-    /// @dev Address determinism: returned address must equal getTokenAddress(STABLECOIN, 6, sender, salt)
+    /// @dev Address determinism: returned address must equal getTokenAddress(STABLECOIN, sender, salt)
     function test_createToken_success_stablecoinMatchesPrediction(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, 6, caller, salt);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, caller, salt);
         address actual = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
         assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken emits TokenCreated with the correct identity fields
-    /// @dev Event integrity: token, variant, name, symbol, decimals must match the inputs.
+    /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
     ///      see test_createToken_success_emitsRoleGrantedForInitialAdmin for that.
-    function test_createToken_success_emitsTokenCreated(address caller, bytes32 salt, uint8 decimals) public {
+    function test_createToken_success_emitsTokenCreated(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        decimals = uint8(bound(decimals, 2, 18));
-        ITokenFactory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin, decimals);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, caller, salt);
+        ITokenFactory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin);
+        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", decimals);
+        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", 18);
         _createDefault(caller, salt, p, new bytes[](0));
     }
 
@@ -292,12 +278,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @dev "Demonstrate no owner" path: factory accepts zero admin, token has no admin afterward
     ///      (no role grants, policy changes, or pauses ever possible). Replaces the prior
     ///      _revert_zeroAdmin_default stub now that the design explicitly allows this.
-    function test_createToken_success_zeroAdminGrantsNoRole_default(address caller, bytes32 salt, uint8 decimals)
-        public
-    {
+    function test_createToken_success_zeroAdminGrantsNoRole_default(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        decimals = uint8(bound(decimals, 2, 18));
-        ITokenFactory.B20CreateParams memory p = _b20Params("NoOwner", "NOWN", address(0), decimals);
+        ITokenFactory.B20CreateParams memory p = _b20Params("NoOwner", "NOWN", address(0));
         address token = _createDefault(caller, salt, p, new bytes[](0));
 
         // No admin was granted. Any admin-gated call from any account reverts.
@@ -352,7 +335,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         assertEq(bytes(longName).length, 40, "test setup: longName must be 40 bytes");
         assertEq(bytes(longSymbol).length, 40, "test setup: longSymbol must be 40 bytes");
 
-        ITokenFactory.B20CreateParams memory p = _b20Params(longName, longSymbol, admin, 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params(longName, longSymbol, admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), longName, "long name must round-trip via storage");
@@ -371,7 +354,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         assertEq(bytes(name32).length, 32, "test setup: name must be exactly 32 bytes");
         assertEq(bytes(symbol33).length, 33, "test setup: symbol must be exactly 33 bytes");
 
-        ITokenFactory.B20CreateParams memory p = _b20Params(name32, symbol33, admin, 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params(name32, symbol33, admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), name32, "32-byte name must round-trip (long path)");
@@ -383,14 +366,12 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      actual paths share the same encoding choice. The Rust impl must agree on
     ///      abi.encode specifically; this test recomputes the address externally using
     ///      abi.encode and asserts the factory returns the same value.
-    function test_getTokenAddress_pinsDownAbiEncoding(address sender, bytes32 salt, uint8 decimals) public view {
-        decimals = uint8(bound(decimals, 2, 18));
-
+    function test_getTokenAddress_pinsDownAbiEncoding(address sender, bytes32 salt) public view {
         bytes8 expectedTail = bytes8(keccak256(abi.encode(sender, salt)));
         uint160 expectedAddr = (uint160(0xB2) << 152) | (uint160(uint8(ITokenFactory.TokenVariant.DEFAULT)) << 72)
-            | (uint160(decimals) << 64) | uint160(uint64(expectedTail));
+            | uint160(uint64(expectedTail));
 
-        address actual = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, sender, salt);
+        address actual = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, sender, salt);
         assertEq(actual, address(expectedAddr), "factory must derive address via abi.encode of (sender, salt)");
     }
 
@@ -404,7 +385,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      length-1 long-string interpretation AND any future regressions of the same shape.
     function test_createToken_success_emptyName_roundTripsAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("", "ETH", admin, 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params("", "ETH", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), "", "empty name must round-trip as empty");
@@ -417,7 +398,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      assert the result is the empty string regardless.
     function test_createToken_success_emptySymbol_roundTripsAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("Token", "", admin, 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params("Token", "", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).symbol(), "", "empty symbol must round-trip as empty");
@@ -428,26 +409,25 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      most likely to surface memory-layout assumptions in the writer.
     function test_createToken_success_bothEmpty_roundTripAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("", "", admin, 18);
+        ITokenFactory.B20CreateParams memory p = _b20Params("", "", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), "", "empty name must round-trip as empty");
         assertEq(MockB20(tokenAddr).symbol(), "", "empty symbol must round-trip as empty");
     }
 
-    /// @notice Verifies the decimals byte at address position [11] matches the created decimals
-    /// @dev Address schema: decimals are encoded in the address for stateless decimals() lookup
-    function test_createToken_success_encodesDecimalsByte(address caller, bytes32 salt, uint8 decimals) public {
+    /// @notice Verifies decimals are fixed by variant and not by address encoding
+    /// @dev Default tokens return 18, stablecoin tokens return 6, and address byte [11] stays reserved.
+    function test_createToken_success_decimalsFixedByVariant(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        decimals = uint8(bound(decimals, 2, 18));
-        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin, decimals);
-        address token = _createDefault(caller, salt, p, new bytes[](0));
+        address defaultToken = _createDefault(caller, salt, _b20Params("Test", "TST", admin), new bytes[](0));
+        address stablecoinToken = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
 
-        // Byte [11] of the address.
+        assertEq(MockB20(defaultToken).decimals(), 18, "default decimals must be fixed at 18");
+        assertEq(MockB20(stablecoinToken).decimals(), 6, "stablecoin decimals must be fixed at 6");
         // forge-lint: disable-next-line(unsafe-typecast)
-        uint8 byteAt11 = uint8(uint160(token) >> 64);
-        assertEq(byteAt11, decimals, "address byte [11] must equal decimals");
-        // And decimals() (which reads the byte) returns the same.
-        assertEq(MockB20(token).decimals(), decimals, "decimals() must return encoded value");
+        assertEq(uint8(uint160(defaultToken) >> 64), 0, "address byte [11] is reserved and must be zero");
+        // forge-lint: disable-next-line(unsafe-typecast)
+        assertEq(uint8(uint160(stablecoinToken) >> 64), 0, "address byte [11] is reserved and must be zero");
     }
 }

--- a/test/unit/TokenFactory/getTokenAddress.t.sol
+++ b/test/unit/TokenFactory/getTokenAddress.t.sol
@@ -16,87 +16,60 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
 
     /// @notice Verifies getTokenAddress is deterministic for the same inputs
     /// @dev Pure view: repeated calls with identical args must return identical addresses
-    function test_getTokenAddress_success_deterministic(uint8 variantInt, uint8 decimals, address sender, bytes32 salt)
-        public
-        view
-    {
+    function test_getTokenAddress_success_deterministic(uint8 variantInt, address sender, bytes32 salt) public view {
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, sender, salt);
-        address b = factory.getTokenAddress(variant, decimals, sender, salt);
+        address a = factory.getTokenAddress(variant, sender, salt);
+        address b = factory.getTokenAddress(variant, sender, salt);
         assertEq(a, b, "address derivation must be deterministic");
     }
 
-    /// @notice Verifies different variants produce different addresses for the same (decimals, sender, salt)
+    /// @notice Verifies different variants produce different addresses for the same (sender, salt)
     /// @dev Variant byte at position [10] is part of the address derivation
-    function test_getTokenAddress_success_differentVariantDiffers(uint8 decimals, address sender, bytes32 salt)
-        public
-        view
-    {
-        address asDefault = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, decimals, sender, salt);
-        address asStablecoin = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, decimals, sender, salt);
-        address asSecurity = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, decimals, sender, salt);
+    function test_getTokenAddress_success_differentVariantDiffers(address sender, bytes32 salt) public view {
+        address asDefault = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, sender, salt);
+        address asStablecoin = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, sender, salt);
+        address asSecurity = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, sender, salt);
         assertTrue(asDefault != asStablecoin, "DEFAULT vs STABLECOIN must differ");
         assertTrue(asDefault != asSecurity, "DEFAULT vs SECURITY must differ");
         assertTrue(asStablecoin != asSecurity, "STABLECOIN vs SECURITY must differ");
     }
 
-    /// @notice Verifies different decimals produce different addresses for the same (variant, sender, salt)
-    /// @dev Decimals byte at position [11] is part of the address derivation
-    function test_getTokenAddress_success_differentDecimalsDiffers(
-        uint8 variantInt,
-        address sender,
-        bytes32 salt,
-        uint8 d1,
-        uint8 d2
-    ) public view {
-        vm.assume(d1 != d2);
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, d1, sender, salt);
-        address b = factory.getTokenAddress(variant, d2, sender, salt);
-        assertTrue(a != b, "different decimals must yield different addresses");
-    }
-
-    /// @notice Verifies different senders produce different addresses for the same (variant, decimals, salt)
+    /// @notice Verifies different senders produce different addresses for the same (variant, salt)
     /// @dev Sender is mixed into the trailing 8-byte hash at address bytes [12:20]
     function test_getTokenAddress_success_differentSenderDiffers(
         uint8 variantInt,
-        uint8 decimals,
         address s1,
         address s2,
         bytes32 salt
     ) public view {
         vm.assume(s1 != s2);
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, s1, salt);
-        address b = factory.getTokenAddress(variant, decimals, s2, salt);
+        address a = factory.getTokenAddress(variant, s1, salt);
+        address b = factory.getTokenAddress(variant, s2, salt);
         assertTrue(a != b, "different senders must yield different addresses");
     }
 
-    /// @notice Verifies different salts produce different addresses for the same (variant, decimals, sender)
+    /// @notice Verifies different salts produce different addresses for the same (variant, sender)
     /// @dev Salt is mixed into the trailing 8-byte hash at address bytes [12:20]
     function test_getTokenAddress_success_differentSaltDiffers(
         uint8 variantInt,
-        uint8 decimals,
         address sender,
         bytes32 s1,
         bytes32 s2
     ) public view {
         vm.assume(s1 != s2);
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, sender, s1);
-        address b = factory.getTokenAddress(variant, decimals, sender, s2);
+        address a = factory.getTokenAddress(variant, sender, s1);
+        address b = factory.getTokenAddress(variant, sender, s2);
         assertTrue(a != b, "different salts must yield different addresses");
     }
 
     /// @notice Verifies the first 10 bytes of the returned address match the B-20 prefix
     /// @dev Address schema: bytes [0:10] are the shared 0xB200...000 prefix
     ///      (byte [0] = 0xB2, bytes [1:9] = 0x00)
-    function test_getTokenAddress_success_prefixIsB20(uint8 variantInt, uint8 decimals, address sender, bytes32 salt)
-        public
-        view
-    {
+    function test_getTokenAddress_success_prefixIsB20(uint8 variantInt, address sender, bytes32 salt) public view {
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+        address a = factory.getTokenAddress(variant, sender, salt);
 
         // Drop the bottom 10 bytes; what remains should be 0xB2 followed by 9 zero bytes.
         uint160 topTenBytes = uint160(a) >> 80;
@@ -108,12 +81,11 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
     /// @dev Address schema: variant byte enables stateless getTokenVariant lookup
     function test_getTokenAddress_success_variantByteAtPosition10(
         uint8 variantInt,
-        uint8 decimals,
         address sender,
         bytes32 salt
     ) public view {
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+        address a = factory.getTokenAddress(variant, sender, salt);
 
         // Byte [10] = bits [72..79]. Mask after shift.
         // forge-lint: disable-next-line(unsafe-typecast)
@@ -121,20 +93,18 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         assertEq(byteAt10, uint8(variant), "address byte [10] must equal variant ordinal");
     }
 
-    /// @notice Verifies byte [11] of the returned address equals the decimals value
-    /// @dev Address schema: decimals byte enables stateless decimals() lookup
-    function test_getTokenAddress_success_decimalsByteAtPosition11(
+    /// @notice Verifies byte [11] of the returned address is reserved (always zero)
+    function test_getTokenAddress_success_reservedByteAtPosition11(
         uint8 variantInt,
-        uint8 decimals,
         address sender,
         bytes32 salt
     ) public view {
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, decimals, sender, salt);
+        address a = factory.getTokenAddress(variant, sender, salt);
 
         // Byte [11] = bits [64..71]. Mask after shift.
         // forge-lint: disable-next-line(unsafe-typecast)
         uint8 byteAt11 = uint8(uint160(a) >> 64);
-        assertEq(byteAt11, decimals, "address byte [11] must equal decimals");
+        assertEq(byteAt11, 0, "address byte [11] is reserved and must be zero");
     }
 }

--- a/test/unit/TokenFactory/getTokenAddress.t.sol
+++ b/test/unit/TokenFactory/getTokenAddress.t.sol
@@ -35,7 +35,7 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
     }
 
     /// @notice Verifies different senders produce different addresses for the same (variant, salt)
-    /// @dev Sender is mixed into the trailing 8-byte hash at address bytes [12:20]
+    /// @dev Sender is mixed into the trailing 9-byte hash at address bytes [11:20]
     function test_getTokenAddress_success_differentSenderDiffers(
         uint8 variantInt,
         address s1,
@@ -50,7 +50,7 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
     }
 
     /// @notice Verifies different salts produce different addresses for the same (variant, sender)
-    /// @dev Salt is mixed into the trailing 8-byte hash at address bytes [12:20]
+    /// @dev Salt is mixed into the trailing 9-byte hash at address bytes [11:20]
     function test_getTokenAddress_success_differentSaltDiffers(
         uint8 variantInt,
         address sender,
@@ -93,8 +93,8 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         assertEq(byteAt10, uint8(variant), "address byte [10] must equal variant ordinal");
     }
 
-    /// @notice Verifies byte [11] of the returned address is reserved (always zero)
-    function test_getTokenAddress_success_reservedByteAtPosition11(
+    /// @notice Verifies byte [11] comes from the hash tail entropy
+    function test_getTokenAddress_success_byte11DerivedFromTailEntropy(
         uint8 variantInt,
         address sender,
         bytes32 salt
@@ -102,9 +102,11 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
         address a = factory.getTokenAddress(variant, sender, salt);
 
-        // Byte [11] = bits [64..71]. Mask after shift.
+        bytes9 tail = bytes9(keccak256(abi.encode(sender, salt)));
+        uint8 expectedByte11 = uint8(uint72(tail) >> 64);
+        // Byte [11] = bits [64..71] of the 72-bit tail.
         // forge-lint: disable-next-line(unsafe-typecast)
         uint8 byteAt11 = uint8(uint160(a) >> 64);
-        assertEq(byteAt11, 0, "address byte [11] is reserved and must be zero");
+        assertEq(byteAt11, expectedByte11, "address byte [11] must come from tail entropy");
     }
 }

--- a/test/unit/TokenFactory/getTokenVariant.t.sol
+++ b/test/unit/TokenFactory/getTokenVariant.t.sol
@@ -43,12 +43,12 @@ contract TokenFactoryGetTokenVariantTest is TokenFactoryTest {
     /// @notice Verifies getTokenVariant returns NONE for B-20-prefixed addresses with an invalid variant byte
     /// @dev Bytes >= 4 in position [10] are not valid TokenVariant ordinals; impl returns NONE rather than
     ///      reverting on out-of-range enum cast.
-    function test_getTokenVariant_success_noneForInvalidVariantByte(uint8 invalidByte, bytes8 tail)
+    function test_getTokenVariant_success_noneForInvalidVariantByte(uint8 invalidByte, bytes9 tail)
         public
         view
     {
         invalidByte = uint8(bound(uint256(invalidByte), 4, 255));
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(invalidByte) << 72) | uint160(uint64(tail));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(invalidByte) << 72) | uint160(uint72(tail));
         assertEq(
             uint256(factory.getTokenVariant(address(addr))),
             uint256(ITokenFactory.TokenVariant.NONE),

--- a/test/unit/TokenFactory/getTokenVariant.t.sol
+++ b/test/unit/TokenFactory/getTokenVariant.t.sol
@@ -43,13 +43,12 @@ contract TokenFactoryGetTokenVariantTest is TokenFactoryTest {
     /// @notice Verifies getTokenVariant returns NONE for B-20-prefixed addresses with an invalid variant byte
     /// @dev Bytes >= 4 in position [10] are not valid TokenVariant ordinals; impl returns NONE rather than
     ///      reverting on out-of-range enum cast.
-    function test_getTokenVariant_success_noneForInvalidVariantByte(uint8 invalidByte, uint8 decimals, bytes8 tail)
+    function test_getTokenVariant_success_noneForInvalidVariantByte(uint8 invalidByte, bytes8 tail)
         public
         view
     {
         invalidByte = uint8(bound(uint256(invalidByte), 4, 255));
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(invalidByte) << 72) | (uint160(decimals) << 64)
-            | uint160(uint64(tail));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(invalidByte) << 72) | uint160(uint64(tail));
         assertEq(
             uint256(factory.getTokenVariant(address(addr))),
             uint256(ITokenFactory.TokenVariant.NONE),

--- a/test/unit/TokenFactory/isB20.t.sol
+++ b/test/unit/TokenFactory/isB20.t.sol
@@ -30,12 +30,11 @@ contract TokenFactoryIsB20Test is TokenFactoryTest {
     /// @dev Recognition is purely prefix-based; the trailing bytes are unconstrained.
     ///      This is intentional: isB20 is a pure prefix check, so synthetic addresses
     ///      that share the prefix but were never created by the factory also pass.
-    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, uint8 decimalsByte, bytes8 tail)
+    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, bytes8 tail)
         public
         view
     {
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(variantByte) << 72) | (uint160(decimalsByte) << 64)
-            | uint160(uint64(tail));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(variantByte) << 72) | uint160(uint64(tail));
         assertTrue(factory.isB20(address(addr)), "B-20-prefixed address must be recognized");
     }
 }

--- a/test/unit/TokenFactory/isB20.t.sol
+++ b/test/unit/TokenFactory/isB20.t.sol
@@ -30,11 +30,11 @@ contract TokenFactoryIsB20Test is TokenFactoryTest {
     /// @dev Recognition is purely prefix-based; the trailing bytes are unconstrained.
     ///      This is intentional: isB20 is a pure prefix check, so synthetic addresses
     ///      that share the prefix but were never created by the factory also pass.
-    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, bytes8 tail)
+    function test_isB20_success_trueForAnyB20PrefixAddress(uint8 variantByte, bytes9 tail)
         public
         view
     {
-        uint160 addr = (uint160(0xB2) << 152) | (uint160(variantByte) << 72) | uint160(uint64(tail));
+        uint160 addr = (uint160(0xB2) << 152) | (uint160(variantByte) << 72) | uint160(uint72(tail));
         assertTrue(factory.isB20(address(addr)), "B-20-prefixed address must be recognized");
     }
 }


### PR DESCRIPTION
## Summary
- Make token decimals fixed by variant: default tokens return `18`, stablecoin tokens return `6`.
- Remove default-token decimals from `B20CreateParams` and remove decimals from `getTokenAddress`/address derivation inputs.
- Treat address byte `[11]` as reserved (`0x00`) and update mocks, NatSpec, and tests accordingly.
- Update mutation harness cases to reflect the new address/decimals behavior.

## Test plan
- [x] `forge test --match-path "test/unit/TokenFactory/*.t.sol"`
- [x] `forge test --match-path "test/unit/B20/erc20/decimals.t.sol"`
- [x] `forge test`

Made with [Cursor](https://cursor.com)