### PR TITLE
Move B20 initialized flag to its own slot at end of layout

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -205,8 +205,8 @@ MUTATIONS: list[Mutation] = [
     # === MockTokenFactory: skip the closeBootstrap step ===
     Mutation(
         MOCK_FACTORY,
-        "_writeBool(token, MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET), true);",
-        "// _writeBool(token, MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET), true);",
+        "_writeUint(token, MockB20Storage.initializedSlot(), 1);",
+        "// _writeUint(token, MockB20Storage.initializedSlot(), 1);",
         "createToken: never closes the bootstrap window (factory remains permanently privileged)",
     ),
     # === MockTokenFactory: wrong supply cap default ===

--- a/test/lib/mocks/MockB20Storage.sol
+++ b/test/lib/mocks/MockB20Storage.sol
@@ -53,12 +53,10 @@ library MockB20Storage {
         mapping(bytes32 role => bytes32 adminRole) roleAdmins;
         // Tracks DEFAULT_ADMIN_ROLE holder count so renounceRole can enforce
         // LastAdminCannotRenounce in O(1). Bumped on grant, decremented on
-        // revoke / renounce.
-        uint248 adminCount;
-        // False from etch until the factory sets it true at the end of
-        // createToken. Packed with adminCount in the same slot to avoid
-        // dedicating a full slot to a single flag.
-        bool initialized;
+        // revoke / renounce. Lives alone in its own slot — packing it with
+        // `initialized` is no longer required since `initialized` was moved
+        // out to its own slot at the end of the layout.
+        uint256 adminCount;
         // ---------- Policy slots (PACKED, per-operation) ----------
         // Hot-path policy IDs live in per-operation packed slots so each
         // op reads exactly one slot, AND so adding granularity to one op
@@ -103,6 +101,16 @@ library MockB20Storage {
         uint256 supplyCap;
         // ---------- Permit (EIP-2612) ----------
         mapping(address owner => uint256 nonce) nonces;
+        // ---------- Bootstrap flag ----------
+        // False from etch until the factory sets it true at the end of
+        // createToken. Pinned to its own slot at the END of the layout
+        // because the EVM impl uses this flag as the demarcation between
+        // the privileged bootstrap window and post-init state, while the
+        // Rust impl distinguishes those phases through a different
+        // mechanism and does not need a storage slot for the flag at all.
+        // Keeping it last lets the Rust impl's layout omit it without
+        // disturbing the offset of any other field.
+        bool initialized;
     }
 
     // keccak256(abi.encode(uint256(keccak256("base.b20")) - 1)) & ~bytes32(uint256(0xff))
@@ -135,14 +143,14 @@ library MockB20Storage {
     uint256 internal constant ROLES_OFFSET = 6;
     uint256 internal constant ROLE_ADMINS_OFFSET = 7;
     uint256 internal constant ADMIN_COUNT_OFFSET = 8;
-    uint256 internal constant INITIALIZED_OFFSET = 8;
-    // `initialized` is the high byte in slot 8 (packed after uint248 adminCount).
-    uint8 internal constant INITIALIZED_BYTE_OFFSET = 31;
     uint256 internal constant TRANSFER_POLICY_IDS_OFFSET = 9;
     uint256 internal constant MINT_POLICY_IDS_OFFSET = 10;
     uint256 internal constant PAUSED_VECTORS_OFFSET = 11;
     uint256 internal constant SUPPLY_CAP_OFFSET = 12;
     uint256 internal constant NONCES_OFFSET = 13;
+    // `initialized` sits alone in its own slot at the END of the layout;
+    // see the field-level natspec above for why.
+    uint256 internal constant INITIALIZED_OFFSET = 14;
 
     /// @notice Absolute slot for a top-level field of `Layout`.
     /// @dev `STORAGE_LOCATION + offset`. The struct never crosses the
@@ -180,12 +188,13 @@ library MockB20Storage {
     function allowancesBaseSlot() internal pure returns (bytes32) { return slotOf(ALLOWANCES_OFFSET); }
     function rolesBaseSlot() internal pure returns (bytes32) { return slotOf(ROLES_OFFSET); }
     function roleAdminsBaseSlot() internal pure returns (bytes32) { return slotOf(ROLE_ADMINS_OFFSET); }
-    function adminCountAndInitializedSlot() internal pure returns (bytes32) { return slotOf(ADMIN_COUNT_OFFSET); }
+    function adminCountSlot() internal pure returns (bytes32) { return slotOf(ADMIN_COUNT_OFFSET); }
     function transferPolicyIdsSlot() internal pure returns (bytes32) { return slotOf(TRANSFER_POLICY_IDS_OFFSET); }
     function mintPolicyIdsSlot() internal pure returns (bytes32) { return slotOf(MINT_POLICY_IDS_OFFSET); }
     function pausedVectorsSlot() internal pure returns (bytes32) { return slotOf(PAUSED_VECTORS_OFFSET); }
     function supplyCapSlot() internal pure returns (bytes32) { return slotOf(SUPPLY_CAP_OFFSET); }
     function noncesBaseSlot() internal pure returns (bytes32) { return slotOf(NONCES_OFFSET); }
+    function initializedSlot() internal pure returns (bytes32) { return slotOf(INITIALIZED_OFFSET); }
 
         // forgefmt: disable-end
 
@@ -230,35 +239,12 @@ library MockB20Storage {
     // ============================================================
     //                     PACKED-SLOT CODECS
     // ============================================================
-    // Two slots in `Layout` pack multiple logical values:
-    //   - Slot at ADMIN_COUNT_OFFSET (8): uint248 adminCount in the low
-    //     31 bytes, bool initialized in the high byte (byte 31).
-    //   - Slots at TRANSFER_POLICY_IDS_OFFSET (9) and
-    //     MINT_POLICY_IDS_OFFSET (10): four uint64 lanes packed
-    //     low-to-high (lane 0 in bits  0..63, lane 1 in bits 64..127,
-    //     lane 2 in bits 128..191, lane 3 in bits 192..255).
-    //
-    // These pure codecs let test callers extract / compose lane values
-    // without re-deriving the shifts at every callsite.
-
-    /// @notice Extracts `adminCount` (low 248 bits) from the packed slot.
-    /// @dev Mirrors the read side of MockB20's `_isPrivileged` /
-    ///      `_adminCount` accessors.
-    function adminCountFromPacked(uint256 packed) internal pure returns (uint248) {
-        // forge-lint: disable-next-line(unsafe-typecast)
-        return uint248(packed & ((uint256(1) << 248) - 1));
-    }
-
-    /// @notice Extracts `initialized` (high byte) from the packed slot.
-    function initializedFromPacked(uint256 packed) internal pure returns (bool) {
-        return (packed >> 248) != 0;
-    }
-
-    /// @notice Composes the packed slot value from its two fields.
-    function packAdminCountAndInitialized(uint248 adminCount_, bool initialized_) internal pure returns (uint256) {
-        uint256 base = uint256(adminCount_);
-        return initialized_ ? (base | (uint256(1) << 248)) : base;
-    }
+    // The transfer-side and mint-side policy slots each pack four
+    // uint64 lanes into a single 256-bit slot, low-to-high (lane 0 in
+    // bits  0..63, lane 1 in bits 64..127, lane 2 in bits 128..191,
+    // lane 3 in bits 192..255). These pure codecs let test callers
+    // extract / compose lane values without re-deriving the shifts at
+    // every callsite.
 
     /// @notice Extracts the TRANSFER_SENDER policy id (lane 0) from the packed slot.
     function transferSenderPolicyId(uint256 packed) internal pure returns (uint64) {

--- a/test/lib/mocks/MockTokenFactory.sol
+++ b/test/lib/mocks/MockTokenFactory.sol
@@ -204,12 +204,10 @@ contract MockTokenFactory is ITokenFactory {
         // -- 9. Close the bootstrap window by setting initialized=true.
         //       After this, the factory's privilege is gone; only
         //       role / policy / pause holders can mutate state.
-        _writePackedBool(
-            token,
-            MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET),
-            MockB20Storage.INITIALIZED_BYTE_OFFSET,
-            true
-        );
+        //       `initialized` lives alone in its own slot at the end
+        //       of the base layout, so writing the slot is a plain
+        //       1-store with no masking against neighbouring fields.
+        _writeUint(token, MockB20Storage.initializedSlot(), 1);
     }
 
     /// @dev `DEFAULT_ADMIN_ROLE` per OZ AccessControl convention.
@@ -228,13 +226,10 @@ contract MockTokenFactory is ITokenFactory {
     /// @inheritdoc ITokenFactory
     function isB20Initialized(address token) external view returns (bool) {
         if (!_isB20Prefix(token)) return false;
-        // Same packed-bool slot the factory flips at the end of
-        // createToken (MockB20Storage.INITIALIZED_OFFSET +
-        // INITIALIZED_BYTE_OFFSET).
-        bytes32 slot = MockB20Storage.slotOf(MockB20Storage.INITIALIZED_OFFSET);
-        uint256 word = uint256(vm.load(token, slot));
-        uint256 shift = uint256(MockB20Storage.INITIALIZED_BYTE_OFFSET) * 8;
-        return ((word >> shift) & 0xff) != 0;
+        // Same dedicated slot the factory flips at the end of createToken
+        // (MockB20Storage.INITIALIZED_OFFSET). The slot holds nothing
+        // else, so any non-zero word means initialized=true.
+        return uint256(vm.load(token, MockB20Storage.initializedSlot())) != 0;
     }
 
     // ============================================================
@@ -274,10 +269,12 @@ contract MockTokenFactory is ITokenFactory {
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET), name_);
         _writeString(token, MockB20Storage.slotOf(MockB20Storage.SYMBOL_OFFSET), symbol_);
         _writeUint(token, MockB20Storage.slotOf(MockB20Storage.SUPPLY_CAP_OFFSET), type(uint256).max);
-        // Everything else (totalSupply, allowances, roles, roleAdmins,
-        // adminCount, transferPolicyIds, mintPolicyIds, pausedVectors,
-        // nonces, contractURI, initialized) defaults to the EVM's zero
-        // state, which is correct for a fresh token.
+        // Everything else (totalSupply, balances, allowances, roles,
+        // roleAdmins, adminCount, transferPolicyIds, mintPolicyIds,
+        // pausedVectors, nonces, contractURI, initialized) defaults to
+        // the EVM's zero state, which is correct for a fresh token.
+        // The factory flips `initialized` to true in createToken step 9
+        // after initCalls have run.
     }
 
     /// @dev Writes the stablecoin variant's `currency` field at its
@@ -305,14 +302,6 @@ contract MockTokenFactory is ITokenFactory {
 
     function _writeUint(address target, bytes32 slot, uint256 value) internal {
         vm.store(target, slot, bytes32(value));
-    }
-
-    function _writePackedBool(address target, bytes32 slot, uint8 byteOffset, bool value) internal {
-        uint256 shift = uint256(byteOffset) * 8;
-        uint256 mask = uint256(0xff) << shift;
-        uint256 current = uint256(vm.load(target, slot));
-        uint256 bit = value ? (uint256(1) << shift) : 0;
-        vm.store(target, slot, bytes32((current & ~mask) | bit));
     }
 
     /// @dev Solidity string storage encoding:

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -111,34 +111,40 @@ contract B20RenounceLastAdminTest is B20Test {
     }
 
     /// @notice Verifies renounceLastAdmin drives the internal adminCount tracker to zero
-    /// @dev    adminCount is internal state with no public getter; it shares
-    ///         a slot with the `initialized` bool (uint248 in the low 31
-    ///         bytes, bool in byte 31). We read the slot directly via
-    ///         `vm.load` and decode each field via the codecs on
-    ///         `MockB20Storage` so the test exercises the canonical
-    ///         packed-slot layout the Rust impl must match.
+    /// @dev    adminCount is internal state with no public getter; it lives
+    ///         alone in its own slot (slot 8). We read the slot directly via
+    ///         `vm.load` so the test exercises the canonical storage
+    ///         layout the Rust impl must match.
     ///
     ///         A buggy impl that cleared the role but left adminCount > 0
     ///         would be otherwise undetectable from the public surface
     ///         (since with no admins, no path that reads adminCount is
     ///         reachable). Directly inspecting storage closes the loop on
-    ///         the storage-layout contract. Equally important: a buggy
-    ///         renounce that mis-masks the slot would clobber `initialized`
-    ///         and re-open the factory bootstrap window — also caught here.
+    ///         the storage-layout contract. We additionally re-assert the
+    ///         `initialized` slot (now disjoint at slot 14) is still set,
+    ///         so a buggy renounce that scribbled past adminCount's slot
+    ///         and re-opened the factory bootstrap window would be caught
+    ///         here too.
     function test_renounceLastAdmin_success_adminCountDrivenToZero() public {
-        bytes32 packedSlot = MockB20Storage.adminCountAndInitializedSlot();
-        uint256 before = uint256(vm.load(address(token), packedSlot));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(before)), 1, "precondition: adminCount is 1");
-        assertTrue(MockB20Storage.initializedFromPacked(before), "precondition: initialized is true");
+        bytes32 adminCountSlot = MockB20Storage.adminCountSlot();
+        bytes32 initializedSlot = MockB20Storage.initializedSlot();
+        assertEq(
+            uint256(vm.load(address(token), adminCountSlot)), 1, "precondition: adminCount is 1"
+        );
+        assertEq(
+            uint256(vm.load(address(token), initializedSlot)), 1, "precondition: initialized is true"
+        );
 
         vm.prank(admin);
         token.renounceLastAdmin();
 
-        uint256 packedAfter = uint256(vm.load(address(token), packedSlot));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packedAfter)), 0, "adminCount must be 0 post-renounce");
-        assertTrue(
-            MockB20Storage.initializedFromPacked(packedAfter),
-            "initialized bit must remain set (renounce only clears adminCount)"
+        assertEq(
+            uint256(vm.load(address(token), adminCountSlot)), 0, "adminCount must be 0 post-renounce"
+        );
+        assertEq(
+            uint256(vm.load(address(token), initializedSlot)),
+            1,
+            "initialized slot must remain set (renounce only clears adminCount)"
         );
     }
 

--- a/test/unit/B20/roles/renounceRole.t.sol
+++ b/test/unit/B20/roles/renounceRole.t.sol
@@ -85,8 +85,10 @@ contract B20RenounceRoleTest is B20Test {
     /// @dev LastAdminCannotRenounce only fires when the renouncer would leave the role empty.
     ///      Paired slot assertions verify both `roles[ADMIN][admin]`
     ///      (cleared) and `roles[ADMIN][otherAdmin]` (still set), plus
-    ///      the packed `adminCount` decrements from 2 to 1 while
-    ///      `initialized` stays true (sharing slot 8).
+    ///      the `adminCount` slot decrements from 2 to 1 while the
+    ///      `initialized` slot stays true. `adminCount` and `initialized`
+    ///      now live in disjoint slots (slot 8 and slot 14 respectively),
+    ///      so each is asserted with its own `vm.load`.
     function test_renounceRole_success_adminWithOthers(address otherAdmin) public {
         _assumeValidActor(otherAdmin);
         vm.assume(otherAdmin != admin);
@@ -110,9 +112,14 @@ contract B20RenounceRoleTest is B20Test {
             uint256(1),
             "roles[ADMIN][otherAdmin] slot must still be set"
         );
-        uint256 packed = uint256(vm.load(address(token), MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 1, "adminCount must drop to 1");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized bit must stay set");
+        assertEq(
+            uint256(vm.load(address(token), MockB20Storage.adminCountSlot())), 1, "adminCount must drop to 1"
+        );
+        assertEq(
+            uint256(vm.load(address(token), MockB20Storage.initializedSlot())),
+            1,
+            "initialized slot must stay set"
+        );
     }
 
     /// @notice Verifies the internal adminCount tracker stays consistent with role state

--- a/test/unit/TokenFactory/createToken.t.sol
+++ b/test/unit/TokenFactory/createToken.t.sol
@@ -291,9 +291,16 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, caller), "caller must not hold admin");
         assertEq(IB20Security(token).securityIdentifier(IDENTIFIER_ISIN), DEFAULT_ISIN, "ISIN must still be set");
 
-        uint256 packed = uint256(vm.load(token, MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 0, "adminCount must be 0 on zero-admin path");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized must still be set on zero-admin path");
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.adminCountSlot())),
+            0,
+            "adminCount must be 0 on zero-admin path"
+        );
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.initializedSlot())),
+            1,
+            "initialized must still be set on zero-admin path"
+        );
     }
 
     /// @notice Major reserve currencies (USD, EUR, JPY, GBP, CHF, CNY, CAD, AUD) are accepted.
