### PR TITLE
chore: add ActivationRegistryFeatureList constants library

### DIFF
--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice Canonical feature id constants for the activation registry.
+library ActivationRegistryFeatureList {
+    /// @dev keccak256("base.b20_security")
+    bytes32 internal constant B20_SECURITY = 0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6;
+
+    /// @dev keccak256("base.b20_token")
+    bytes32 internal constant B20_TOKEN = 0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752;
+
+    /// @dev keccak256("base.token_factory")
+    bytes32 internal constant TOKEN_FACTORY = 0xceff857b4173841a3aef07ca52b183282fe74fe117e8f9dda0dcb3ddafd18a5b;
+
+    /// @dev keccak256("base.policy_registry")
+    bytes32 internal constant POLICY_REGISTRY = 0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f;
+}


### PR DESCRIPTION
## Summary
- Adds `test/lib/mocks/ActivationRegistryFeatureList.sol` with canonical `bytes32` feature id constants (`B20_SECURITY`, `B20_TOKEN`, `TOKEN_FACTORY`, `POLICY_REGISTRY`) for use in tests against the activation registry.

## Test plan
- [ ] `forge build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)