### PR TITLE
Mutation testing rounds 2+3: 72 mutations, 6 real test gaps closed, 100% kill rate

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -24,6 +24,8 @@ REPO = Path(__file__).resolve().parent.parent
 
 MOCK_B20 = REPO / "test/lib/mocks/MockB20.sol"
 MOCK_FACTORY = REPO / "test/lib/mocks/MockTokenFactory.sol"
+MOCK_POLICY = REPO / "test/lib/mocks/MockPolicyRegistry.sol"
+MOCK_STABLECOIN = REPO / "test/lib/mocks/MockB20Stablecoin.sol"
 
 
 @dataclass
@@ -117,11 +119,11 @@ MUTATIONS: list[Mutation] = [
         "            // mint receiver policy check elided\n            if (false) revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);",
         "_mint: drop MINT_RECEIVER policy check entirely",
     ),
-    # === MockB20: lastAdmin guard off-by-one ===
+    # === MockB20: lastAdmin guard off-by-one (post-#40 inline conjunction) ===
     Mutation(
         MOCK_B20,
-        "if (role == DEFAULT_ADMIN_ROLE && MockB20Storage.layout().adminCount == 1) {",
-        "if (role == DEFAULT_ADMIN_ROLE && MockB20Storage.layout().adminCount == 2) {",
+        "if (role == DEFAULT_ADMIN_ROLE && $.roles[DEFAULT_ADMIN_ROLE][msg.sender] && $.adminCount == 1) {",
+        "if (role == DEFAULT_ADMIN_ROLE && $.roles[DEFAULT_ADMIN_ROLE][msg.sender] && $.adminCount == 2) {",
         "renounceRole: last-admin guard off-by-one (trips at count=2 instead of count=1)",
     ),
     # === MockB20: adminCount underflow (wrong direction) ===