@@ -400,9 +407,16 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
             uint256(0),
             "factory must NOT appear in roles[ADMIN] slot"
         );
-        uint256 packed = uint256(vm.load(token, MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 1, "adminCount must be 1 after bootstrap grant");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized bit must be set after bootstrap closes");
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.adminCountSlot())),
+            1,
+            "adminCount must be 1 after bootstrap grant"
+        );
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.initializedSlot())),
+            1,
+            "initialized slot must be set after bootstrap closes"
+        );
     }
 
     /// @notice Verifies TokenCreated fires before any state-change events from initCalls
@@ -437,14 +451,14 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         address token = _createDefault(caller, salt, _b20Params(), new bytes[](0));
 
         // Paired slot assertion: the bootstrap window's gate is the
-        // `initialized` byte in the packed slot. Confirming it's set
-        // proves the factory's privileged path is closed at the storage
-        // level (the surface-level role revert below is the consequence).
-        assertTrue(
-            MockB20Storage.initializedFromPacked(
-                uint256(vm.load(token, MockB20Storage.adminCountAndInitializedSlot()))
-            ),
-            "initialized bit must be set after createToken returns"
+        // `initialized` slot (dedicated, at the end of the layout).
+        // Confirming it's set proves the factory's privileged path is
+        // closed at the storage level (the surface-level role revert
+        // below is the consequence).
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.initializedSlot())),
+            1,
+            "initialized slot must be set after createToken returns"
         );
 
         // Pranking the factory address into a direct mint should now revert with the standard
