### PR TITLE
Suffix policy-type identifiers with _POLICY for parity with _ROLE

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -101,23 +101,23 @@ MUTATIONS: list[Mutation] = [
     # === MockB20: skip policy check on sender (matches new inline pattern) ===
     Mutation(
         MOCK_B20,
-        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {\n                revert PolicyForbids(TRANSFER_SENDER, senderPolicyId);\n            }",
-        "            // sender policy check elided\n            if (false) revert PolicyForbids(TRANSFER_SENDER, senderPolicyId);",
-        "_transfer: drop TRANSFER_SENDER policy check entirely",
+        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {\n                revert PolicyForbids(TRANSFER_SENDER_POLICY, senderPolicyId);\n            }",
+        "            // sender policy check elided\n            if (false) revert PolicyForbids(TRANSFER_SENDER_POLICY, senderPolicyId);",
+        "_transfer: drop TRANSFER_SENDER_POLICY policy check entirely",
     ),
     # === MockB20: skip policy check on receiver (matches new inline pattern) ===
     Mutation(
         MOCK_B20,
-        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(receiverPolicyId, to)) {\n                revert PolicyForbids(TRANSFER_RECEIVER, receiverPolicyId);\n            }",
-        "            // receiver policy check elided\n            if (false) revert PolicyForbids(TRANSFER_RECEIVER, receiverPolicyId);",
-        "_transfer: drop TRANSFER_RECEIVER policy check entirely",
+        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(receiverPolicyId, to)) {\n                revert PolicyForbids(TRANSFER_RECEIVER_POLICY, receiverPolicyId);\n            }",
+        "            // receiver policy check elided\n            if (false) revert PolicyForbids(TRANSFER_RECEIVER_POLICY, receiverPolicyId);",
+        "_transfer: drop TRANSFER_RECEIVER_POLICY policy check entirely",
     ),