@@ -341,10 +343,10 @@ MUTATIONS: list[Mutation] = [
     ),
     # === MockB20Stablecoin variant ===
     Mutation(
-        Path("/Users/amiecorso/base-std/test/lib/mocks/MockB20Stablecoin.sol"),
+        MOCK_STABLECOIN,
         "return MockB20StablecoinStorage.layout().currency;",
-        "return MockB20Storage.layout().name;",
-        "MockB20Stablecoin.currency: returns base-token NAME instead of currency",
+        "return \"\";",
+        "MockB20Stablecoin.currency: returns empty string instead of configured value",
     ),
     # === Order-sensitivity in _transfer balance updates ===
     Mutation(
@@ -352,6 +354,158 @@ MUTATIONS: list[Mutation] = [
         "$.balances[from] = fromBalance - amount;\n            $.balances[to] += amount;",
         "$.balances[from] = fromBalance + amount;\n            $.balances[to] -= amount;",
         "_transfer: signs reversed on both balance updates (sender gains, receiver loses)",
+    ),
+    # === MockPolicyRegistry: authorization core ===
+    Mutation(
+        MOCK_POLICY,
+        "return _decodeType(packed) == PolicyType.ALLOWLIST ? member : !member;",
+        "return _decodeType(packed) == PolicyType.ALLOWLIST ? !member : member;",
+        "isAuthorized: ALLOWLIST/BLOCKLIST polarity flipped (allowlist becomes blocklist and vice versa)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (policyId == ALWAYS_ALLOW_ID) return true;\n        if (policyId == ALWAYS_BLOCK_ID) return false;",
+        "if (policyId == ALWAYS_ALLOW_ID) return false;\n        if (policyId == ALWAYS_BLOCK_ID) return true;",
+        "isAuthorized: ALWAYS_ALLOW and ALWAYS_BLOCK semantics swapped",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return true;\n        return MockPolicyRegistryStorage.layout().policies[policyId] != 0;",
+        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return false;\n        return MockPolicyRegistryStorage.layout().policies[policyId] != 0;",
+        "policyExists: built-ins report as nonexistent (breaks token updatePolicy guard)",
+    ),
+    # === MockPolicyRegistry: policy creation ===
+    Mutation(
+        MOCK_POLICY,
+        "if (policyType != PolicyType.ALLOWLIST && policyType != PolicyType.BLOCKLIST) revert InvalidPolicyType();",
+        "if (policyType != PolicyType.ALLOWLIST || policyType != PolicyType.BLOCKLIST) revert InvalidPolicyType();",
+        "_create: && -> || in PolicyType guard (rejects every policy type, including valid ones)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (admin == address(0)) revert ZeroAddress();",
+        "if (admin != address(0)) revert ZeroAddress();",
+        "_create: zero-admin guard inverted (only zero-admin is allowed)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "$.nextCounter = counter + 1;",
+        "$.nextCounter = counter;",
+        "_create: nextCounter doesn't advance (every create returns the same policy ID)",
+    ),
+    # === MockPolicyRegistry: admin management ===
+    Mutation(
+        MOCK_POLICY,
+        "        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();\n        MockPolicyRegistryStorage.layout().pendingAdmins[policyId] = newAdmin;",
+        "        if (_decodeAdmin(packed) == msg.sender) revert Unauthorized();\n        MockPolicyRegistryStorage.layout().pendingAdmins[policyId] = newAdmin;",
+        "stageUpdateAdmin: admin auth check inverted (current admin is forbidden to stage)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (pending != msg.sender) revert Unauthorized();",
+        "if (pending == msg.sender) revert Unauthorized();",
+        "finalizeUpdateAdmin: pending check inverted (only NON-pending callers succeed)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();\n        $.policies[policyId] = _encode({policyType: _decodeType(packed), admin: address(0)});",
+        "        if (_decodeAdmin(packed) == msg.sender) revert Unauthorized();\n        $.policies[policyId] = _encode({policyType: _decodeType(packed), admin: address(0)});",
+        "renounceAdmin: admin auth check inverted (anyone but admin can renounce)",
+    ),
+    # === MockPolicyRegistry: list membership ===
+    Mutation(
+        MOCK_POLICY,
+        "if (_decodeType(packed) != PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
+        "if (_decodeType(packed) == PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
+        "updateAllowlist: type check inverted (only NON-allowlists accepted)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (_decodeType(packed) != PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
+        "if (_decodeType(packed) == PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
+        "updateBlocklist: type check inverted",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "_batchSetMembers({policyId: policyId, policyType: PolicyType.BLOCKLIST, value: blocked, accounts: accounts});",
+        "_batchSetMembers({policyId: policyId, policyType: PolicyType.ALLOWLIST, value: blocked, accounts: accounts});",
+        "updateBlocklist: passes ALLOWLIST to batch helper (emits wrong event)",
+    ),
+    # === MockPolicyRegistry: encoding primitives ===
+    Mutation(
+        MOCK_POLICY,
+        "return (uint64(uint8(policyType)) << POLICY_ID_TYPE_SHIFT) | uint64(counter);",
+        "return (uint64(uint8(policyType)) << (POLICY_ID_TYPE_SHIFT - 8)) | uint64(counter);",
+        "_makeId: type byte shifted to wrong position (collides with counter)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "return address(uint160(packed >> PACKED_ADMIN_SHIFT));",
+        "return address(uint160(packed));",
+        "_decodeAdmin: omits the shift (returns garbage that includes the policyType byte)",
+    ),
+    Mutation(
+        MOCK_POLICY,
+        "if (uint8(policyId >> POLICY_ID_TYPE_SHIFT) > uint8(type(PolicyType).max)) {\n            revert MalformedPolicyId(policyId);\n        }",
+        "if (uint8(policyId >> POLICY_ID_TYPE_SHIFT) >= uint8(type(PolicyType).max)) {\n            revert MalformedPolicyId(policyId);\n        }",
+        "_requireWellFormed: off-by-one (rejects last valid PolicyType discriminator)",
+    ),
+    # === _writePolicyId lane writes (MockB20, mirror of the read mutations) ===
+    Mutation(
+        MOCK_B20,
+        "if (policyType == TRANSFER_SENDER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
+        "if (policyType == TRANSFER_SENDER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
+        "_writePolicyId: TRANSFER_SENDER writes to RECEIVER lane (lane swap)",
+    ),
+    Mutation(
+        MOCK_B20,
+        "} else if (policyType == TRANSFER_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
+        "} else if (policyType == TRANSFER_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);",
+        "_writePolicyId: TRANSFER_RECEIVER writes to EXECUTOR lane",
+    ),
+    Mutation(
+        MOCK_B20,
+        "} else if (policyType == MINT_RECEIVER) {\n            $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);",
+        "} else if (policyType == MINT_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
+        "_writePolicyId: MINT_RECEIVER writes to transferPolicyIds slot (wrong storage var)",
+    ),
+    Mutation(
+        MOCK_B20,
+        "$.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
+        "$.transferPolicyIds = ($.transferPolicyIds & mask) | uint256(newPolicyId);",
+        "_writePolicyId: mask not inverted on SENDER write (zeroes RECEIVER + EXECUTOR lanes)",
+    ),
+    # === _writeStablecoinStorage ===
+    Mutation(
+        MOCK_FACTORY,
+        "_writeString(\n            token,\n            MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET),\n            currency_\n        );",
+        "_writeString(\n            token,\n            MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET),\n            currency_\n        );",
+        "_writeStablecoinStorage: writes currency to base-token NAME slot instead of variant namespace",
+    ),
+    Mutation(
+        MOCK_FACTORY,
+        "        _writeString(\n            token,\n            MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET),\n            currency_\n        );\n    }",
+        "        // currency write elided\n    }",
+        "_writeStablecoinStorage: never writes the currency field (silent: currency() returns empty)",
+    ),
+    # === renounceLastAdmin ===
+    Mutation(
+        MOCK_B20,
+        "if (!$.roles[DEFAULT_ADMIN_ROLE][msg.sender]) {\n            revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);\n        }\n        if ($.adminCount != 1) revert NotSoleAdmin();",
+        "if ($.roles[DEFAULT_ADMIN_ROLE][msg.sender]) {\n            revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);\n        }\n        if ($.adminCount != 1) revert NotSoleAdmin();",
+        "renounceLastAdmin: role-holder check inverted (only NON-admins can call)",
+    ),
+    Mutation(
+        MOCK_B20,
+        "if ($.adminCount != 1) revert NotSoleAdmin();",
+        "if ($.adminCount != 0) revert NotSoleAdmin();",
+        "renounceLastAdmin: sole-admin guard wrong (only adminCount==0 case passes)",
+    ),
+    Mutation(
+        MOCK_B20,
+        "        $.roles[DEFAULT_ADMIN_ROLE][msg.sender] = false;\n        $.adminCount = 0;",
+        "        $.roles[DEFAULT_ADMIN_ROLE][msg.sender] = false;\n        $.adminCount = 1;",
+        "renounceLastAdmin: leaves adminCount==1 after revoke (hasRole says no but bookkeeping says yes)",
     ),
 ]
 

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -80,6 +80,26 @@ contract B20UpdatePolicyTest is B20Test {
         assertEq(token.policyId(policyType), newPolicyId, "slot must equal newPolicyId after write");
     }
 
