### PR TITLE
chore: modifier cleanup and test fixes

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -63,12 +63,16 @@ MUTATIONS: list[Mutation] = [
         "if (!_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);",
         "_transfer: invert pause check (paused transfers succeed, unpaused revert)",
     ),
-    # === MockB20: role check in _mint ===
+    # === MockB20: role check in _requireRole (the onlyRole modifier body) ===
+    # After the modifier refactor, role checks at the call site (mint, pause,
+    # unpause, burn, burnBlocked, setName, setSymbol, etc.) all funnel through
+    # _requireRole. Inverting it inverts every onlyRole-gated path at once;
+    # the mint role-revert test (and many others) should still kill it.
     Mutation(
         MOCK_B20,
-        "if (!hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);",
-        "if (hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);",
-        "_mint: invert role check (only non-MINT_ROLE callers can mint)",
+        "if (!hasRole(role, msg.sender)) {\n            revert AccessControlUnauthorizedAccount(msg.sender, role);\n        }",
+        "if (hasRole(role, msg.sender)) {\n            revert AccessControlUnauthorizedAccount(msg.sender, role);\n        }",
+        "_requireRole: invert role check (role-holders fail every onlyRole gate)",
     ),
     # === MockB20: supply cap off-by-one ===
     Mutation(

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -6,7 +6,6 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
 
 import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
 
 /// @notice Canonical B-20 role and policy-type identifier constants.
 ///         Declared as a library (not on the contract) so tests and

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -106,6 +106,30 @@ contract MockB20 is IB20 {
     bytes32 public constant MINT_RECEIVER_POLICY = B20Constants.MINT_RECEIVER_POLICY;
 
     // ============================================================
+    //                          MODIFIERS
+    // ============================================================
+
+    /// @dev Gates a function on `msg.sender` holding `role`. Reverts
+    ///      `AccessControlUnauthorizedAccount` if not. The factory
+    ///      bootstrap window (`_isPrivileged()`) bypasses the check;
+    ///      see the contract-level natspec for the bypass invariant.
+    ///      Bodies of role-gated functions assume the check has run.
+    modifier onlyRole(bytes32 role) {
+        _requireRole(role);
+        _;
+    }
+
+    /// @dev Gates a function on `msg.sender` holding the admin role
+    ///      that governs `role` (per `getRoleAdmin`). Same factory
+    ///      bypass as `onlyRole`. Used by `grantRole` / `revokeRole`
+    ///      / `setRoleAdmin`, where the gate is over the meta-role,
+    ///      not the role itself.
+    modifier onlyRoleAdmin(bytes32 role) {
+        if (!_isPrivileged()) _requireRoleAdmin(role);
+        _;
+    }
+
+    // ============================================================
     //                          ERC-20: VIEWS
     // ============================================================
 
@@ -193,14 +217,12 @@ contract MockB20 is IB20 {
     //                         METADATA UPDATES
     // ============================================================
 
-    function setName(string calldata newName) external {
-        _requireRole(METADATA_ROLE);
+    function setName(string calldata newName) external onlyRole(METADATA_ROLE) {
         MockB20Storage.layout().name = newName;
         emit NameUpdated(msg.sender, newName);
     }
 
-    function setSymbol(string calldata newSymbol) external {
-        _requireRole(METADATA_ROLE);
+    function setSymbol(string calldata newSymbol) external onlyRole(METADATA_ROLE) {
         MockB20Storage.layout().symbol = newSymbol;
         emit SymbolUpdated(msg.sender, newSymbol);
     }
@@ -227,11 +249,8 @@ contract MockB20 is IB20 {
         emit Memo(memo);
     }
 
-    function burnBlocked(address from, uint256 amount) external {
+    function burnBlocked(address from, uint256 amount) external onlyRole(BURN_BLOCKED_ROLE) {
         if (!_isPrivileged()) {
-            if (!hasRole(BURN_BLOCKED_ROLE, msg.sender)) {
-                revert AccessControlUnauthorizedAccount(msg.sender, BURN_BLOCKED_ROLE);
-            }
             if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
             // The point of burnBlocked is to seize from policy-blocked
             // accounts. Read the transfer-sender policy ID out of the
@@ -260,13 +279,11 @@ contract MockB20 is IB20 {
         return adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE ? DEFAULT_ADMIN_ROLE : adminRole;
     }
 
-    function grantRole(bytes32 role, address account) external {
-        if (!_isPrivileged()) _requireRoleAdmin(role);
+    function grantRole(bytes32 role, address account) external onlyRoleAdmin(role) {
         _grantRole(role, account);
     }
 
-    function revokeRole(bytes32 role, address account) external {
-        if (!_isPrivileged()) _requireRoleAdmin(role);
+    function revokeRole(bytes32 role, address account) external onlyRoleAdmin(role) {
         _revokeRole(role, account);
     }
 
@@ -297,8 +314,7 @@ contract MockB20 is IB20 {
         emit LastAdminRenounced(msg.sender);
     }
 
-    function setRoleAdmin(bytes32 role, bytes32 newAdminRole) external {
-        if (!_isPrivileged()) _requireRoleAdmin(role);
+    function setRoleAdmin(bytes32 role, bytes32 newAdminRole) external onlyRoleAdmin(role) {
         bytes32 previousAdminRole = MockB20Storage.layout().roleAdmins[role];
         // Default admin if not explicitly set; expose it in the event.
         if (previousAdminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) {
@@ -333,12 +349,7 @@ contract MockB20 is IB20 {
         return _isPaused(feature);
     }
 
-    function pause(PausableFeature[] calldata features) external {
-        if (!_isPrivileged()) {
-            if (!hasRole(PAUSE_ROLE, msg.sender)) {
-                revert AccessControlUnauthorizedAccount(msg.sender, PAUSE_ROLE);
-            }
-        }
+    function pause(PausableFeature[] calldata features) external onlyRole(PAUSE_ROLE) {
         if (features.length == 0) revert EmptyFeatureSet();
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         for (uint256 i = 0; i < features.length; i++) {
@@ -347,12 +358,7 @@ contract MockB20 is IB20 {
         emit Paused(msg.sender, features);
     }
 
-    function unpause(PausableFeature[] calldata features) external {
-        if (!_isPrivileged()) {
-            if (!hasRole(UNPAUSE_ROLE, msg.sender)) {
-                revert AccessControlUnauthorizedAccount(msg.sender, UNPAUSE_ROLE);
-            }
-        }
+    function unpause(PausableFeature[] calldata features) external onlyRole(UNPAUSE_ROLE) {
         if (features.length == 0) revert EmptyFeatureSet();
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         for (uint256 i = 0; i < features.length; i++) {
@@ -369,8 +375,7 @@ contract MockB20 is IB20 {
         return _readPolicyId(policyType);
     }
 
-    function updatePolicy(bytes32 policyType, uint64 newPolicyId) external {
-        _requireAdmin();
+    function updatePolicy(bytes32 policyType, uint64 newPolicyId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         // Read the old ID first: this both supplies the value for the
         // event and validates that `policyType` is supported (reverts
         // UnsupportedPolicyType cheaply, before the cross-contract
@@ -434,8 +439,7 @@ contract MockB20 is IB20 {
         return MockB20Storage.layout().supplyCap;
     }
 
-    function setSupplyCap(uint256 newSupplyCap) external {
-        _requireAdmin();
+    function setSupplyCap(uint256 newSupplyCap) external onlyRole(DEFAULT_ADMIN_ROLE) {
         uint256 currentSupply = MockB20Storage.layout().totalSupply;
         if (newSupplyCap < currentSupply) revert InvalidSupplyCap(currentSupply, newSupplyCap);
         uint256 oldSupplyCap = MockB20Storage.layout().supplyCap;
@@ -520,8 +524,7 @@ contract MockB20 is IB20 {
         return MockB20Storage.layout().contractURI;
     }
 
-    function setContractURI(string calldata newURI) external {
-        _requireAdmin();
+    function setContractURI(string calldata newURI) external onlyRole(DEFAULT_ADMIN_ROLE) {
         MockB20Storage.layout().contractURI = newURI;
         emit ContractURIUpdated();
     }
@@ -538,13 +541,8 @@ contract MockB20 is IB20 {
         return msg.sender == FACTORY && !MockB20Storage.layout().initialized;
     }
 
-    function _requireAdmin() internal view {
-        if (_isPrivileged()) return;
-        if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
-            revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);
-        }
-    }
-
+    /// @dev Body for the `onlyRole` modifier. Honors the factory bootstrap
+    ///      bypass; otherwise reverts `AccessControlUnauthorizedAccount`.
     function _requireRole(bytes32 role) internal view {
         if (_isPrivileged()) return;
         if (!hasRole(role, msg.sender)) {
@@ -552,6 +550,12 @@ contract MockB20 is IB20 {
         }
     }
 
+    /// @dev Body for the `onlyRoleAdmin` modifier (the privileged bypass
+    ///      lives in the modifier, not here, so this helper is reusable
+    ///      from any context that has already cleared the bypass).
+    ///      Resolves the admin-of-`role` per `getRoleAdmin` semantics:
+    ///      an unset entry collapses to `DEFAULT_ADMIN_ROLE` unless `role`
+    ///      itself is `DEFAULT_ADMIN_ROLE`.
     function _requireRoleAdmin(bytes32 role) internal view {
         bytes32 adminRole = MockB20Storage.layout().roleAdmins[role];
         if (adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) adminRole = DEFAULT_ADMIN_ROLE;
@@ -620,11 +624,10 @@ contract MockB20 is IB20 {
         emit Transfer(from, to, amount);
     }
 
-    function _mint(address to, uint256 amount) internal {
+    function _mint(address to, uint256 amount) internal onlyRole(MINT_ROLE) {
         if (to == address(0)) revert InvalidReceiver(to);
 
         if (!_isPrivileged()) {
-            if (!hasRole(MINT_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, MINT_ROLE);
             if (_isPaused(PausableFeature.MINT)) revert ContractPaused(PausableFeature.MINT);
             uint64 mintReceiverPolicyId = uint64(MockB20Storage.layout().mintPolicyIds);
             if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(mintReceiverPolicyId, to)) {
@@ -642,9 +645,8 @@ contract MockB20 is IB20 {
         emit Transfer(address(0), to, amount);
     }
 
-    function _burnSelf(address from, uint256 amount) internal {
+    function _burnSelf(address from, uint256 amount) internal onlyRole(BURN_ROLE) {
         if (!_isPrivileged()) {
-            if (!hasRole(BURN_ROLE, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, BURN_ROLE);
             if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
         }
         _burnRaw(from, amount);

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -85,6 +85,25 @@ contract MockB20Security is MockB20, IB20Security {
     uint256 public constant WAD_PRECISION = 1e18;
 
     // ============================================================
+    //                          MODIFIERS
+    // ============================================================
+
+    /// @dev Like the base `onlyRole` but without the factory bootstrap
+    ///      bypass: the role check is unconditional, even for the
+    ///      factory in the init window. Reserved for variant paths
+    ///      that deliberately reject the bypass — currently just
+    ///      `batchBurn`, the corporate-actions clawback that has no
+    ///      init-time use case (see this contract's natspec). Lives
+    ///      here, not on the base, because no base function needs the
+    ///      stricter gate.
+    modifier onlyRoleStrict(bytes32 role) {
+        if (!hasRole(role, msg.sender)) {
+            revert AccessControlUnauthorizedAccount(msg.sender, role);
+        }
+        _;
+    }
+
+    // ============================================================
     //                        ANNOUNCEMENTS
     // ============================================================
 
@@ -93,9 +112,7 @@ contract MockB20Security is MockB20, IB20Security {
         string calldata id,
         string calldata description,
         string calldata uri
-    ) external {
-        _requireRole(SECURITY_OPERATOR_ROLE);
-
+    ) external onlyRole(SECURITY_OPERATOR_ROLE) {
         MockB20SecurityStorage.Layout storage $ = MockB20SecurityStorage.layout();
         if ($.usedAnnouncementIds[id]) revert AnnouncementIdAlreadyUsed(id);
         // Mark consumed BEFORE the emit and BEFORE any inner calls so
@@ -135,8 +152,7 @@ contract MockB20Security is MockB20, IB20Security {
         return (MockB20Storage.layout().balances[account] * _sharesToTokensRatio()) / WAD_PRECISION;
     }
 
-    function updateShareRatio(uint256 newSharesToTokensRatio) external {
-        _requireRole(SECURITY_OPERATOR_ROLE);
+    function updateShareRatio(uint256 newSharesToTokensRatio) external onlyRole(SECURITY_OPERATOR_ROLE) {
         MockB20SecurityStorage.layout().sharesToTokensRatio = newSharesToTokensRatio;
         emit ShareRatioUpdated(newSharesToTokensRatio);
     }
@@ -156,12 +172,19 @@ contract MockB20Security is MockB20, IB20Security {
         }
     }
 
-    function batchBurn(address[] calldata accounts, uint256[] calldata amounts) external {
-        if (accounts.length != amounts.length) revert LengthMismatch(accounts.length, amounts.length);
-        if (accounts.length == 0) revert EmptyBatch();
-        if (!hasRole(BURN_FROM_ROLE, msg.sender)) {
-            revert AccessControlUnauthorizedAccount(msg.sender, BURN_FROM_ROLE);
+    /// @dev `onlyRoleStrict` (not `onlyRole`): the factory bootstrap
+    ///      bypass is deliberately NOT honored here, per the contract
+    ///      natspec — clawback against existing balances has no init-time
+    ///      use case, so granting the factory a bypass would only widen
+    ///      the attack surface.
+    function batchBurn(address[] calldata accounts, uint256[] calldata amounts)
+        external
+        onlyRoleStrict(BURN_FROM_ROLE)
+    {
+        if (accounts.length != amounts.length) {
+            revert LengthMismatch(accounts.length, amounts.length);
         }
+        if (accounts.length == 0) revert EmptyBatch();
         if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
         for (uint256 i = 0; i < accounts.length; i++) {
             _burnRaw(accounts[i], amounts[i]);
@@ -184,8 +207,7 @@ contract MockB20Security is MockB20, IB20Security {
         emit Redeemed(msg.sender, amount, ratio);
     }
 
-    function updateMinimumRedeemable(uint256 newMinimumRedeemable) external {
-        _requireAdmin();
+    function updateMinimumRedeemable(uint256 newMinimumRedeemable) external onlyRole(DEFAULT_ADMIN_ROLE) {
         MockB20RedeemStorage.layout().minimumRedeemable = newMinimumRedeemable;
         emit MinimumRedeemableUpdated(newMinimumRedeemable);
     }
@@ -202,8 +224,10 @@ contract MockB20Security is MockB20, IB20Security {
         return MockB20SecurityStorage.layout().identifiers[identifierType];
     }
 
-    function updateSecurityIdentifier(string calldata identifierType, string calldata value) external {
-        _requireRole(SECURITY_OPERATOR_ROLE);
+    function updateSecurityIdentifier(string calldata identifierType, string calldata value)
+        external
+        onlyRole(SECURITY_OPERATOR_ROLE)
+    {
         if (bytes(identifierType).length == 0) revert InvalidIdentifierType();
         MockB20SecurityStorage.layout().identifiers[identifierType] = value;
         emit SecurityIdentifierUpdated(identifierType, value);

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -96,22 +96,14 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         adminCount > 0 would be otherwise undetectable from the public surface
     ///         (since with no admins, no path that reads adminCount is reachable).
     ///         Directly inspecting storage closes the loop on the rusty-storage contract.
-    ///
-    ///         `adminCount` is `uint248` packed with the `bool initialized` flag in
-    ///         the same slot (initialized at byte 31, adminCount in the low 248 bits),
-    ///         so we mask out the high byte before comparing.
     function test_renounceLastAdmin_success_adminCountDrivenToZero() public {
         bytes32 adminCountSlot = MockB20Storage.slotOf(MockB20Storage.ADMIN_COUNT_OFFSET);
-        uint256 adminCountMask = (uint256(1) << 248) - 1;
-
-        uint256 rawBefore = uint256(vm.load(address(token), adminCountSlot));
-        assertEq(rawBefore & adminCountMask, 1, "precondition: count is 1");
+        assertEq(uint256(vm.load(address(token), adminCountSlot)), 1, "precondition: count is 1");
 
         vm.prank(admin);
         token.renounceLastAdmin();
 
-        uint256 rawAfter = uint256(vm.load(address(token), adminCountSlot));
-        assertEq(rawAfter & adminCountMask, 0, "adminCount must be 0 post-renounce");
+        assertEq(uint256(vm.load(address(token), adminCountSlot)), 0, "adminCount must be 0 post-renounce");
     }
 
     /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -96,14 +96,22 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         adminCount > 0 would be otherwise undetectable from the public surface
     ///         (since with no admins, no path that reads adminCount is reachable).
     ///         Directly inspecting storage closes the loop on the rusty-storage contract.
+    ///
+    ///         `adminCount` is `uint248` packed with the `bool initialized` flag in
+    ///         the same slot (initialized at byte 31, adminCount in the low 248 bits),
+    ///         so we mask out the high byte before comparing.
     function test_renounceLastAdmin_success_adminCountDrivenToZero() public {
         bytes32 adminCountSlot = MockB20Storage.slotOf(MockB20Storage.ADMIN_COUNT_OFFSET);
-        assertEq(uint256(vm.load(address(token), adminCountSlot)), 1, "precondition: count is 1");
+        uint256 adminCountMask = (uint256(1) << 248) - 1;
+
+        uint256 rawBefore = uint256(vm.load(address(token), adminCountSlot));
+        assertEq(rawBefore & adminCountMask, 1, "precondition: count is 1");
 
         vm.prank(admin);
         token.renounceLastAdmin();
 
-        assertEq(uint256(vm.load(address(token), adminCountSlot)), 0, "adminCount must be 0 post-renounce");
+        uint256 rawAfter = uint256(vm.load(address(token), adminCountSlot));
+        assertEq(rawAfter & adminCountMask, 0, "adminCount must be 0 post-renounce");
     }
 
     /// @notice Verifies renounceLastAdmin emits LastAdminRenounced(previousAdmin)

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -10,9 +10,11 @@ import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPo
 contract B20MintTest is B20Test {
     /// @notice Verifies mint reverts when caller lacks MINT_ROLE
     /// @dev Access control: only role-holders can mint; checks AccessControlUnauthorizedAccount.
-    ///      Note _mint's check order: InvalidReceiver(0) fires BEFORE the role check, so
-    ///      we filter to != 0 to exercise the role-check path specifically. The
-    ///      InvalidReceiver path is covered by test_mint_revert_zeroRecipient.
+    ///      The `onlyRole(MINT_ROLE)` modifier on `_mint` runs before any in-body input
+    ///      validation, so the role-check path fires regardless of `to`. The
+    ///      InvalidReceiver path is covered by test_mint_revert_zeroRecipient. The
+    ///      `to != 0` filter is kept for clarity (it documents which path each
+    ///      test exercises) but is no longer load-bearing.
     function test_mint_revert_unauthorized(address caller, address to, uint256 amount) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);
@@ -63,7 +65,11 @@ contract B20MintTest is B20Test {
         _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
 
         vm.prank(minter);
-        vm.expectRevert(abi.encodeWithSelector(IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
         token.mint(to, amount);
     }
 


### PR DESCRIPTION
#### Refactor: role-check helpers → modifiers
- MockB20.sol: added onlyRole(role) (factory bootstrap bypass) and onlyRoleAdmin(role) (admin-of-role + bypass) modifiers; deleted dead _requireAdmin helper. Replaced ~12 inline hasRole(...) revert / _requireRole(...) / _requireAdmin() / _requireRoleAdmin(...) callsites with the modifier annotation.
- MockB20Security.sol: same conversion for the variant's role-gated functions; added onlyRoleStrict(role) (no bypass) for the lone path that intentionally rejects the bootstrap bypass (batchBurn).
- Killed a stale self-import (import {B20Constants} from "test/lib/mocks/MockB20.sol" inside MockB20.sol) that was triggering the IDE's shadow warning.

#### Test fixes
- mint.t.sol: updated stale comment that documented the old check order; the onlyRole modifier now runs before in-body input validation.

#### Mutation script
- mutate.py: retargeted the _mint MINT_ROLE inline-check mutation to _requireRole, since the original substring no longer exists in source. New mutation is broader (inverts every onlyRole gate) but still killed by the existing tests.
Result: 316 / 316 tests passing.