### PR TITLE
Simplify dead-fall-through to DEFAULT_ADMIN_ROLE in MockB20

### DIFF
--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -62,6 +62,17 @@ contract MockB20 is IB20 {
 
     /// @notice Default top-level admin role. Equal to `bytes32(0)` per
     ///         the OZ AccessControl convention.
+    ///
+    ///         The `bytes32(0)` identity is load-bearing: because the
+    ///         constant equals the EVM storage zero-default, any role
+    ///         whose admin has never been set via `setRoleAdmin` falls
+    ///         through to DEFAULT_ADMIN_ROLE on a raw read of
+    ///         `roleAdmins[role]` with no fall-through code required.
+    ///         `getRoleAdmin`, `setRoleAdmin`, and `_requireRoleAdmin`
+    ///         all rely on this and do not branch on `role ==
+    ///         DEFAULT_ADMIN_ROLE`. The Rust precompile impl reproduces
+    ///         the same identity so its own raw read returns the same
+    ///         bytes32 for an unconfigured role.
     bytes32 public constant DEFAULT_ADMIN_ROLE = B20Constants.DEFAULT_ADMIN_ROLE;
 
     /// @notice Role identifiers. Values delegate to `B20Constants` so the
@@ -249,9 +260,12 @@ contract MockB20 is IB20 {
     }
 
     function getRoleAdmin(bytes32 role) external view returns (bytes32) {
-        bytes32 adminRole = MockB20Storage.layout().roleAdmins[role];
-        // Default admin if not explicitly overridden via setRoleAdmin.
-        return adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE ? DEFAULT_ADMIN_ROLE : adminRole;
+        // Raw read. An unconfigured admin reads as `bytes32(0)`, which
+        // IS `DEFAULT_ADMIN_ROLE`, so the OZ "unset roles default to
+        // DEFAULT_ADMIN_ROLE" semantics fall out for free — no
+        // fall-through ternary required. See the DEFAULT_ADMIN_ROLE
+        // constant's natspec for why this identity is load-bearing.
+        return MockB20Storage.layout().roleAdmins[role];
     }
 
     function grantRole(bytes32 role, address account) external onlyRoleAdmin(role) {
@@ -290,11 +304,12 @@ contract MockB20 is IB20 {
     }
 
     function setRoleAdmin(bytes32 role, bytes32 newAdminRole) external onlyRoleAdmin(role) {
+        // Raw read for the event payload. An unconfigured admin reads
+        // as `bytes32(0)` which IS `DEFAULT_ADMIN_ROLE`, so the
+        // `RoleAdminChanged.previousAdminRole` field carries the
+        // correct identifier with no fall-through code. See the
+        // DEFAULT_ADMIN_ROLE constant's natspec.
         bytes32 previousAdminRole = MockB20Storage.layout().roleAdmins[role];
-        // Default admin if not explicitly set; expose it in the event.
-        if (previousAdminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) {
-            previousAdminRole = DEFAULT_ADMIN_ROLE;
-        }
         MockB20Storage.layout().roleAdmins[role] = newAdminRole;
         emit RoleAdminChanged(role, previousAdminRole, newAdminRole);
     }
@@ -526,12 +541,16 @@ contract MockB20 is IB20 {
     /// @dev Body for the `onlyRoleAdmin` modifier (the privileged bypass
     ///      lives in the modifier, not here, so this helper is reusable
     ///      from any context that has already cleared the bypass).
-    ///      Resolves the admin-of-`role` per `getRoleAdmin` semantics:
-    ///      an unset entry collapses to `DEFAULT_ADMIN_ROLE` unless `role`
-    ///      itself is `DEFAULT_ADMIN_ROLE`.
+    ///      Resolves the admin-of-`role` per `getRoleAdmin` semantics
+    ///      via a raw storage read: an unset entry reads as
+    ///      `bytes32(0)`, which IS `DEFAULT_ADMIN_ROLE`, so unconfigured
+    ///      roles correctly require the default admin to authorize
+    ///      without any fall-through code. The revert payload's
+    ///      `adminRole` field carries the same identifier — for
+    ///      unconfigured roles it's `bytes32(0) == DEFAULT_ADMIN_ROLE`,
+    ///      which is the role the caller actually needs to hold.
     function _requireRoleAdmin(bytes32 role) internal view {
         bytes32 adminRole = MockB20Storage.layout().roleAdmins[role];
-        if (adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE) adminRole = DEFAULT_ADMIN_ROLE;
         if (!hasRole(adminRole, msg.sender)) revert AccessControlUnauthorizedAccount(msg.sender, adminRole);
     }
 

--- a/test/unit/B20/roles/setRoleAdmin.t.sol
+++ b/test/unit/B20/roles/setRoleAdmin.t.sol
@@ -40,14 +40,13 @@ contract B20SetRoleAdminTest is B20Test {
 
     /// @notice Verifies setRoleAdmin emits RoleAdminChanged(role, previousAdminRole, newAdminRole)
     /// @dev Event integrity; canonical RoleAdminChanged emission test.
-    ///      For an unconfigured non-default role, previousAdminRole is the implied
-    ///      DEFAULT_ADMIN_ROLE; for DEFAULT_ADMIN_ROLE itself, previous is bytes32(0).
+    ///      Every role on a fresh token is unconfigured, so the previous
+    ///      admin reads as the storage zero-default `bytes32(0)`, which
+    ///      IS `DEFAULT_ADMIN_ROLE`. The same value covers both the
+    ///      DEFAULT_ADMIN_ROLE-itself case and every other role.
     function test_setRoleAdmin_success_emitsRoleAdminChanged(bytes32 role, bytes32 newAdminRole) public {
-        bytes32 previousAdminRole =
-            role == B20Constants.DEFAULT_ADMIN_ROLE ? bytes32(0) : B20Constants.DEFAULT_ADMIN_ROLE;
-
         vm.expectEmit(true, false, false, true, address(token));
-        emit IB20.RoleAdminChanged(role, previousAdminRole, newAdminRole);
+        emit IB20.RoleAdminChanged(role, bytes32(0), newAdminRole);
         vm.prank(admin);
         token.setRoleAdmin(role, newAdminRole);
     }


### PR DESCRIPTION
## Why

Three sites in `MockB20.sol` carry a ternary of the form

```solidity
return adminRole == bytes32(0) && role != DEFAULT_ADMIN_ROLE
    ? DEFAULT_ADMIN_ROLE : adminRole;
```

intended to fall through to the default admin for unconfigured roles. The ternary is a **tautology**: `DEFAULT_ADMIN_ROLE` is defined as `bytes32(0)`, which is also the EVM storage zero-default. The case table:

| `adminRole` | `role` | Branch taken | Returned value |
|---|---|---|---|
| `bytes32(0)` | `DEFAULT_ADMIN_ROLE` | `adminRole` | `bytes32(0)` |
| `bytes32(0)` | other | `DEFAULT_ADMIN_ROLE` | `bytes32(0)` |
| non-zero | `DEFAULT_ADMIN_ROLE` | `adminRole` | non-zero |
| non-zero | other | `adminRole` | non-zero |

Both branches produce the same bytes32 in every row. The `role != DEFAULT_ADMIN_ROLE` guard implies a special case that doesn't exist — DEFAULT_ADMIN_ROLE being its own admin falls out of the same `bytes32(0)` identity for free.

This matches [OZ AccessControl's pattern](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/AccessControl.sol#L104-L106), which just does `return _roles[role].adminRole;` with no fall-through code.

## What

- **`getRoleAdmin`** — ternary → raw read.
- **`setRoleAdmin`** — drop dead branch; previous-admin event field is the raw read.
- **`_requireRoleAdmin`** — drop dead branch; revert payload's `adminRole` field is the raw read (still the correct identifier since `bytes32(0) == DEFAULT_ADMIN_ROLE`).
- **`DEFAULT_ADMIN_ROLE` constant natspec** — document the load-bearing identity so future readers find the rationale next to the constant rather than fragmented across three call sites.
- **`setRoleAdmin.t.sol`** — the event emission test carried the same dead ternary to compute the expected `previousAdminRole`; collapse it too.

## Verification

- `forge build`: clean
- `forge test`: 440 passed, 0 failed
- Behaviorally identical — `bytes32(0) == DEFAULT_ADMIN_ROLE` makes every dropped branch a no-op.