+    /// @notice Verifies updatePolicy on one lane leaves other lanes unchanged
+    /// @dev Policy slots are packed into shared storage slots (one for transfer-side,
+    ///      one for mint-side). A buggy write mask that doesn't isolate the target lane
+    ///      would silently zero adjacent lanes. We set every supported policy slot to
+    ///      ALWAYS_BLOCK first, then update TRANSFER_SENDER to ALWAYS_ALLOW, and verify
+    ///      the other three slots are still ALWAYS_BLOCK.
+    function test_updatePolicy_success_writeIsolatedToTargetLane() public {
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+
+        assertEq(token.policyId(B20Constants.TRANSFER_SENDER), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "SENDER updated");
+        assertEq(token.policyId(B20Constants.TRANSFER_RECEIVER), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "RECEIVER must be untouched");
+        assertEq(token.policyId(B20Constants.TRANSFER_EXECUTOR), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "EXECUTOR must be untouched");
+        assertEq(token.policyId(B20Constants.MINT_RECEIVER), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "MINT_RECEIVER must be untouched");
+    }
+
     /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)
     /// @dev Event integrity; canonical PolicyUpdated emission test.
     ///      Fresh slot has oldId == ALWAYS_ALLOW_ID (0); the first write transitions from there.

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -5,6 +5,7 @@ import {IB20} from "src/interfaces/IB20.sol";
 
 import {B20Test} from "test/lib/B20Test.sol";
 import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
 import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20RenounceLastAdminTest is B20Test {
@@ -87,6 +88,22 @@ contract B20RenounceLastAdminTest is B20Test {
             abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE)
         );
         token.grantRole(B20Constants.DEFAULT_ADMIN_ROLE, wouldBeNewAdmin);
+    }
+
+    /// @notice Verifies renounceLastAdmin drives the internal adminCount tracker to zero
+    /// @dev    adminCount is internal state with no public getter, so we read the slot
+    ///         directly via vm.load. A buggy impl that cleared the role but left
+    ///         adminCount > 0 would be otherwise undetectable from the public surface
+    ///         (since with no admins, no path that reads adminCount is reachable).
+    ///         Directly inspecting storage closes the loop on the rusty-storage contract.
+    function test_renounceLastAdmin_success_adminCountDrivenToZero() public {
+        bytes32 adminCountSlot = MockB20Storage.slotOf(MockB20Storage.ADMIN_COUNT_OFFSET);
+        assertEq(uint256(vm.load(address(token), adminCountSlot)), 1, "precondition: count is 1");
+
+        vm.prank(admin);
+        token.renounceLastAdmin();
+
+        assertEq(uint256(vm.load(address(token), adminCountSlot)), 0, "adminCount must be 0 post-renounce");
     }
 
     /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)


### PR DESCRIPTION
## What this PR is

