### PR TITLE
feat: add AlreadyDeactivated error to IActivationRegistry

### DIFF
--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -40,6 +40,10 @@ interface IActivationRegistry {
     ///         activated.
     error AlreadyActivated(bytes32 feature);
 
+    /// @notice `deactivate` was called on a feature that is already
+    ///         deactivated.
+    error AlreadyDeactivated(bytes32 feature);
+
     /// @notice `feature` is not activated. Returned by `deactivate` and
     ///         by precompiles that consult the registry as a hard gate
     ///         (the chain node uses an `assertActivated`-style flow for
@@ -91,8 +95,8 @@ interface IActivationRegistry {
     function activate(bytes32 feature) external;
 
     /// @notice Deactivates `feature`. Caller MUST equal `admin()` (else
-    ///         `Unauthorized`). Reverts with `FeatureNotActivated` if
-    ///         the feature is not currently activated; reverts with
+    ///         `Unauthorized`). Reverts with `AlreadyDeactivated` if
+    ///         the feature is already deactivated; reverts with
     ///         `StaticCallNotAllowed` if invoked under `STATICCALL`.
     ///         Emits `FeatureDeactivated` on success.
     function deactivate(bytes32 feature) external;


### PR DESCRIPTION
## Summary

- Adds `AlreadyDeactivated(bytes32 feature)` error to `IActivationRegistry` to mirror the error already defined in the Rust ABI (`activation/abi.rs`)
- Updates the `deactivate` NatSpec to reference `AlreadyDeactivated` as the revert condition when the feature is already inactive

## Motivation

The Rust ABI and the Solidity interface were out of sync — `abi.rs` already declared `AlreadyDeactivated` but it was missing from the Solidity interface. This brings them into alignment.

## Test plan

- [ ] Confirm `AlreadyDeactivated` selector in Solidity matches the one generated by `alloy_sol_types` in `abi.rs`

Made with [Cursor](https://cursor.com)