-    # === MockB20: skip MINT_RECEIVER policy check (matches new inline pattern) ===
+    # === MockB20: skip MINT_RECEIVER_POLICY policy check (matches new inline pattern) ===
     Mutation(
         MOCK_B20,
-        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {\n                revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);\n            }",
-        "            // mint receiver policy check elided\n            if (false) revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);",
-        "_mint: drop MINT_RECEIVER policy check entirely",
+        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {\n                revert PolicyForbids(MINT_RECEIVER_POLICY, mintReceiverPolicyId);\n            }",
+        "            // mint receiver policy check elided\n            if (false) revert PolicyForbids(MINT_RECEIVER_POLICY, mintReceiverPolicyId);",
+        "_mint: drop MINT_RECEIVER_POLICY policy check entirely",
     ),
     # === MockB20: lastAdmin guard off-by-one (post-#40 inline conjunction) ===
     Mutation(
@@ -299,21 +299,21 @@ MUTATIONS: list[Mutation] = [
     # === Policy lane wiring (transferPolicyIds reads) ===
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds);",
-        "if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds >> 64);",
-        "_readPolicyId: TRANSFER_SENDER reads RECEIVER lane (wrong shift)",
+        "if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);",
+        "if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds >> 64);",
+        "_readPolicyId: TRANSFER_SENDER_POLICY reads RECEIVER lane (wrong shift)",
     ),
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 64);",
-        "if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 128);",
-        "_readPolicyId: TRANSFER_RECEIVER reads EXECUTOR lane (wrong shift)",
+        "if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);",
+        "if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 128);",
+        "_readPolicyId: TRANSFER_RECEIVER_POLICY reads EXECUTOR lane (wrong shift)",
     ),
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds >> 128);",
-        "if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds);",
-        "_readPolicyId: TRANSFER_EXECUTOR reads SENDER lane (wrong shift)",
+        "if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);",
+        "if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds);",
+        "_readPolicyId: TRANSFER_EXECUTOR_POLICY reads SENDER lane (wrong shift)",
     ),
     # === Permit cross-cutting ===
     Mutation(
@@ -440,21 +440,21 @@ MUTATIONS: list[Mutation] = [
     # === _writePolicyId lane writes (MockB20, mirror of the read mutations) ===
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_SENDER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
-        "if (policyType == TRANSFER_SENDER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
-        "_writePolicyId: TRANSFER_SENDER writes to RECEIVER lane (lane swap)",
+        "if (policyType == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
+        "if (policyType == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
+        "_writePolicyId: TRANSFER_SENDER_POLICY writes to RECEIVER lane (lane swap)",
     ),
     Mutation(
         MOCK_B20,
-        "} else if (policyType == TRANSFER_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
-        "} else if (policyType == TRANSFER_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);",
-        "_writePolicyId: TRANSFER_RECEIVER writes to EXECUTOR lane",
+        "} else if (policyType == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
+        "} else if (policyType == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);",
+        "_writePolicyId: TRANSFER_RECEIVER_POLICY writes to EXECUTOR lane",
     ),
     Mutation(
         MOCK_B20,
-        "} else if (policyType == MINT_RECEIVER) {\n            $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);",
-        "} else if (policyType == MINT_RECEIVER) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
-        "_writePolicyId: MINT_RECEIVER writes to transferPolicyIds slot (wrong storage var)",
+        "} else if (policyType == MINT_RECEIVER_POLICY) {\n            $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);",
+        "} else if (policyType == MINT_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
+        "_writePolicyId: MINT_RECEIVER_POLICY writes to transferPolicyIds slot (wrong storage var)",
     ),
     Mutation(
         MOCK_B20,

--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -45,13 +45,13 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         to a dedicated storage slot on the token. The policy-type
 ///         identifier is the `keccak256` hash of its name. Four standard
 ///         types are exposed as constants on this base surface:
-///         - `TRANSFER_SENDER`   — checked against `from` on every transfer
-///         - `TRANSFER_RECEIVER` — checked against `to`   on every transfer
-///         - `TRANSFER_EXECUTOR` — checked against `msg.sender` on `transferFrom`
+///         - `TRANSFER_SENDER_POLICY`   — checked against `from` on every transfer
+///         - `TRANSFER_RECEIVER_POLICY` — checked against `to`   on every transfer
+///         - `TRANSFER_EXECUTOR_POLICY` — checked against `msg.sender` on `transferFrom`
 ///                                  (when distinct from `from`)
-///         - `MINT_RECEIVER`     — checked against `to`   on every mint
+///         - `MINT_RECEIVER_POLICY`     — checked against `to`   on every mint
 ///         Variants extend this set by adding their own dedicated slots
-///         (e.g. `IB20Security` adds `REDEEMER_SENDER` for its `redeem`
+///         (e.g. `IB20Security` adds `REDEEMER_SENDER_POLICY` for its `redeem`
 ///         path, stored in the variant's own namespaced storage). There
 ///         is no generic catch-all mapping: every `policyType` either
 ///         resolves to a real slot or doesn't exist at all. Both reads
@@ -71,8 +71,8 @@ pragma solidity >=0.8.20 <0.9.0;
 ///
 ///         Asymmetric per-role configuration is expressed by pointing
 ///         different slots at different policies — for example, a
-///         sanctions BLOCKLIST on `TRANSFER_SENDER` and an unrestricted
-///         always-allow on `TRANSFER_RECEIVER`. The registry stays flat;
+///         sanctions BLOCKLIST on `TRANSFER_SENDER_POLICY` and an unrestricted
+///         always-allow on `TRANSFER_RECEIVER_POLICY`. The registry stays flat;
 ///         all composition happens at the token layer. `approve` is NOT
 ///         gated by any policy (only the act of MOVING balance is gated).
 ///
@@ -173,7 +173,7 @@ interface IB20 {
     error SupplyCapExceeded(uint256 cap, uint256 attempted);
 
     /// @notice A policy slot denied the operation. `policyType` identifies
-    ///         which slot (e.g. `TRANSFER_SENDER`, `MINT_RECEIVER`) and
+    ///         which slot (e.g. `TRANSFER_SENDER_POLICY`, `MINT_RECEIVER_POLICY`) and
     ///         `policyId` is the ID currently set in that slot.
     error PolicyForbids(bytes32 policyType, uint64 policyId);
 
@@ -192,7 +192,7 @@ interface IB20 {
     error UnsupportedPolicyType(bytes32 policyType);
 
     /// @notice `burnBlocked` was called against a `from` address that is
-    ///         currently authorized under the active `TRANSFER_SENDER`
+    ///         currently authorized under the active `TRANSFER_SENDER_POLICY`
     ///         policy. `burnBlocked` exists specifically to seize supply
     ///         from policy-blocked addresses; calling it against a
     ///         non-blocked address is rejected by design.
@@ -309,7 +309,7 @@ interface IB20 {
 
     /// @notice Emitted by `updatePolicy` when a token's policy slot is
     ///         changed. `policyType` is one of the standard policy-type
-    ///         identifiers (e.g. `TRANSFER_SENDER()`); `oldPolicyId` and
+    ///         identifiers (e.g. `TRANSFER_SENDER_POLICY()`); `oldPolicyId` and
     ///         `newPolicyId` are the prior and current registry IDs for
     ///         that slot. Initial slot assignment at creation is also
     ///         emitted via `PolicyUpdated` with `oldPolicyId == 0`.
@@ -363,7 +363,7 @@ interface IB20 {
     /// @notice Required to call `burnBlocked`. Held separately from
     ///         `BURN_ROLE` so the authority to destroy a third party's
     ///         balance (gated on that party being unauthorized under the
-    ///         active `TRANSFER_SENDER` policy) can be granted only to a
+    ///         active `TRANSFER_SENDER_POLICY` policy) can be granted only to a
     ///         compliance role, not to general burn operators.
     function BURN_BLOCKED_ROLE() external view returns (bytes32);
 
@@ -392,22 +392,22 @@ interface IB20 {
 
     /// @notice The policy slot consulted against `from` on every transfer
     ///         (including the `from` side of `transferFrom`). Identifier
-    ///         is `keccak256("TRANSFER_SENDER")`.
-    function TRANSFER_SENDER() external view returns (bytes32);
+    ///         is `keccak256("TRANSFER_SENDER_POLICY")`.
+    function TRANSFER_SENDER_POLICY() external view returns (bytes32);
 
     /// @notice The policy slot consulted against `to` on every transfer.
-    ///         Identifier is `keccak256("TRANSFER_RECEIVER")`.
-    function TRANSFER_RECEIVER() external view returns (bytes32);
+    ///         Identifier is `keccak256("TRANSFER_RECEIVER_POLICY")`.
+    function TRANSFER_RECEIVER_POLICY() external view returns (bytes32);
 
     /// @notice The policy slot consulted against `msg.sender` on
     ///         `transferFrom` (the spender, when distinct from `from`).
     ///         Not consulted on `transfer` (where `msg.sender == from`).
-    ///         Identifier is `keccak256("TRANSFER_EXECUTOR")`.
-    function TRANSFER_EXECUTOR() external view returns (bytes32);
+    ///         Identifier is `keccak256("TRANSFER_EXECUTOR_POLICY")`.
+    function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
 
     /// @notice The policy slot consulted against `to` on every mint.
-    ///         Identifier is `keccak256("MINT_RECEIVER")`.
-    function MINT_RECEIVER() external view returns (bytes32);
+    ///         Identifier is `keccak256("MINT_RECEIVER_POLICY")`.
+    function MINT_RECEIVER_POLICY() external view returns (bytes32);
 
     /*//////////////////////////////////////////////////////////////
                                   ERC-20
@@ -435,14 +435,14 @@ interface IB20 {
 
     /// @notice Transfers `amount` from `msg.sender` to `to`. Reverts with:
     ///         - `ContractPaused(TRANSFER)` if `TRANSFER` is paused.
-    ///         - `PolicyForbids(TRANSFER_SENDER,   policyId)` if `msg.sender`
-    ///           is not authorized under the active `TRANSFER_SENDER` policy.
-    ///         - `PolicyForbids(TRANSFER_RECEIVER, policyId)` if `to` is not
-    ///           authorized under the active `TRANSFER_RECEIVER` policy.
+    ///         - `PolicyForbids(TRANSFER_SENDER_POLICY,   policyId)` if `msg.sender`
+    ///           is not authorized under the active `TRANSFER_SENDER_POLICY` policy.
+    ///         - `PolicyForbids(TRANSFER_RECEIVER_POLICY, policyId)` if `to` is not
+    ///           authorized under the active `TRANSFER_RECEIVER_POLICY` policy.
     ///         - `InsufficientBalance(msg.sender, balance, amount)` if the
     ///           caller does not have enough balance.
     ///         - `InvalidReceiver(to)` if `to == address(0)`.
-    /// @dev    Does NOT consult the `TRANSFER_EXECUTOR` policy: on direct
+    /// @dev    Does NOT consult the `TRANSFER_EXECUTOR_POLICY` policy: on direct
     ///         `transfer` the executor IS the sender, and the sender
     ///         check already covers that address. When the token is
     ///         configured as a gas asset, fee debits go through this
@@ -454,9 +454,9 @@ interface IB20 {
     ///         - `InsufficientAllowance(msg.sender, allowance, amount)`
     ///           if the caller does not have enough allowance from `from`.
     ///         - `InvalidSender(from)` if `from == address(0)`.
-    ///         - `PolicyForbids(TRANSFER_EXECUTOR, policyId)` if
+    ///         - `PolicyForbids(TRANSFER_EXECUTOR_POLICY, policyId)` if
     ///           `msg.sender != from` and `msg.sender` is not authorized
-    ///           under the active `TRANSFER_EXECUTOR` policy.
+    ///           under the active `TRANSFER_EXECUTOR_POLICY` policy.
     /// @dev    The sender-side check is performed against `from` (the
     ///         party whose balance moves), the receiver check against
     ///         `to`, and the executor check against `msg.sender` only
@@ -517,8 +517,8 @@ interface IB20 {
     ///         1. `totalSupply + amount <= supplyCap` (else
     ///            `SupplyCapExceeded`).
     ///         2. `MINT` is not paused (else `ContractPaused(MINT)`).
-    ///         3. `to` is authorized under the active `MINT_RECEIVER`
-    ///            policy (else `PolicyForbids(MINT_RECEIVER, policyId)`).
+    ///         3. `to` is authorized under the active `MINT_RECEIVER_POLICY`
+    ///            policy (else `PolicyForbids(MINT_RECEIVER_POLICY, policyId)`).
     /// @dev    Per-minter rate limiting is NOT enshrined at any level
     ///         (Default or variant). Minter quotas live in EVM
     ///         periphery contracts: a controller / wrapper that holds
@@ -552,7 +552,7 @@ interface IB20 {
     ///         `BURN_BLOCKED_ROLE`. Subject to:
     ///         1. `BURN` is not paused (else `ContractPaused(BURN)`).
     ///         2. `from` is NOT authorized under the active
-    ///            `TRANSFER_SENDER` policy (else `AccountNotBlocked(from)`).
+    ///            `TRANSFER_SENDER_POLICY` policy (else `AccountNotBlocked(from)`).
     ///            `burnBlocked` exists for seizure of policy-blocked
     ///            balance; calling it against an authorized address is
     ///            rejected by design.
@@ -679,10 +679,10 @@ interface IB20 {
     /// @notice The current policy ID configured for `policyType`. Returns
     ///         `0` (always-allow built-in) for any policy slot that has
     ///         never been assigned. Standard policy types are exposed as
-    ///         the role-identifier constants `TRANSFER_SENDER()`,
-    ///         `TRANSFER_RECEIVER()`, `TRANSFER_EXECUTOR()`, and
-    ///         `MINT_RECEIVER()`. Variants add their own constants for
-    ///         variant-specific operations (e.g. `REDEEMER_SENDER()` on
+    ///         the role-identifier constants `TRANSFER_SENDER_POLICY()`,
+    ///         `TRANSFER_RECEIVER_POLICY()`, `TRANSFER_EXECUTOR_POLICY()`, and
+    ///         `MINT_RECEIVER_POLICY()`. Variants add their own constants for
+    ///         variant-specific operations (e.g. `REDEEMER_SENDER_POLICY()` on
     ///         `IB20Security`). User-defined policy types are also
     ///         supported and may be used by periphery contracts that
     ///         layer additional gating on top.

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -122,8 +122,8 @@ interface IB20Security is IB20 {
 
     /// @notice The policy slot consulted against `msg.sender` on
     ///         `redeem` and `redeemWithMemo`. Identifier is
-    ///         `keccak256("REDEEMER_SENDER")`.
-    function REDEEMER_SENDER() external view returns (bytes32);
+    ///         `keccak256("REDEEMER_SENDER_POLICY")`.
+    function REDEEMER_SENDER_POLICY() external view returns (bytes32);
 
     /*//////////////////////////////////////////////////////////////
                               ANNOUNCEMENTS
@@ -188,7 +188,7 @@ interface IB20Security is IB20 {
     ///         allocations, secondary issuances, etc.) that need to
     ///         land many recipients in one transaction.
     ///
-    /// @dev    Requires `MINT_ROLE`. Subject to the `MINT_RECEIVER`
+    /// @dev    Requires `MINT_ROLE`. Subject to the `MINT_RECEIVER_POLICY`
     ///         policy per recipient and to the `MINT` pause vector.
     ///         Reverts on length mismatch or empty arrays. Operators
     ///         should pair this with a separate `announce(...)` call
@@ -209,7 +209,7 @@ interface IB20Security is IB20 {
     ///
     /// @dev    Requires `BURN_ROLE`. Each `accounts[i]` MUST
     ///         currently be unauthorized under the active
-    ///         `TRANSFER_SENDER` policy; otherwise reverts with
+    ///         `TRANSFER_SENDER_POLICY` policy; otherwise reverts with
     ///         `AccountNotBlocked(accounts[i])`. Subject to the `BURN`
     ///         pause vector. Reverts on length mismatch or empty
     ///         arrays. Emits `Transfer(accounts[i], address(0),
@@ -219,7 +219,7 @@ interface IB20Security is IB20 {
     ///         enforce the pairing on-chain.
     ///
     /// @param  accounts Accounts whose balances will be debited. Each
-    ///                  MUST be unauthorized under `TRANSFER_SENDER`.
+    ///                  MUST be unauthorized under `TRANSFER_SENDER_POLICY`.
     /// @param  amounts  Per-account amounts, parallel to `accounts`.
     function batchBurn(address[] calldata accounts, uint256[] calldata amounts) external;
 
@@ -230,7 +230,7 @@ interface IB20Security is IB20 {
     /// @notice Burns `amount` tokens from the caller, recording intent
     ///         to settle off-chain.
     ///
-    /// @dev    Subject to the `REDEEMER_SENDER` policy and to the
+    /// @dev    Subject to the `REDEEMER_SENDER_POLICY` policy and to the
     ///         `REDEEM` pause vector. Reverts when the corresponding
     ///         share amount (`amount * sharesToTokensRatio /
     ///         WAD_PRECISION`) is below `minimumRedeemable`. Emits

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -36,7 +36,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///                  absence of a configured policy means no restriction.
 ///         - `1` — always-block. `isAuthorized(1, any)` returns false.
 ///                  Useful as an explicit hard-deny on a policy slot
-///                  (e.g. disabling redemption by pointing `REDEEMER_SENDER`
+///                  (e.g. disabling redemption by pointing `REDEEMER_SENDER_POLICY`
 ///                  at this ID), or as a kill switch independent of
 ///                  token-level pause.
 ///

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -25,8 +25,8 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 contract B20Test is TokenFactoryTest {
     // Role identifiers (DEFAULT_ADMIN_ROLE, MINT_ROLE, BURN_ROLE,
     // BURN_BLOCKED_ROLE, PAUSE_ROLE, UNPAUSE_ROLE, METADATA_ROLE) and
-    // policy-type identifiers (TRANSFER_SENDER, TRANSFER_RECEIVER,
-    // TRANSFER_EXECUTOR, MINT_RECEIVER) are NOT redeclared here.
+    // policy-type identifiers (TRANSFER_SENDER_POLICY, TRANSFER_RECEIVER_POLICY,
+    // TRANSFER_EXECUTOR_POLICY, MINT_RECEIVER_POLICY) are NOT redeclared here.
     // Tests reference them directly from MockB20 as `MINT_ROLE`
     // etc. — single source of truth, no drift risk.
     //
@@ -133,13 +133,13 @@ contract B20Test is TokenFactoryTest {
     ///         unsupported `bytes32` revert `UnsupportedPolicyType`.
     /// @dev    Variant tests can wrap this with their own indexer that
     ///         extends the codomain (e.g. a Security test that also
-    ///         covers `REDEEMER_SENDER`).
+    ///         covers `REDEEMER_SENDER_POLICY`).
     function _knownPolicyType(uint8 idx) internal pure returns (bytes32) {
         uint8 i = idx % 4;
-        if (i == 0) return B20Constants.TRANSFER_SENDER;
-        if (i == 1) return B20Constants.TRANSFER_RECEIVER;
-        if (i == 2) return B20Constants.TRANSFER_EXECUTOR;
-        return B20Constants.MINT_RECEIVER;
+        if (i == 0) return B20Constants.TRANSFER_SENDER_POLICY;
+        if (i == 1) return B20Constants.TRANSFER_RECEIVER_POLICY;
+        if (i == 2) return B20Constants.TRANSFER_EXECUTOR_POLICY;
+        return B20Constants.MINT_RECEIVER_POLICY;
     }
 
     /// @notice True iff `policyType` is one of the four base-token
@@ -147,10 +147,10 @@ contract B20Test is TokenFactoryTest {
     ///         `bytes32` and need to filter to the supported / unsupported
     ///         partition.
     function _isKnownPolicyType(bytes32 policyType) internal pure returns (bool) {
-        return policyType == B20Constants.TRANSFER_SENDER
-            || policyType == B20Constants.TRANSFER_RECEIVER
-            || policyType == B20Constants.TRANSFER_EXECUTOR
-            || policyType == B20Constants.MINT_RECEIVER;
+        return policyType == B20Constants.TRANSFER_SENDER_POLICY
+            || policyType == B20Constants.TRANSFER_RECEIVER_POLICY
+            || policyType == B20Constants.TRANSFER_EXECUTOR_POLICY
+            || policyType == B20Constants.MINT_RECEIVER_POLICY;
     }
 
     /// @notice Pauses a single `PausableFeature`, lazily granting `PAUSE_ROLE`

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -28,10 +28,10 @@ library B20Constants {
     bytes32 internal constant UNPAUSE_ROLE = keccak256("UNPAUSE_ROLE");
     bytes32 internal constant METADATA_ROLE = keccak256("METADATA_ROLE");
 
-    bytes32 internal constant TRANSFER_SENDER = keccak256("TRANSFER_SENDER");
-    bytes32 internal constant TRANSFER_RECEIVER = keccak256("TRANSFER_RECEIVER");
-    bytes32 internal constant TRANSFER_EXECUTOR = keccak256("TRANSFER_EXECUTOR");
-    bytes32 internal constant MINT_RECEIVER = keccak256("MINT_RECEIVER");
+    bytes32 internal constant TRANSFER_SENDER_POLICY = keccak256("TRANSFER_SENDER_POLICY");
+    bytes32 internal constant TRANSFER_RECEIVER_POLICY = keccak256("TRANSFER_RECEIVER_POLICY");
+    bytes32 internal constant TRANSFER_EXECUTOR_POLICY = keccak256("TRANSFER_EXECUTOR_POLICY");
+    bytes32 internal constant MINT_RECEIVER_POLICY = keccak256("MINT_RECEIVER_POLICY");
 }
 
 /// @title MockB20
@@ -101,10 +101,10 @@ contract MockB20 is IB20 {
     bytes32 public constant METADATA_ROLE = B20Constants.METADATA_ROLE;
 
     /// @notice Policy-type identifiers. Same `keccak256` convention as roles.
-    bytes32 public constant TRANSFER_SENDER = B20Constants.TRANSFER_SENDER;
-    bytes32 public constant TRANSFER_RECEIVER = B20Constants.TRANSFER_RECEIVER;
-    bytes32 public constant TRANSFER_EXECUTOR = B20Constants.TRANSFER_EXECUTOR;
-    bytes32 public constant MINT_RECEIVER = B20Constants.MINT_RECEIVER;
+    bytes32 public constant TRANSFER_SENDER_POLICY = B20Constants.TRANSFER_SENDER_POLICY;
+    bytes32 public constant TRANSFER_RECEIVER_POLICY = B20Constants.TRANSFER_RECEIVER_POLICY;
+    bytes32 public constant TRANSFER_EXECUTOR_POLICY = B20Constants.TRANSFER_EXECUTOR_POLICY;
+    bytes32 public constant MINT_RECEIVER_POLICY = B20Constants.MINT_RECEIVER_POLICY;
 
     // ============================================================
     //                          ERC-20: VIEWS
@@ -152,7 +152,7 @@ contract MockB20 is IB20 {
             // slot for sender + receiver.
             uint64 executorPolicyId = uint64(MockB20Storage.layout().transferPolicyIds >> 128);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
-                revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
+                revert PolicyForbids(TRANSFER_EXECUTOR_POLICY, executorPolicyId);
             }
         }
         _transfer(from, to, amount);
@@ -182,7 +182,7 @@ contract MockB20 is IB20 {
             _consumeAllowance(from, msg.sender, amount);
             uint64 executorPolicyId = uint64(MockB20Storage.layout().transferPolicyIds >> 128);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(executorPolicyId, msg.sender)) {
-                revert PolicyForbids(TRANSFER_EXECUTOR, executorPolicyId);
+                revert PolicyForbids(TRANSFER_EXECUTOR_POLICY, executorPolicyId);
             }
         }
         _transfer(from, to, amount);
@@ -397,10 +397,10 @@ contract MockB20 is IB20 {
     ///      falling through to `super`.
     function _readPolicyId(bytes32 policyType) internal view virtual returns (uint64) {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
-        if (policyType == TRANSFER_SENDER) return uint64($.transferPolicyIds);
-        if (policyType == TRANSFER_RECEIVER) return uint64($.transferPolicyIds >> 64);
-        if (policyType == TRANSFER_EXECUTOR) return uint64($.transferPolicyIds >> 128);
-        if (policyType == MINT_RECEIVER) return uint64($.mintPolicyIds);
+        if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);
+        if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);
+        if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);
+        if (policyType == MINT_RECEIVER_POLICY) return uint64($.mintPolicyIds);
         revert UnsupportedPolicyType(policyType);
     }
 
@@ -414,13 +414,13 @@ contract MockB20 is IB20 {
     function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         uint256 mask = uint256(type(uint64).max);
-        if (policyType == TRANSFER_SENDER) {
+        if (policyType == TRANSFER_SENDER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);
-        } else if (policyType == TRANSFER_RECEIVER) {
+        } else if (policyType == TRANSFER_RECEIVER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
-        } else if (policyType == TRANSFER_EXECUTOR) {
+        } else if (policyType == TRANSFER_EXECUTOR_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
-        } else if (policyType == MINT_RECEIVER) {
+        } else if (policyType == MINT_RECEIVER_POLICY) {
             $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);
         } else {
             revert UnsupportedPolicyType(policyType);
@@ -604,10 +604,10 @@ contract MockB20 is IB20 {
             uint64 senderPolicyId = uint64(packed);
             uint64 receiverPolicyId = uint64(packed >> 64);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {
-                revert PolicyForbids(TRANSFER_SENDER, senderPolicyId);
+                revert PolicyForbids(TRANSFER_SENDER_POLICY, senderPolicyId);
             }
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(receiverPolicyId, to)) {
-                revert PolicyForbids(TRANSFER_RECEIVER, receiverPolicyId);
+                revert PolicyForbids(TRANSFER_RECEIVER_POLICY, receiverPolicyId);
             }
         }
 
@@ -629,7 +629,7 @@ contract MockB20 is IB20 {
             if (_isPaused(PausableFeature.MINT)) revert ContractPaused(PausableFeature.MINT);
             uint64 mintReceiverPolicyId = uint64(MockB20Storage.layout().mintPolicyIds);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {
-                revert PolicyForbids(MINT_RECEIVER, mintReceiverPolicyId);
+                revert PolicyForbids(MINT_RECEIVER_POLICY, mintReceiverPolicyId);
             }
         }
 

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -76,7 +76,7 @@ library MockB20Storage {
         //   word3 (bytes 24..31, bits 192..255): reserved
         // Note: bit ranges are shown low..high to avoid [end:start] ambiguity.
         uint256 transferPolicyIds;
-        // Mint-side policies (read by `_mint`). Only `MINT_RECEIVER` is
+        // Mint-side policies (read by `_mint`). Only `MINT_RECEIVER_POLICY` is
         // defined today; the remaining three uint64 slots are reserved
         // for future granular mint-side policy types (e.g.
         // MINT_AUTHORIZER) so adding one doesn't force a second SLOAD.

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -59,7 +59,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @notice Built-in policy ID that always rejects any account.
     /// @dev    Useful as an explicit hard-deny on a slot (e.g. disabling
-    ///         redemption by pointing `REDEEMER_SENDER` here).
+    ///         redemption by pointing `REDEEMER_SENDER_POLICY` here).
     uint64 public constant ALWAYS_BLOCK_ID = PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
     /// @notice First counter value handed out to custom policies. Floors

--- a/test/unit/B20/erc20/transfer.t.sol
+++ b/test/unit/B20/erc20/transfer.t.sol
@@ -20,27 +20,27 @@ contract B20TransferTest is B20Test {
         token.transfer(to, amount);
     }
 
-    /// @notice Verifies transfer reverts when sender is not authorized under TRANSFER_SENDER
-    /// @dev Policy guard for the from-side; checks PolicyForbids(TRANSFER_SENDER, policyId) error
+    /// @notice Verifies transfer reverts when sender is not authorized under TRANSFER_SENDER_POLICY
+    /// @dev Policy guard for the from-side; checks PolicyForbids(TRANSFER_SENDER_POLICY, policyId) error
     function test_transfer_revert_senderPolicyForbids(address from, address to, uint256 amount) public {
         _assumeValidActor(from);
         _assumeValidActor(to);
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(from);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transfer(to, amount);
     }
 
-    /// @notice Verifies transfer reverts when recipient is not authorized under TRANSFER_RECEIVER
-    /// @dev Policy guard for the to-side; checks PolicyForbids(TRANSFER_RECEIVER, policyId) error
+    /// @notice Verifies transfer reverts when recipient is not authorized under TRANSFER_RECEIVER_POLICY
+    /// @dev Policy guard for the to-side; checks PolicyForbids(TRANSFER_RECEIVER_POLICY, policyId) error
     function test_transfer_revert_receiverPolicyForbids(address from, address to, uint256 amount) public {
         _assumeValidActor(from);
         _assumeValidActor(to);
-        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(from);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transfer(to, amount);
     }
 

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -30,7 +30,7 @@ contract B20TransferFromTest is B20Test {
         token.transferFrom(from, to, amount);
     }
 
-    /// @notice Verifies transferFrom reverts when caller is not authorized under TRANSFER_EXECUTOR
+    /// @notice Verifies transferFrom reverts when caller is not authorized under TRANSFER_EXECUTOR_POLICY
     /// @dev Executor-side policy guard fires after allowance consumption and before _transfer.
     function test_transferFrom_revert_executorPolicyForbids(address caller, address from, address to, uint256 amount)
         public
@@ -43,14 +43,14 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_EXECUTOR_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 
-    /// @notice Verifies transferFrom reverts when from is not authorized under TRANSFER_SENDER
+    /// @notice Verifies transferFrom reverts when from is not authorized under TRANSFER_SENDER_POLICY
     /// @dev Sender-side policy guard fires inside _transfer.
     function test_transferFrom_revert_senderPolicyForbids(address caller, address from, address to, uint256 amount)
         public
@@ -63,14 +63,14 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 
-    /// @notice Verifies transferFrom reverts when to is not authorized under TRANSFER_RECEIVER
+    /// @notice Verifies transferFrom reverts when to is not authorized under TRANSFER_RECEIVER_POLICY
     /// @dev Receiver-side policy guard fires inside _transfer.
     function test_transferFrom_revert_receiverPolicyForbids(address caller, address from, address to, uint256 amount)
         public
@@ -83,10 +83,10 @@ contract B20TransferFromTest is B20Test {
 
         vm.prank(from);
         token.approve(caller, amount);
-        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.transferFrom(from, to, amount);
     }
 

--- a/test/unit/B20/policy/policyTypeConstants.t.sol
+++ b/test/unit/B20/policy/policyTypeConstants.t.sol
@@ -9,31 +9,31 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 ///         fixed keccak digest. Substantive policy-related functions
 ///         (`policyId`, `updatePolicy`) live in their own files.
 contract B20PolicyTypeConstantsTest is B20Test {
-    /// @notice Verifies TRANSFER_SENDER returns keccak256("TRANSFER_SENDER")
+    /// @notice Verifies TRANSFER_SENDER_POLICY returns keccak256("TRANSFER_SENDER_POLICY")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_SENDER_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_SENDER(), keccak256("TRANSFER_SENDER"), "B20Constants.TRANSFER_SENDER digest");
-        assertEq(token.TRANSFER_SENDER(), B20Constants.TRANSFER_SENDER, "must match B20Test's local constant");
+    function test_TRANSFER_SENDER_POLICY_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_SENDER_POLICY(), keccak256("TRANSFER_SENDER_POLICY"), "B20Constants.TRANSFER_SENDER_POLICY digest");
+        assertEq(token.TRANSFER_SENDER_POLICY(), B20Constants.TRANSFER_SENDER_POLICY, "must match B20Test's local constant");
     }
 
-    /// @notice Verifies TRANSFER_RECEIVER returns keccak256("TRANSFER_RECEIVER")
+    /// @notice Verifies TRANSFER_RECEIVER_POLICY returns keccak256("TRANSFER_RECEIVER_POLICY")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_RECEIVER_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_RECEIVER(), keccak256("TRANSFER_RECEIVER"), "B20Constants.TRANSFER_RECEIVER digest");
-        assertEq(token.TRANSFER_RECEIVER(), B20Constants.TRANSFER_RECEIVER, "must match B20Test's local constant");
+    function test_TRANSFER_RECEIVER_POLICY_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_RECEIVER_POLICY(), keccak256("TRANSFER_RECEIVER_POLICY"), "B20Constants.TRANSFER_RECEIVER_POLICY digest");
+        assertEq(token.TRANSFER_RECEIVER_POLICY(), B20Constants.TRANSFER_RECEIVER_POLICY, "must match B20Test's local constant");
     }
 
-    /// @notice Verifies TRANSFER_EXECUTOR returns keccak256("TRANSFER_EXECUTOR")
+    /// @notice Verifies TRANSFER_EXECUTOR_POLICY returns keccak256("TRANSFER_EXECUTOR_POLICY")
     /// @dev Identifier stability for off-chain consumers
-    function test_TRANSFER_EXECUTOR_success_matchesExpected() public view {
-        assertEq(token.TRANSFER_EXECUTOR(), keccak256("TRANSFER_EXECUTOR"), "B20Constants.TRANSFER_EXECUTOR digest");
-        assertEq(token.TRANSFER_EXECUTOR(), B20Constants.TRANSFER_EXECUTOR, "must match B20Test's local constant");
+    function test_TRANSFER_EXECUTOR_POLICY_success_matchesExpected() public view {
+        assertEq(token.TRANSFER_EXECUTOR_POLICY(), keccak256("TRANSFER_EXECUTOR_POLICY"), "B20Constants.TRANSFER_EXECUTOR_POLICY digest");
+        assertEq(token.TRANSFER_EXECUTOR_POLICY(), B20Constants.TRANSFER_EXECUTOR_POLICY, "must match B20Test's local constant");
     }
 
-    /// @notice Verifies MINT_RECEIVER returns keccak256("MINT_RECEIVER")
+    /// @notice Verifies MINT_RECEIVER_POLICY returns keccak256("MINT_RECEIVER_POLICY")
     /// @dev Identifier stability for off-chain consumers
-    function test_MINT_RECEIVER_success_matchesExpected() public view {
-        assertEq(token.MINT_RECEIVER(), keccak256("MINT_RECEIVER"), "B20Constants.MINT_RECEIVER digest");
-        assertEq(token.MINT_RECEIVER(), B20Constants.MINT_RECEIVER, "must match B20Test's local constant");
+    function test_MINT_RECEIVER_POLICY_success_matchesExpected() public view {
+        assertEq(token.MINT_RECEIVER_POLICY(), keccak256("MINT_RECEIVER_POLICY"), "B20Constants.MINT_RECEIVER_POLICY digest");
+        assertEq(token.MINT_RECEIVER_POLICY(), B20Constants.MINT_RECEIVER_POLICY, "must match B20Test's local constant");
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -84,20 +84,20 @@ contract B20UpdatePolicyTest is B20Test {
     /// @dev Policy slots are packed into shared storage slots (one for transfer-side,
     ///      one for mint-side). A buggy write mask that doesn't isolate the target lane
     ///      would silently zero adjacent lanes. We set every supported policy slot to
-    ///      ALWAYS_BLOCK first, then update TRANSFER_SENDER to ALWAYS_ALLOW, and verify
+    ///      ALWAYS_BLOCK first, then update TRANSFER_SENDER_POLICY to ALWAYS_ALLOW, and verify
     ///      the other three slots are still ALWAYS_BLOCK.
     function test_updatePolicy_success_writeIsolatedToTargetLane() public {
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        _setPolicy(B20Constants.TRANSFER_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        _setPolicy(B20Constants.TRANSFER_EXECUTOR, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        _setPolicy(B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
 
-        assertEq(token.policyId(B20Constants.TRANSFER_SENDER), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "SENDER updated");
-        assertEq(token.policyId(B20Constants.TRANSFER_RECEIVER), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "RECEIVER must be untouched");
-        assertEq(token.policyId(B20Constants.TRANSFER_EXECUTOR), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "EXECUTOR must be untouched");
-        assertEq(token.policyId(B20Constants.MINT_RECEIVER), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "MINT_RECEIVER must be untouched");
+        assertEq(token.policyId(B20Constants.TRANSFER_SENDER_POLICY), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "SENDER updated");
+        assertEq(token.policyId(B20Constants.TRANSFER_RECEIVER_POLICY), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "RECEIVER must be untouched");
+        assertEq(token.policyId(B20Constants.TRANSFER_EXECUTOR_POLICY), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "EXECUTOR must be untouched");
+        assertEq(token.policyId(B20Constants.MINT_RECEIVER_POLICY), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "MINT_RECEIVER_POLICY must be untouched");
     }
 
     /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)

--- a/test/unit/B20/supply/burnBlocked.t.sol
+++ b/test/unit/B20/supply/burnBlocked.t.sol
@@ -26,10 +26,10 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_revert_whenBurnPaused(address from, uint256 amount) public {
         _assumeValidActor(from);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
-        // We also need TRANSFER_SENDER set to ALWAYS_BLOCK_ID so the from-not-authorized
+        // We also need TRANSFER_SENDER_POLICY set to ALWAYS_BLOCK_ID so the from-not-authorized
         // path is satisfied; otherwise the policy check inside burnBlocked fires
         // with AccountNotBlocked first.
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
         _pause(IB20.PausableFeature.BURN);
 
         vm.prank(burnBlocker);
@@ -37,12 +37,12 @@ contract B20BurnBlockedTest is B20Test {
         token.burnBlocked(from, amount);
     }
 
-    /// @notice Verifies burnBlocked reverts when the target is authorized under TRANSFER_SENDER
+    /// @notice Verifies burnBlocked reverts when the target is authorized under TRANSFER_SENDER_POLICY
     /// @dev Seizure is only permitted against policy-blocked addresses; checks AccountNotBlocked(from)
     function test_burnBlocked_revert_accountNotBlocked(address from, uint256 amount) public {
         _assumeValidActor(from);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
-        // Default TRANSFER_SENDER is ALWAYS_ALLOW_ID (0), so every address is "authorized" → not blocked.
+        // Default TRANSFER_SENDER_POLICY is ALWAYS_ALLOW_ID (0), so every address is "authorized" → not blocked.
 
         vm.prank(burnBlocker);
         vm.expectRevert(abi.encodeWithSelector(IB20.AccountNotBlocked.selector, from));
@@ -55,7 +55,7 @@ contract B20BurnBlockedTest is B20Test {
         _assumeValidActor(from);
         amount = bound(amount, 1, type(uint256).max);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID); // from is policy-blocked
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID); // from is policy-blocked
 
         // from has zero balance.
         vm.prank(burnBlocker);
@@ -69,8 +69,8 @@ contract B20BurnBlockedTest is B20Test {
         _assumeValidActor(from);
         // Mint while no policy is set so the mint isn't blocked.
         _mint(from, amount);
-        // Now block from via TRANSFER_SENDER policy, then seize.
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        // Now block from via TRANSFER_SENDER_POLICY policy, then seize.
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
 
         vm.prank(burnBlocker);
@@ -83,7 +83,7 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_success_decreasesTotalSupply(address from, uint256 amount) public {
         _assumeValidActor(from);
         _mint(from, amount);
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
         uint256 before = token.totalSupply();
 
@@ -97,7 +97,7 @@ contract B20BurnBlockedTest is B20Test {
     function test_burnBlocked_success_emitsTransferAndBurnedBlocked(address from, uint256 amount) public {
         _assumeValidActor(from);
         _mint(from, amount);
-        _setPolicy(B20Constants.TRANSFER_SENDER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
         _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
 
         vm.expectEmit(true, true, false, true, address(token));

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -55,15 +55,15 @@ contract B20MintTest is B20Test {
         token.mint(to, amount);
     }
 
-    /// @notice Verifies mint reverts when recipient fails the MINT_RECEIVER policy
-    /// @dev Policy guard for issuance; checks PolicyForbids(MINT_RECEIVER, policyId)
+    /// @notice Verifies mint reverts when recipient fails the MINT_RECEIVER_POLICY policy
+    /// @dev Policy guard for issuance; checks PolicyForbids(MINT_RECEIVER_POLICY, policyId)
     function test_mint_revert_receiverPolicyForbids(address to, uint256 amount) public {
         _assumeValidActor(to);
         _grantRole(B20Constants.MINT_ROLE, minter);
-        _setPolicy(B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(minter);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
         token.mint(to, amount);
     }
 


### PR DESCRIPTION
## Summary
- Rename the five policy-type getters on `IB20` and `IB20Security` to add a `_POLICY` suffix, matching the existing `*_ROLE` convention:
  - `TRANSFER_SENDER` → `TRANSFER_SENDER_POLICY`
  - `TRANSFER_RECEIVER` → `TRANSFER_RECEIVER_POLICY`
  - `TRANSFER_EXECUTOR` → `TRANSFER_EXECUTOR_POLICY`
  - `MINT_RECEIVER` → `MINT_RECEIVER_POLICY`
  - `REDEEMER_SENDER` → `REDEEMER_SENDER_POLICY`
- Updates the keccak256 string preimages so on-chain identifier bytes32 values match the new names.
- Propagates the rename through tests, mocks, natspec docstrings, and `script/mutate.py`.

## Test plan
- [x] `forge build` clean (only pre-existing lint warnings)
- [x] `forge test` — 315/316 pass; the single failure (`test_renounceLastAdmin_success_adminCountDrivenToZero`) reproduces on clean `main` and is unrelated to this rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)