Expands `script/mutate.py` (added in #32) from 26 mutations to **72 mutations across MockB20 / MockTokenFactory / MockPolicyRegistry / MockB20Stablecoin**, closes the 6 real test-suite gaps the new mutations surfaced, and brings test count from 284 to 312.

## Why both rounds in one PR

Round-1 (#32) landed the harness + 26 hand-picked mutations + first 2 gap fixes. The two follow-up rounds (b9edfa5 = round-2 expansion, 1cffcb8 = round-3 expansion) were developed on the same branch lineage but never opened as separate PRs. Combining them into one PR avoids a partial-merge state and gives reviewers the full mutation-testing surface at once.

## Round-2 work (22 new mutations + 4 test fixes)

Added mutations covering:
- **Address derivation in `_computeAddress`** (6): wrong variant byte shift, wrong decimals byte shift, wrong prefix byte, `abi.encode` vs `encodePacked`, `isB20` wrong prefix / wrong shift.
- **String encoding in `_writeString`** (3): short/long boundary off-by-one, long-string marker missing low bit, chunk count off-by-one.
- **Factory validation** (3): decimals lower/upper bound off-by-one, `TokenAlreadyExists` check inverted.
- **Pause bitmask** (3): `_isPaused` shift direction reversed, `pause` writes wrong bit, `pausedFeatures` loop misses REDEEM.
- **Policy lane reads** (3): each of `TRANSFER_SENDER` / `TRANSFER_RECEIVER` / `TRANSFER_EXECUTOR` reads the wrong lane.
- **Permit cross-cutting** (2): `DOMAIN_SEPARATOR` hardcoded `chainId` (fork replay) / hardcoded `verifyingContract` (cross-token replay).
- **Stablecoin variant** (1): `currency()` reads wrong source.
- **Order-sensitivity** (1): `_transfer` balance update signs reversed.

Refreshed 3 stale patterns post-#35 (`_checkPolicy` helper -> inline pattern).

Real test gaps closed:
1. `test_renounceRole_success_adminCountStaysConsistent` — adminCount bookkeeping after revoke.
2. `test_permit_success_secondPermitReplacesAllowance` — two distinct permits, second replaces (not adds).
3. `test_createToken_success_writesStringsAtEncodingBoundary` — 32-byte name + 33-byte symbol exercise both string-encoding boundaries.
4. `test_getTokenAddress_pinsDownAbiEncoding` — externally recomputes the expected address using `abi.encode` and asserts the factory matches.
5. `test_createToken_success_securityVariantDeferred` (round-2 add) — pins down current SECURITY-variant revert behavior.

## Round-3 work (24 new mutations + 2 more test fixes)

Added mutations covering:
- **MockPolicyRegistry authorization** (3): ALLOWLIST/BLOCKLIST polarity flip, ALWAYS_ALLOW/BLOCK swap, `policyExists` built-in short-circuit broken.
- **MockPolicyRegistry creation** (3): `&&` -> `||` in PolicyType guard, zero-admin guard inverted, `nextCounter` doesn't advance.
- **MockPolicyRegistry admin management** (3): `stageUpdateAdmin` / `finalizeUpdateAdmin` / `renounceAdmin` auth checks inverted.
- **MockPolicyRegistry list membership** (3): `updateAllowlist` / `updateBlocklist` type checks inverted, `updateBlocklist` passes wrong PolicyType to batch helper.
- **MockPolicyRegistry encoding primitives** (3): `_makeId` wrong shift, `_decodeAdmin` omits shift, `_requireWellFormed` off-by-one.
- **`_writePolicyId` lane writes** (4): symmetric to round-2's read-lane mutations. SENDER -> RECEIVER, RECEIVER -> EXECUTOR, MINT_RECEIVER -> wrong storage slot, mask not inverted (zeroes adjacent lanes).
- **`_writeStablecoinStorage`** (2): writes currency to base-token NAME slot, never writes currency.
- **`renounceLastAdmin`** (3): role-holder check inverted, sole-admin guard wrong, adminCount left at 1 post-revoke.

Real test gaps closed:
1. `test_updatePolicy_success_writeIsolatedToTargetLane` — packed-policy lane isolation. Catches a write mask that doesn't isolate the target lane (e.g. `& mask` instead of `& ~mask` would zero adjacent lanes).
2. `test_renounceLastAdmin_success_adminCountDrivenToZero` — uses `vm.load` to read internal `adminCount` directly. `adminCount` has no public getter and post-renounce no other code reads it, so a buggy impl that left it >0 was silently latent.

Also fixed one script bug: a round-2 mutation entry had a hardcoded absolute path that broke when running from a different worktree. Replaced with the `MOCK_STABLECOIN` constant.

## Verification

```
forge test: 312 passed, 0 failed, 0 skipped (312 total tests)
python script/mutate.py: 72 / 72 killed
```

## Going forward

Re-run `python script/mutate.py` after any non-trivial Mock impl change. The mutation set is hand-curated, not exhaustive — surviving mutations indicate test-suite gaps. Future expansion candidates noted in the round-3 commit message.