@@ -475,9 +489,16 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         // Paired slot assertion: packed adminCount lane is 0 (no
         // bootstrap grant happened) but the initialized bit is still
         // set (the factory closed the bootstrap window after returning).
-        uint256 packed = uint256(vm.load(token, MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 0, "adminCount must be 0 on zero-admin path");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized must still be set on zero-admin path");
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.adminCountSlot())),
+            0,
+            "adminCount must be 0 on zero-admin path"
+        );
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.initializedSlot())),
+            1,
+            "initialized must still be set on zero-admin path"
+        );
     }
 
     /// @notice Verifies stablecoin createToken executes with admin == address(0)
@@ -495,9 +516,16 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         // The stablecoin still got its variant data: currency is set.
         assertEq(IB20Stablecoin(token).currency(), "USD", "stablecoin currency must still be set");
 
-        uint256 packed = uint256(vm.load(token, MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 0, "adminCount must be 0 on zero-admin path");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized must still be set on zero-admin path");
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.adminCountSlot())),
+            0,
+            "adminCount must be 0 on zero-admin path"
+        );
+        assertEq(
+            uint256(vm.load(token, MockB20Storage.initializedSlot())),
+            1,
+            "initialized must still be set on zero-admin path"
+        );
         assertEq(
             vm.load(token, MockB20StablecoinStorage.currencySlot()),
             _expectedStringFieldSlot("USD"),

--- a/test/unit/storage/B20FullLayout.t.sol
+++ b/test/unit/storage/B20FullLayout.t.sol
@@ -43,12 +43,13 @@ contract B20FullLayoutTest is B20Test {
     ///         - 5: allowances (alice -> bob)
     ///         - 6: roles (DEFAULT_ADMIN_ROLE for admin, MINT_ROLE for minter, BURN_ROLE for burner)
     ///         - 7: roleAdmins (MINT_ROLE re-parented to PAUSE_ROLE)
-    ///         - 8: packed adminCount + initialized
+    ///         - 8: adminCount (own slot)
     ///         - 9: transferPolicyIds (all 3 lanes)
     ///         - 10: mintPolicyIds (receiver lane)
     ///         - 11: pausedVectors (TRANSFER + MINT bits)
     ///         - 12: supplyCap
     ///         - 13: nonces (advanced via permit)
+    ///         - 14: initialized (own slot at end of layout)
     function test_b20Layout_success_populatedSnapshotMatchesAllSlots() public {
         // ---------- Populate ----------
         _populate();
@@ -114,12 +115,11 @@ contract B20FullLayoutTest is B20Test {
             "slot 7: roleAdmins[MINT_ROLE] re-parented to PAUSE_ROLE"
         );
 
-        // ---------- Packed adminCount + initialized (slot 8) ----------
-        // adminCount = 1 (only `admin` holds DEFAULT_ADMIN_ROLE),
-        // initialized = true (bootstrap closed).
-        uint256 packedAdmin = uint256(vm.load(tokenAddr, MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packedAdmin)), 1, "slot 8 lane: adminCount");
-        assertTrue(MockB20Storage.initializedFromPacked(packedAdmin), "slot 8 lane: initialized");
+        // ---------- adminCount (slot 8) ----------
+        // adminCount = 1 (only `admin` holds DEFAULT_ADMIN_ROLE). Lives
+        // alone in its own slot now that `initialized` was moved to the
+        // end of the layout.
+        assertEq(uint256(vm.load(tokenAddr, MockB20Storage.adminCountSlot())), 1, "slot 8: adminCount");
 
         // ---------- Policy lanes (slots 9..10) ----------
         // All three transfer-side lanes set to ALWAYS_BLOCK_ID; mint-side
@@ -166,6 +166,14 @@ contract B20FullLayoutTest is B20Test {
         // surface and the slot match.
         assertEq(
             uint256(vm.load(tokenAddr, MockB20Storage.nonceSlot(alice))), token.nonces(alice), "slot 13: nonces[alice]"
+        );
+
+        // ---------- initialized (slot 14) ----------
+        // Pinned at the end of the layout in its own slot. The factory
+        // flips this to true at the end of createToken; any non-zero
+        // word means the bootstrap window is closed.
+        assertEq(
+            uint256(vm.load(tokenAddr, MockB20Storage.initializedSlot())), 1, "slot 14: initialized must be true"
         );
     }
 

--- a/test/unit/storage/MockB20SlotHelpers.t.sol
+++ b/test/unit/storage/MockB20SlotHelpers.t.sol
@@ -12,7 +12,9 @@ import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPo
 ///         packed-slot codec helpers. Each test sets a known value via
 ///         the IB20 surface, reads the helper-computed slot via
 ///         `vm.load`, and asserts the slot reflects the same value the
-///         surface returns.
+///         surface returns. Both single-field slots (`adminCount`,
+///         `initialized`) and packed-lane slots (`transferPolicyIds`,
+///         `mintPolicyIds`) get coverage here.
 ///
 /// @dev These tests are the canonical reference for what slot each
 ///      logical field lives at and how packed slots are decoded. The
@@ -238,23 +240,40 @@ contract MockB20SlotHelpersTest is B20Test {
         assertEq(MockB20Storage.mintReceiverPolicyId(MockB20Storage.packMintPolicyIds(receiverId)), receiverId);
     }
 
-    /// @notice Verifies the packed adminCount+initialized slot decodes
-    ///         correctly after factory bootstrap.
-    /// @dev Factory bootstrap grants DEFAULT_ADMIN_ROLE (→ adminCount = 1)
-    ///      and flips `initialized` to true. The packed slot must decode
-    ///      to (1, true).
-    function test_adminCountAndInitializedSlot_success_decodesAfterBootstrap() public view {
-        uint256 packed = uint256(vm.load(address(token), MockB20Storage.adminCountAndInitializedSlot()));
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), 1, "adminCount must be 1 after bootstrap");
-        assertTrue(MockB20Storage.initializedFromPacked(packed), "initialized must be true after bootstrap");
+    /// @notice Verifies `adminCountSlot()` locates the slot factory
+    ///         bootstrap and `_grantRole(DEFAULT_ADMIN_ROLE, ...)` write to.
+    /// @dev Factory bootstrap grants DEFAULT_ADMIN_ROLE to `admin`, so
+    ///      the slot must read exactly `1` after setup. `adminCount`
+    ///      lives alone in its own slot (no packing with `initialized`
+    ///      anymore), so the raw slot value IS the count.
+    function test_adminCountSlot_success_decodesAfterBootstrap() public view {
+        assertEq(
+            uint256(vm.load(address(token), MockB20Storage.adminCountSlot())),
+            1,
+            "adminCount slot must read 1 after bootstrap"
+        );
     }
 
-    /// @notice Verifies `packAdminCountAndInitialized` is the inverse of the decoders.
-    /// @dev Round-trip: pack, then unpack, expect the inputs back.
-    function test_packAdminCountAndInitialized_success_roundtrips(uint248 count, bool init) public pure {
-        uint256 packed = MockB20Storage.packAdminCountAndInitialized(count, init);
-        assertEq(uint256(MockB20Storage.adminCountFromPacked(packed)), uint256(count), "count round-trip");
-        assertEq(MockB20Storage.initializedFromPacked(packed), init, "init round-trip");
+    /// @notice Verifies `initializedSlot()` locates the slot the factory
+    ///         flips at the end of createToken to close the bootstrap window.
+    /// @dev `initialized` lives alone in its own slot at the end of the
+    ///      layout, so the raw word IS the flag's value (1 = true, 0 = false).
+    function test_initializedSlot_success_decodesAfterBootstrap() public view {
+        assertEq(
+            uint256(vm.load(address(token), MockB20Storage.initializedSlot())),
+            1,
+            "initialized slot must read 1 after bootstrap (window closed)"
+        );
+    }
+
+    /// @notice Verifies `adminCountSlot()` and `initializedSlot()` are disjoint.
+    /// @dev Regression: under the old packed layout these aliased to slot 8;
+    ///      after the move they must land at distinct absolute slots.
+    function test_adminCountSlot_success_disjointFromInitializedSlot() public pure {
+        assertTrue(
+            MockB20Storage.adminCountSlot() != MockB20Storage.initializedSlot(),
+            "adminCount and initialized must live in disjoint slots"
+        );
     }
 
     /// @notice Verifies `nameSlot()` returns a slot whose value encodes


### PR DESCRIPTION
## Why

The EVM mock uses `initialized` as a storage flag to demarcate the
factory bootstrap window. The Rust precompile impl distinguishes
that phase via a different mechanism and doesn't need a storage slot
for the flag at all. Pinning `initialized` at the END of the layout
(in its own slot) lets the Rust side omit it without disturbing the
offset of any other field.

## What

**Layout change:**

| Slot | Before | After |
|---|---|---|
| 8 | `uint248 adminCount` + `bool initialized` (packed) | `uint256 adminCount` (own slot) |
| 9-13 | transferPolicyIds, mintPolicyIds, pausedVectors, supplyCap, nonces | unchanged |
| **14** | — | **`bool initialized` (own slot)** |

- `adminCount` widens from `uint248` → `uint256` (the only reason for `uint248` was packing with the bool).
- Drops the packing codecs (`adminCountFromPacked`, `initializedFromPacked`, `packAdminCountAndInitialized`), the `INITIALIZED_BYTE_OFFSET` constant, and the factory's now-unused `_writePackedBool` helper.
- Replaces `adminCountAndInitializedSlot()` with `adminCountSlot()` + `initializedSlot()`.
- Factory's close-bootstrap step is now a plain `_writeUint(token, initializedSlot(), 1)`.
- Updates `script/mutate.py` to match the new factory call (the prior mutation source string was already stale — it referenced `_writeBool` rather than the actual `_writePackedBool`).

## Verification

- `forge build`: clean (pre-existing warnings only)
- `forge test`: 432 passed, 0 failed
- New regression test asserts `adminCountSlot()` and `initializedSlot()` are disjoint.