### PR TITLE
docs: add AGENTS.md clarifying main is the active branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+## Branching
+
+- **`main` is the default branch.** Branch from `main` and open PRs against `main`.
+- Ignore `master` — it is stale. Do not branch from it, target it in PRs, or use it as a base reference.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at the repo root noting that `main` is the active branch and `master` is stale. Intended to keep agents (and humans) from branching off / PR'ing against `master`.

## Test plan
- [ ] N/A — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)