### PR TITLE
chore: rename factory interface and types to IB20Factory, fix P0 review comments

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -3,22 +3,22 @@ pragma solidity >=0.8.20 <0.9.0;
 
 import {IActivationRegistry} from "./interfaces/IActivationRegistry.sol";
 import {IPolicyRegistry} from "./interfaces/IPolicyRegistry.sol";
-import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
+import {IB20Factory} from "./interfaces/IB20Factory.sol";
 
 /// @title Standard Precompiles Library for Base
 /// @notice Address constants for Base's singleton precompiles, paired
 ///         with interface-typed handles so callers can interact with
-///         them directly (e.g. `StdPrecompiles.TOKEN_FACTORY.createToken(...)`).
+///         them directly (e.g. `StdPrecompiles.B20_FACTORY.createB20(...)`).
 library StdPrecompiles {
     /// @dev The `0xB20F` prefix mirrors the `0xB2` B-20 token prefix while staying
     ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
-    ///      so `isB20(TOKEN_FACTORY_ADDRESS)` returns false unambiguously. The
+    ///      so `isB20(B20_FACTORY_ADDRESS)` returns false unambiguously. The
     ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
-    address internal constant TOKEN_FACTORY_ADDRESS = 0xb20F00000000000000000000000000000000000f;
+    address internal constant B20_FACTORY_ADDRESS = 0xb20F00000000000000000000000000000000000f;
     address internal constant POLICY_REGISTRY_ADDRESS = 0xb030000000000000000000000000000000000000;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x84530000000000000000000000000000000000ff;
 
-    ITokenFactory internal constant TOKEN_FACTORY = ITokenFactory(TOKEN_FACTORY_ADDRESS);
+    IB20Factory internal constant B20_FACTORY = IB20Factory(B20_FACTORY_ADDRESS);
     IPolicyRegistry internal constant POLICY_REGISTRY = IPolicyRegistry(POLICY_REGISTRY_ADDRESS);
     IActivationRegistry internal constant ACTIVATION_REGISTRY = IActivationRegistry(ACTIVATION_REGISTRY_ADDRESS);
 }

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -182,7 +182,7 @@ interface IB20Factory {
 
     /// @notice The leading `version` byte in `params` does not match
     ///         any known encoding for the requested variant.
-    error UnsupportedVersion(uint8 version);
+    error UnsupportedVersion(uint8 version, B20Variant variant);
 
     /// @notice A required string argument was the empty string (e.g.
     ///         security `isin`). The stablecoin `currency` field is
@@ -219,10 +219,10 @@ interface IB20Factory {
     ///         context during the same transaction — NOT as a field on
     ///         this event. Role state is always observable via the
     ///         `RoleGranted` / `RoleRevoked` event stream from the token;
-    ///         `TokenCreated` is the token-identity signal only. The
+    ///         `B20Created` is the token-identity signal only. The
     ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
     ///         skips the grant and emits no `RoleGranted` at bootstrap.
-    event TokenCreated(address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals);
+    event B20Created(address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals);
 
     /*//////////////////////////////////////////////////////////////
                                  CREATE
@@ -254,7 +254,7 @@ interface IB20Factory {
     ///         contract URI, etc. Any init-call revert reverts the
     ///         entire creation.
     ///
-    ///         Emits `TokenCreated` once the token's identity is sealed
+    ///         Emits `B20Created` once the token's identity is sealed
     ///         and before any `initCalls` are dispatched, so init-call
     ///         effects appear strictly after the creation event in the
     ///         log order.

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20 <0.9.0;
 
-/// @title ITokenFactory
+/// @title IB20Factory
 /// @notice Singleton factory precompile for creating B-20 tokens of any
 ///         variant. A single entry point `createToken` dispatches on a
-///         `TokenVariant` discriminator; per-variant creation arguments
+///         `B20Variant` discriminator; per-variant creation arguments
 ///         are ABI-encoded into `params` and prefixed with a `version`
 ///         byte so the encoding can evolve without breaking the factory's
 ///         immutable surface. Creation is permissionless; the caller picks
@@ -19,7 +19,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         **Token address schema (20 bytes).**
 ///         - `[0:10]`  — `bytes10(0xB200000000000000000000)` shared
 ///                       prefix identifying a factory-created B-20.
-///         - `[10]`    — `bytes1(variant)` (matches `TokenVariant`).
+///         - `[10]`    — `bytes1(variant)` (matches `B20Variant`).
 ///         - `[11:20]` — `bytes9(keccak256(abi.encode(msg.sender, salt)))`.
 ///
 ///         **Variant evolution.** Adding new required fields to an
@@ -59,7 +59,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         checks (e.g. stablecoins must specify a non-empty `currency`)
 ///         are applied at the end of the variant decode, after the
 ///         common version check, so each variant owns its own invariants.
-interface ITokenFactory {
+interface IB20Factory {
     /*//////////////////////////////////////////////////////////////
                                   TYPES
     //////////////////////////////////////////////////////////////*/
@@ -70,7 +70,7 @@ interface ITokenFactory {
     ///         factory-created B-20 in the first place is answered by
     ///         `isB20` (a prefix check on bytes `[0:10]`); the variant
     ///         byte itself does not need an "absent" sentinel.
-    enum TokenVariant {
+    enum B20Variant {
         DEFAULT,
         STABLECOIN,
         SECURITY
@@ -174,7 +174,7 @@ interface ITokenFactory {
     ///         Caller must use a different salt.
     error TokenAlreadyExists(address token);
 
-    /// @notice `variant` is not a recognized `TokenVariant`. Reached
+    /// @notice `variant` is not a recognized `B20Variant`. Reached
     ///         only when the factory is invoked with a raw variant byte
     ///         outside the enum range (typed `createToken` callers are
     ///         rejected by ABI decoding before this check fires).
@@ -222,7 +222,7 @@ interface ITokenFactory {
     ///         `TokenCreated` is the token-identity signal only. The
     ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
     ///         skips the grant and emits no `RoleGranted` at bootstrap.
-    event TokenCreated(address indexed token, TokenVariant indexed variant, string name, string symbol, uint8 decimals);
+    event TokenCreated(address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals);
 
     /*//////////////////////////////////////////////////////////////
                                  CREATE
@@ -269,7 +269,7 @@ interface ITokenFactory {
     ///                   token-side authorization checks are bypassed
     ///                   for this window only.
     /// @return token     The address of the newly created token.
-    function createToken(TokenVariant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
+    function createB20(B20Variant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
         external
         returns (address token);
 
@@ -282,7 +282,7 @@ interface ITokenFactory {
     ///         depends only on these inputs; the remaining `params`
     ///         fields (including decimals, which are fixed by variant)
     ///         do not affect the address.
-    function getTokenAddress(TokenVariant variant, address sender, bytes32 salt) external view returns (address);
+    function getB20Address(B20Variant variant, address sender, bytes32 salt) external view returns (address);
 
     /// @notice Whether `token` was created by this factory. Recovered
     ///         from the address prefix (bytes `[0:10]`); no storage read.

--- a/test/lib/B20FactoryTest.sol
+++ b/test/lib/B20FactoryTest.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.20;
 
 import {BaseTest} from "test/lib/BaseTest.sol";
 
-import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
 
-/// @notice Base test contract for `ITokenFactory` unit tests, and the
+/// @notice Base test contract for `IB20Factory` unit tests, and the
 ///         parent for token-test bases (`B20Test`, `B20StablecoinTest`)
 ///         which need factory create helpers in setUp.
 ///
@@ -14,16 +14,16 @@ import {StdPrecompiles} from "src/StdPrecompiles.sol";
 /// `BaseTest`; adds the factory handle and the per-variant param
 /// builder / create wrapper helpers used by both factory tests and
 /// token tests.
-contract TokenFactoryTest is BaseTest {
+contract B20FactoryTest is BaseTest {
     // -- Precompile handle --
-    ITokenFactory internal factory = StdPrecompiles.TOKEN_FACTORY;
+    IB20Factory internal factory = StdPrecompiles.B20_FACTORY;
 
     // ============================================================
     //                  SECURITY-VARIANT FIXTURES
     // ============================================================
     // Shared across every test that constructs `B20SecurityCreateParams`
     // (the factory-side `createToken` tests and the variant-side
-    // `B20Security/*` tests). Lives on `TokenFactoryTest` because it's
+    // `B20Security/*` tests). Lives on `B20FactoryTest` because it's
     // the deepest common base of both. Production code (the factory
     // mock and the Rust precompile) hardcodes the `"ISIN"` key the
     // same way; that's intentional and not test-fixture data.
@@ -50,13 +50,13 @@ contract TokenFactoryTest is BaseTest {
     function _b20Params(string memory name_, string memory symbol_, address initialAdmin_)
         internal
         pure
-        returns (ITokenFactory.B20CreateParams memory)
+        returns (IB20Factory.B20CreateParams memory)
     {
-        return ITokenFactory.B20CreateParams({version: 1, name: name_, symbol: symbol_, initialAdmin: initialAdmin_});
+        return IB20Factory.B20CreateParams({version: 1, name: name_, symbol: symbol_, initialAdmin: initialAdmin_});
     }
 
     /// @notice Build a default `B20CreateParams` (`Test`/`TST`, admin).
-    function _b20Params() internal view returns (ITokenFactory.B20CreateParams memory) {
+    function _b20Params() internal view returns (IB20Factory.B20CreateParams memory) {
         return _b20Params("Test", "TST", admin);
     }
 
@@ -66,14 +66,14 @@ contract TokenFactoryTest is BaseTest {
         string memory symbol_,
         address initialAdmin_,
         string memory currency_
-    ) internal pure returns (ITokenFactory.B20StablecoinCreateParams memory) {
-        return ITokenFactory.B20StablecoinCreateParams({
+    ) internal pure returns (IB20Factory.B20StablecoinCreateParams memory) {
+        return IB20Factory.B20StablecoinCreateParams({
             version: 1, name: name_, symbol: symbol_, initialAdmin: initialAdmin_, currency: currency_
         });
     }
 
     /// @notice Build a default `B20StablecoinCreateParams` (`USD Test`/`USDT`, admin, `USD`).
-    function _stablecoinParams() internal view returns (ITokenFactory.B20StablecoinCreateParams memory) {
+    function _stablecoinParams() internal view returns (IB20Factory.B20StablecoinCreateParams memory) {
         return _stablecoinParams("USD Test", "USDT", admin, "USD");
     }
 
@@ -84,8 +84,8 @@ contract TokenFactoryTest is BaseTest {
         address initialAdmin_,
         string memory isin_,
         uint256 minimumRedeemable_
-    ) internal pure returns (ITokenFactory.B20SecurityCreateParams memory) {
-        return ITokenFactory.B20SecurityCreateParams({
+    ) internal pure returns (IB20Factory.B20SecurityCreateParams memory) {
+        return IB20Factory.B20SecurityCreateParams({
             version: 1,
             name: name_,
             symbol: symbol_,
@@ -96,7 +96,7 @@ contract TokenFactoryTest is BaseTest {
     }
 
     /// @notice Build a default `B20SecurityCreateParams` (`Security Test`/`SEC`, admin, `DEFAULT_ISIN`).
-    function _securityParams() internal view returns (ITokenFactory.B20SecurityCreateParams memory) {
+    function _securityParams() internal view returns (IB20Factory.B20SecurityCreateParams memory) {
         return _securityParams("Security Test", "SEC", admin, DEFAULT_ISIN, 0);
     }
 
@@ -106,11 +106,11 @@ contract TokenFactoryTest is BaseTest {
     function _createDefault(
         address caller,
         bytes32 salt,
-        ITokenFactory.B20CreateParams memory params,
+        IB20Factory.B20CreateParams memory params,
         bytes[] memory initCalls
     ) internal returns (address token) {
         vm.prank(caller);
-        return factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(params), initCalls);
+        return factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(params), initCalls);
     }
 
     /// @notice Create a default-variant token with defaults (alice creator, fresh salt, empty init calls).
@@ -122,11 +122,11 @@ contract TokenFactoryTest is BaseTest {
     function _createStablecoin(
         address caller,
         bytes32 salt,
-        ITokenFactory.B20StablecoinCreateParams memory params,
+        IB20Factory.B20StablecoinCreateParams memory params,
         bytes[] memory initCalls
     ) internal returns (address token) {
         vm.prank(caller);
-        return factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(params), initCalls);
+        return factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(params), initCalls);
     }
 
     /// @notice Create a stablecoin-variant token with defaults.
@@ -138,11 +138,11 @@ contract TokenFactoryTest is BaseTest {
     function _createSecurity(
         address caller,
         bytes32 salt,
-        ITokenFactory.B20SecurityCreateParams memory params,
+        IB20Factory.B20SecurityCreateParams memory params,
         bytes[] memory initCalls
     ) internal returns (address token) {
         vm.prank(caller);
-        return factory.createToken(ITokenFactory.TokenVariant.SECURITY, salt, abi.encode(params), initCalls);
+        return factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(params), initCalls);
     }
 
     /// @notice Create a security-variant token with defaults.

--- a/test/lib/B20SecurityTest.sol
+++ b/test/lib/B20SecurityTest.sol
@@ -29,7 +29,7 @@ contract B20SecurityTest is B20Test {
     //              SECURITY-VARIANT IDENTIFIER FIXTURES
     // ============================================================
     // Test-only identifier-type keys (`CUSIP`, `FIGI`). The canonical
-    // `ISIN` key lives on `TokenFactoryTest` as `IDENTIFIER_ISIN`
+    // `ISIN` key lives on `B20FactoryTest` as `IDENTIFIER_ISIN`
     // because the factory writes it during bootstrap too; CUSIP and
     // FIGI are post-creation additions exercised only by the variant
     // tests, so they belong on this base.

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 import {IB20} from "src/interfaces/IB20.sol";
@@ -10,7 +10,7 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 
 /// @notice Base test contract for `IB20` unit tests.
 ///
-/// Extends `TokenFactoryTest` because an IB20 token cannot exist
+/// Extends `B20FactoryTest` because an IB20 token cannot exist
 /// without the factory: `setUp` calls `super.setUp()` to etch every
 /// precompile mock (via `BaseTest`) and pick up the factory create
 /// helpers, then deploys a default-variant token here so the token's
@@ -22,7 +22,7 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 /// token-specific role-holders (`minter`, `burner`, `pauser`,
 /// `unpauser`, `burnBlocker`) so role-gated tests have explicit named
 /// accounts to grant roles to in setUp's initCalls.
-contract B20Test is TokenFactoryTest {
+contract B20Test is B20FactoryTest {
     // Role identifiers (DEFAULT_ADMIN_ROLE, MINT_ROLE, BURN_ROLE,
     // BURN_BLOCKED_ROLE, PAUSE_ROLE, UNPAUSE_ROLE, METADATA_ROLE) and
     // policy-type identifiers (TRANSFER_SENDER_POLICY, TRANSFER_RECEIVER_POLICY,
@@ -62,7 +62,7 @@ contract B20Test is TokenFactoryTest {
     ///         token via the factory mock; variant-specific bases (e.g.
     ///         `B20StablecoinTest`) override to deploy their variant while
     ///         reusing every other piece of `B20Test`.
-    /// @dev    `MockTokenFactory.createToken` etches `MockB20` runtime
+    /// @dev    `MockB20Factory.createToken` etches `MockB20` runtime
     ///         bytecode at the computed address, writes initial state
     ///         directly via vm.store (no init function on the token),
     ///         runs initCalls, then closes the bootstrap window. Calls

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -6,7 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 
 import {MockActivationRegistry} from "test/lib/mocks/MockActivationRegistry.sol";
 import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockTokenFactory} from "test/lib/mocks/MockTokenFactory.sol";
+import {MockB20Factory} from "test/lib/mocks/MockB20Factory.sol";
 
 import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
@@ -15,7 +15,7 @@ import {StdPrecompiles} from "src/StdPrecompiles.sol";
 ///
 /// Owns the actors / labels and the precompile-mock etch wiring that
 /// every concrete base would otherwise re-declare. Concrete bases
-/// (`TokenFactoryTest`, `PolicyRegistryTest`, ...) extend this and
+/// (`B20FactoryTest`, `PolicyRegistryTest`, ...) extend this and
 /// layer on their own helpers and any test-class-specific state.
 ///
 /// **Mock-vs-live.** `setUp` etches each precompile mock at its
@@ -49,7 +49,7 @@ import {StdPrecompiles} from "src/StdPrecompiles.sol";
 /// available, the way the EVM has `SLOAD`.
 ///
 /// **Mock status.**
-///   - `MockTokenFactory` is fully implemented: `createToken` decodes
+///   - `MockB20Factory` is fully implemented: `createToken` decodes
 ///     params, etches the variant-appropriate runtime bytecode at the
 ///     computed B-20 address, writes initial state directly via vm.store
 ///     (no init function on the token), runs initCalls, and closes the
@@ -85,7 +85,7 @@ abstract contract BaseTest is Test {
         vm.label(bob, "bob");
         vm.label(attacker, "attacker");
 
-        vm.label(StdPrecompiles.TOKEN_FACTORY_ADDRESS, "TokenFactory");
+        vm.label(StdPrecompiles.B20_FACTORY_ADDRESS, "B20Factory");
         vm.label(StdPrecompiles.POLICY_REGISTRY_ADDRESS, "PolicyRegistry");
         vm.label(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, "ActivationRegistry");
 
@@ -94,7 +94,7 @@ abstract contract BaseTest is Test {
         // level NatSpec for the rationale on the env var rather than
         // auto-detection.
         if (!vm.envOr("LIVE_PRECOMPILES", false)) {
-            vm.etch(StdPrecompiles.TOKEN_FACTORY_ADDRESS, type(MockTokenFactory).runtimeCode);
+            vm.etch(StdPrecompiles.B20_FACTORY_ADDRESS, type(MockB20Factory).runtimeCode);
             vm.etch(StdPrecompiles.POLICY_REGISTRY_ADDRESS, type(MockPolicyRegistry).runtimeCode);
             vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
         }
@@ -117,7 +117,7 @@ abstract contract BaseTest is Test {
     function _assumeValidCaller(address caller) internal pure {
         vm.assume(caller != address(0));
         vm.assume(caller != address(vm));
-        vm.assume(caller != StdPrecompiles.TOKEN_FACTORY_ADDRESS);
+        vm.assume(caller != StdPrecompiles.B20_FACTORY_ADDRESS);
         vm.assume(caller != StdPrecompiles.POLICY_REGISTRY_ADDRESS);
         vm.assume(caller != StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS);
     }
@@ -170,7 +170,7 @@ abstract contract BaseTest is Test {
     ///         byte-for-byte. This is the storage contract the Rust
     ///         precompile impl must match exactly.
     ///
-    ///         Encoding (mirrors `MockTokenFactory._writeString`):
+    ///         Encoding (mirrors `MockB20Factory._writeString`):
     ///         - Empty string: slot is zero.
     ///         - Length < 32: high portion holds the bytes (left-justified
     ///           in the slot); low byte is `length * 2` (low bit clear).

--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -10,7 +10,7 @@ library ActivationRegistryFeatureList {
     bytes32 internal constant B20_TOKEN = 0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752;
 
     /// @dev keccak256("base.token_factory")
-    bytes32 internal constant TOKEN_FACTORY = 0xceff857b4173841a3aef07ca52b183282fe74fe117e8f9dda0dcb3ddafd18a5b;
+    bytes32 internal constant B20_FACTORY = 0xceff857b4173841a3aef07ca52b183282fe74fe117e8f9dda0dcb3ddafd18a5b;
 
     /// @dev keccak256("base.policy_registry")
     bytes32 internal constant POLICY_REGISTRY = 0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f;

--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -9,8 +9,8 @@ library ActivationRegistryFeatureList {
     /// @dev keccak256("base.b20_token")
     bytes32 internal constant B20_TOKEN = 0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752;
 
-    /// @dev keccak256("base.token_factory")
-    bytes32 internal constant B20_FACTORY = 0xceff857b4173841a3aef07ca52b183282fe74fe117e8f9dda0dcb3ddafd18a5b;
+    /// @dev keccak256("base.b20_factory")
+    bytes32 internal constant B20_FACTORY = 0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800;
 
     /// @dev keccak256("base.policy_registry")
     bytes32 internal constant POLICY_REGISTRY = 0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f;

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -11,7 +11,7 @@ import {B20Constants} from "src/lib/B20Constants.sol";
 /// @title MockB20
 /// @notice Reference implementation of the `IB20` default-token surface.
 ///         Etched at every default-variant B-20 token's factory-derived
-///         address via `vm.etch` from `MockTokenFactory.createToken`.
+///         address via `vm.etch` from `MockB20Factory.createToken`.
 ///
 /// @dev    Written as Solidity-as-if-Rust: the goal is unambiguous
 ///         spec-correspondence with the production Rust precompile, not
@@ -53,7 +53,7 @@ contract MockB20 is IB20 {
     ///         during the bootstrap window (before the factory writes
     ///         `initialized = true` via vm.store) bypass all token-side
     ///         authorization gates.
-    address internal constant FACTORY = StdPrecompiles.TOKEN_FACTORY_ADDRESS;
+    address internal constant FACTORY = StdPrecompiles.B20_FACTORY_ADDRESS;
 
     /// @notice The policy registry precompile address. Consulted on
     ///         every transfer, mint, and `burnBlocked` to resolve the

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -41,7 +41,7 @@ import {
 ///            directly** via `vm.store` at the slot offsets declared in
 ///            `MockB20Storage`. The token has NO factory-only
 ///            entrypoints; its surface is exactly `IB20`.
-///         6. Emit `TokenCreated` (now WITHOUT an `admin` field —
+///         6. Emit `B20Created` (now WITHOUT an `admin` field —
 ///            see step 7).
 ///         7. Grant the initial admin role via a single low-level
 ///            `token.grantRole(DEFAULT_ADMIN_ROLE, admin)` call during
@@ -51,7 +51,7 @@ import {
 ///            `grantRole` call, and it emits the standard
 ///            `RoleGranted(DEFAULT_ADMIN_ROLE, admin, factory)` from
 ///            the token's own context. There is no separate "bootstrap
-///            admin write" or "TokenCreated.admin" field; the canonical
+///            admin write" or "B20Created.admin" field; the canonical
 ///            event for role changes is always `RoleGranted` regardless
 ///            of when it fires. Skipped when `admin == address(0)`
 ///            (the "demonstrate no owner" path).
@@ -109,14 +109,14 @@ contract MockB20Factory is IB20Factory {
 
         if (variant == B20Variant.DEFAULT) {
             B20CreateParams memory p = abi.decode(params, (B20CreateParams));
-            if (p.version != 1) revert UnsupportedVersion(p.version);
+            if (p.version != 1) revert UnsupportedVersion(p.version, variant);
             name_ = p.name;
             symbol_ = p.symbol;
             admin = p.initialAdmin;
             decimals = 18;
         } else if (variant == B20Variant.STABLECOIN) {
             B20StablecoinCreateParams memory p = abi.decode(params, (B20StablecoinCreateParams));
-            if (p.version != 1) revert UnsupportedVersion(p.version);
+            if (p.version != 1) revert UnsupportedVersion(p.version, variant);
             // ISO 4217 fiat allowlist; see docs/b20/stablecoin/currency-validation.md.
             if (!ISO4217.isValidFiatCode(p.currency)) revert InvalidCurrency(p.currency);
             name_ = p.name;
@@ -126,7 +126,7 @@ contract MockB20Factory is IB20Factory {
             currency_ = p.currency;
         } else if (variant == B20Variant.SECURITY) {
             B20SecurityCreateParams memory p = abi.decode(params, (B20SecurityCreateParams));
-            if (p.version != 1) revert UnsupportedVersion(p.version);
+            if (p.version != 1) revert UnsupportedVersion(p.version, variant);
             if (bytes(p.isin).length == 0) revert MissingRequiredField();
             name_ = p.name;
             symbol_ = p.symbol;
@@ -163,10 +163,10 @@ contract MockB20Factory is IB20Factory {
             _writeSecurityStorage(token, isin_, minimumRedeemable_);
         }
 
-        // -- 6. Emit TokenCreated. Identity-only signal; admin role
+        // -- 6. Emit B20Created. Identity-only signal; admin role
         //       assignment is announced via the standard RoleGranted
         //       event from step 7.
-        emit TokenCreated(token, variant, name_, symbol_, decimals);
+        emit B20Created(token, variant, name_, symbol_, decimals);
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 
 import {ISO4217} from "test/lib/ISO4217.sol";
 
@@ -17,9 +17,9 @@ import {
     MockB20RedeemStorage
 } from "test/lib/mocks/MockB20Storage.sol";
 
-/// @title MockTokenFactory
-/// @notice Reference implementation of the `ITokenFactory` precompile
-///         surface. Etched at `StdPrecompiles.TOKEN_FACTORY_ADDRESS`
+/// @title MockB20Factory
+/// @notice Reference implementation of the `IB20Factory` precompile
+///         surface. Etched at `StdPrecompiles.B20_FACTORY_ADDRESS`
 ///         in `BaseTest.setUp` so local tests dispatch through this
 ///         mock; fork tests against a chain with the live precompile
 ///         hit the real factory at the same address with no test-code
@@ -60,7 +60,7 @@ import {
 ///            (the factory). During the bootstrap window the token
 ///            bypasses all authorization gates for factory-originated
 ///            calls per the "fully privileged" semantics on
-///            `ITokenFactory`.
+///            `IB20Factory`.
 ///         9. Flip the `initialized` flag (via `vm.store`), closing the
 ///            privileged window. After this point the factory has no
 ///            special access; all subsequent operations on the token
@@ -85,7 +85,7 @@ import {
 ///         impl's behavior matches the *observable result* even though
 ///         the path differs (atomic slot-write + log-push vs. a single
 ///         self-call frame).
-contract MockTokenFactory is ITokenFactory {
+contract MockB20Factory is IB20Factory {
     /// @dev Hardcoded forge-std VM address. The factory uses `vm.etch`
     ///      to plant token bytecode at the deterministic address and
     ///      `vm.store` to write the token's initial state directly.
@@ -93,8 +93,8 @@ contract MockTokenFactory is ITokenFactory {
     ///      reference impls live under `test/` rather than `src/`.
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    /// @inheritdoc ITokenFactory
-    function createToken(TokenVariant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
+    /// @inheritdoc IB20Factory
+    function createB20(B20Variant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
         external
         returns (address token)
     {
@@ -107,14 +107,14 @@ contract MockTokenFactory is ITokenFactory {
         string memory isin_;
         uint256 minimumRedeemable_;
 
-        if (variant == TokenVariant.DEFAULT) {
+        if (variant == B20Variant.DEFAULT) {
             B20CreateParams memory p = abi.decode(params, (B20CreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
             name_ = p.name;
             symbol_ = p.symbol;
             admin = p.initialAdmin;
             decimals = 18;
-        } else if (variant == TokenVariant.STABLECOIN) {
+        } else if (variant == B20Variant.STABLECOIN) {
             B20StablecoinCreateParams memory p = abi.decode(params, (B20StablecoinCreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
             // ISO 4217 fiat allowlist; see docs/b20/stablecoin/currency-validation.md.
@@ -124,7 +124,7 @@ contract MockTokenFactory is ITokenFactory {
             admin = p.initialAdmin;
             decimals = 6;
             currency_ = p.currency;
-        } else if (variant == TokenVariant.SECURITY) {
+        } else if (variant == B20Variant.SECURITY) {
             B20SecurityCreateParams memory p = abi.decode(params, (B20SecurityCreateParams));
             if (p.version != 1) revert UnsupportedVersion(p.version);
             if (bytes(p.isin).length == 0) revert MissingRequiredField();
@@ -143,9 +143,9 @@ contract MockTokenFactory is ITokenFactory {
         if (token.code.length != 0) revert TokenAlreadyExists(token);
 
         // -- 4. Etch the variant-appropriate runtime bytecode --
-        if (variant == TokenVariant.DEFAULT) {
+        if (variant == B20Variant.DEFAULT) {
             vm.etch(token, type(MockB20).runtimeCode);
-        } else if (variant == TokenVariant.STABLECOIN) {
+        } else if (variant == B20Variant.STABLECOIN) {
             vm.etch(token, type(MockB20Stablecoin).runtimeCode);
         } else {
             // SECURITY (NONE / unknown variants already reverted above).
@@ -157,9 +157,9 @@ contract MockTokenFactory is ITokenFactory {
         //       canonical grantRole path in step 7 so RoleGranted fires
         //       from the token.
         _writeBaseStorage(token, name_, symbol_);
-        if (variant == TokenVariant.STABLECOIN) {
+        if (variant == B20Variant.STABLECOIN) {
             _writeStablecoinStorage(token, currency_);
-        } else if (variant == TokenVariant.SECURITY) {
+        } else if (variant == B20Variant.SECURITY) {
             _writeSecurityStorage(token, isin_, minimumRedeemable_);
         }
 
@@ -181,7 +181,7 @@ contract MockTokenFactory is ITokenFactory {
 
         // -- 8. Dispatch initCalls. Same privileged-window bypass as
         //       step 7; init-call reverts roll up to abort the whole
-        //       creation. Per ITokenFactory.InitCallFailed NatSpec, we
+        //       creation. Per IB20Factory.InitCallFailed NatSpec, we
         //       bubble the underlying revert data when present so
         //       developers see the actual cause (e.g. InvalidReceiver,
         //       SupplyCapExceeded) rather than an opaque wrapper. Only
@@ -213,17 +213,17 @@ contract MockTokenFactory is ITokenFactory {
     /// @dev `DEFAULT_ADMIN_ROLE` per OZ AccessControl convention.
     bytes32 internal constant DEFAULT_ADMIN_ROLE = bytes32(0);
 
-    /// @inheritdoc ITokenFactory
-    function getTokenAddress(TokenVariant variant, address sender, bytes32 salt) external pure returns (address) {
+    /// @inheritdoc IB20Factory
+    function getB20Address(B20Variant variant, address sender, bytes32 salt) external pure returns (address) {
         return _computeAddress(variant, sender, salt);
     }
 
-    /// @inheritdoc ITokenFactory
+    /// @inheritdoc IB20Factory
     function isB20(address token) external pure returns (bool) {
         return _isB20Prefix(token);
     }
 
-    /// @inheritdoc ITokenFactory
+    /// @inheritdoc IB20Factory
     function isB20Initialized(address token) external view returns (bool) {
         if (!_isB20Prefix(token)) return false;
         // Same dedicated slot the factory flips at the end of createToken
@@ -242,7 +242,7 @@ contract MockTokenFactory is ITokenFactory {
     ///        bytes [1:10]  = 0x00 (9 zero bytes)
     ///        byte [10]     = variant
     ///        bytes [11:20] = keccak256(sender, salt)[0:9]
-    function _computeAddress(TokenVariant variant, address sender, bytes32 salt) internal pure returns (address) {
+    function _computeAddress(B20Variant variant, address sender, bytes32 salt) internal pure returns (address) {
         bytes9 tail = bytes9(keccak256(abi.encode(sender, salt)));
         uint160 addr = (uint160(0xB2) << 152) | (uint160(uint8(variant)) << 72) | uint160(uint72(tail));
         return address(addr);

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -58,7 +58,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         IB20Factory.B20CreateParams memory p = _b20Params();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion, IB20Factory.B20Variant.DEFAULT));
         factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(p), new bytes[](0));
     }
 
@@ -73,7 +73,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion, IB20Factory.B20Variant.STABLECOIN));
         factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
@@ -103,7 +103,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         IB20Factory.B20SecurityCreateParams memory p = _securityParams();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion, IB20Factory.B20Variant.SECURITY));
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 
@@ -343,31 +343,31 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         }
     }
 
-    /// @notice Verifies createToken emits TokenCreated with the correct identity fields
+    /// @notice Verifies createToken emits B20Created with the correct identity fields
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
     ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that.
-    function test_createB20_success_emitsTokenCreated(address caller, bytes32 salt) public {
+    function test_createB20_success_emitsB20Created(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin);
         address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit IB20Factory.TokenCreated(predicted, IB20Factory.B20Variant.DEFAULT, "MyToken", "MYT", 18);
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.DEFAULT, "MyToken", "MYT", 18);
         _createDefault(caller, salt, p, new bytes[](0));
     }
 
-    /// @notice Verifies createToken emits TokenCreated with decimals=6 for the security variant
+    /// @notice Verifies createToken emits B20Created with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
     ///      way the default emitter test pins decimals=18.
-    function test_createB20_success_emitsTokenCreated_security(address caller, bytes32 salt) public {
+    function test_createB20_success_emitsB20Created_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20SecurityCreateParams memory p =
             _securityParams("Security Test", "SEC", admin, DEFAULT_ISIN, 0);
         address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit IB20Factory.TokenCreated(predicted, IB20Factory.B20Variant.SECURITY, "Security Test", "SEC", 6);
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.SECURITY, "Security Test", "SEC", 6);
         _createSecurity(caller, salt, p, new bytes[](0));
     }
 
@@ -419,11 +419,11 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         );
     }
 
-    /// @notice Verifies TokenCreated fires before any state-change events from initCalls
-    /// @dev Log ordering invariant per IB20Factory natspec: "Emits TokenCreated once the token's identity
+    /// @notice Verifies B20Created fires before any state-change events from initCalls
+    /// @dev Log ordering invariant per IB20Factory natspec: "Emits B20Created once the token's identity
     ///      is sealed and BEFORE any initCalls are dispatched, so init-call effects appear strictly after
     ///      the creation event in the log order." Sanity check using vm.recordLogs.
-    function test_createB20_success_emitsTokenCreatedBeforeInitCallEvents(address caller, bytes32 salt) public {
+    function test_createB20_success_emitsB20CreatedBeforeInitCallEvents(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         // Use an init call that emits a single, distinctive event we can find: grantRole emits RoleGranted.
         bytes[] memory initCalls = new bytes[](1);
@@ -433,14 +433,14 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         _createDefault(caller, salt, _b20Params(), initCalls);
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
-        // Find indices of TokenCreated and RoleGranted. Since the storage-direct-write
+        // Find indices of B20Created and RoleGranted. Since the storage-direct-write
         // factory emits no RoleGranted at bootstrap, the only RoleGranted in the log
         // is the one from the init call.
-        int256 tokenCreatedAt = _firstLogIndex(logs, IB20Factory.TokenCreated.selector);
+        int256 tokenCreatedAt = _firstLogIndex(logs, IB20Factory.B20Created.selector);
         int256 roleGrantedAt = _firstLogIndex(logs, IB20.RoleGranted.selector);
-        assertGt(tokenCreatedAt, -1, "TokenCreated must be present in the log");
+        assertGt(tokenCreatedAt, -1, "B20Created must be present in the log");
         assertGt(roleGrantedAt, -1, "RoleGranted must be present in the log (from initCall)");
-        assertLt(tokenCreatedAt, roleGrantedAt, "TokenCreated must precede initCall-emitted events");
+        assertLt(tokenCreatedAt, roleGrantedAt, "B20Created must precede initCall-emitted events");
     }
 
     /// @notice Verifies the factory has no persistent privilege after createToken returns

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -6,7 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {IB20} from "src/interfaces/IB20.sol";
 import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
 import {IB20Security} from "src/interfaces/IB20Security.sol";
-import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {ISO4217} from "test/lib/ISO4217.sol";
 
 import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
@@ -17,9 +17,9 @@ import {
     MockB20SecurityStorage,
     MockB20RedeemStorage
 } from "test/lib/mocks/MockB20Storage.sol";
-import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
-contract TokenFactoryCreateTokenTest is TokenFactoryTest {
+contract B20FactoryCreateB20Test is B20FactoryTest {
     // Role identifiers are accessed as `MINT_ROLE` etc. — these are
     // compile-time constants on the contract type, so they don't require an
     // instantiated token (relevant during createToken setup where the token
@@ -29,22 +29,22 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
                                 REVERTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Verifies createToken rejects raw variant bytes outside the TokenVariant enum range
-    /// @dev TokenVariant has no "NONE" sentinel; typed callers cannot construct an out-of-range
+    /// @notice Verifies createToken rejects raw variant bytes outside the B20Variant enum range
+    /// @dev B20Variant has no "NONE" sentinel; typed callers cannot construct an out-of-range
     ///      value. The ABI decoder rejects out-of-range enum bytes with a Panic(0x21) before the
     ///      factory body's `else { revert InvalidVariant(); }` branch is ever reached, so the
     ///      observable behavior from a raw-bytes caller is a decode-time panic rather than a
     ///      typed factory revert.
-    function test_createToken_revert_outOfRangeVariant(address caller, bytes32 salt, uint8 badVariant) public {
+    function test_createB20_revert_outOfRangeVariant(address caller, bytes32 salt, uint8 badVariant) public {
         _assumeValidCaller(caller);
-        badVariant = uint8(bound(uint256(badVariant), uint256(type(ITokenFactory.TokenVariant).max) + 1, 255));
+        badVariant = uint8(bound(uint256(badVariant), uint256(type(IB20Factory.B20Variant).max) + 1, 255));
         vm.prank(caller);
         // ABI decoder panic for out-of-range enum value.
         vm.expectRevert();
         (bool ok,) = address(factory)
             .call(
                 abi.encodeWithSelector(
-                    ITokenFactory.createToken.selector, badVariant, salt, abi.encode(_b20Params()), new bytes[](0)
+                    IB20Factory.createB20.selector, badVariant, salt, abi.encode(_b20Params()), new bytes[](0)
                 )
             );
         ok; // silence unused warning; the revert is asserted via vm.expectRevert.
@@ -52,29 +52,29 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
     /// @notice Verifies createToken reverts for any unsupported params version byte (DEFAULT variant)
     /// @dev Fuzz confirms only the known version (1) decodes; checks UnsupportedVersion(version) error
-    function test_createToken_revert_unsupportedVersion(address caller, uint8 badVersion, bytes32 salt) public {
+    function test_createB20_revert_unsupportedVersion(address caller, uint8 badVersion, bytes32 salt) public {
         _assumeValidCaller(caller);
         vm.assume(badVersion != 1);
-        ITokenFactory.B20CreateParams memory p = _b20Params();
+        IB20Factory.B20CreateParams memory p = _b20Params();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), new bytes[](0));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts for any unsupported version byte on the STABLECOIN variant
     /// @dev Each variant arm has its own version check; this exercises the stablecoin arm's check
     ///      (the default-variant arm has a parallel test above).
-    function test_createToken_revert_unsupportedVersion_stablecoin(address caller, uint8 badVersion, bytes32 salt)
+    function test_createB20_revert_unsupportedVersion_stablecoin(address caller, uint8 badVersion, bytes32 salt)
         public
     {
         _assumeValidCaller(caller);
         vm.assume(badVersion != 1);
-        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams();
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
-        factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
     // STABLECOIN currency validation — see docs/b20/stablecoin/currency-validation.md.
@@ -82,65 +82,65 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Any non-allowlist string reverts with `InvalidCurrency(code)`.
     /// @dev Subsumes every point case (empty, wrong length/case, X-prefix, crypto, etc.)
     ///      via `vm.assume(!isValidFiatCode)`.
-    function test_createToken_revert_currency_rejectsNonAllowlist(string memory code, address caller, bytes32 salt)
+    function test_createB20_revert_currency_rejectsNonAllowlist(string memory code, address caller, bytes32 salt)
         public
     {
         _assumeValidCaller(caller);
         vm.assume(!ISO4217.isValidFiatCode(code));
-        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams("Test", "TST", admin, code);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Test", "TST", admin, code);
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InvalidCurrency.selector, code));
-        factory.createToken(ITokenFactory.TokenVariant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.InvalidCurrency.selector, code));
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts for any unsupported version byte on the SECURITY variant
     /// @dev Each variant arm has its own version check; this exercises the security arm's check.
-    function test_createToken_revert_unsupportedVersion_security(address caller, uint8 badVersion, bytes32 salt)
+    function test_createB20_revert_unsupportedVersion_security(address caller, uint8 badVersion, bytes32 salt)
         public
     {
         _assumeValidCaller(caller);
         vm.assume(badVersion != 1);
-        ITokenFactory.B20SecurityCreateParams memory p = _securityParams();
+        IB20Factory.B20SecurityCreateParams memory p = _securityParams();
         p.version = badVersion;
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.UnsupportedVersion.selector, badVersion));
-        factory.createToken(ITokenFactory.TokenVariant.SECURITY, salt, abi.encode(p), new bytes[](0));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion));
+        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies security createToken reverts when isin is the empty string
     /// @dev Per-variant required-field check; checks MissingRequiredField() error
-    function test_createToken_revert_missingIsin(address caller, bytes32 salt) public {
+    function test_createB20_revert_missingIsin(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20SecurityCreateParams memory p = _securityParams("Security Test", "SEC", admin, "", 0);
+        IB20Factory.B20SecurityCreateParams memory p = _securityParams("Security Test", "SEC", admin, "", 0);
         vm.prank(caller);
-        vm.expectRevert(ITokenFactory.MissingRequiredField.selector);
-        factory.createToken(ITokenFactory.TokenVariant.SECURITY, salt, abi.encode(p), new bytes[](0));
+        vm.expectRevert(IB20Factory.MissingRequiredField.selector);
+        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts when (variant, sender, salt) collides
     /// @dev Deterministic-address uniqueness; checks TokenAlreadyExists(token) error
-    function test_createToken_revert_tokenAlreadyExists(address caller, bytes32 salt) public {
+    function test_createB20_revert_tokenAlreadyExists(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         address first = _createDefault(caller, salt, _b20Params(), new bytes[](0));
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.TokenAlreadyExists.selector, first));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), new bytes[](0));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.TokenAlreadyExists.selector, first));
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(_b20Params()), new bytes[](0));
     }
 
     /// @notice Verifies a failing initCall bubbles the underlying revert reason (regression test for L-01)
-    /// @dev ITokenFactory.InitCallFailed NatSpec (L194-197) specifies two-tier error behavior:
+    /// @dev IB20Factory.InitCallFailed NatSpec (L194-197) specifies two-tier error behavior:
     ///      bubble the underlying revert reason when the call returns one; wrap empty reverts
     ///      with InitCallFailed(index). `mint(address(0), 1)` reverts with `InvalidReceiver(0)`
     ///      inside the token, and the factory MUST surface that error verbatim, not swallow
     ///      it into `InitCallFailed(0)`. A buggy impl that discards revert data via `(bool ok,)`
     ///      surfaces the opaque wrapper instead.
-    function test_createToken_revert_initCallFailed_bubblesRevertReason(address caller, bytes32 salt) public {
+    function test_createB20_revert_initCallFailed_bubblesRevertReason(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         bytes[] memory initCalls = new bytes[](1);
         initCalls[0] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
         vm.prank(caller);
         vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
     }
 
     /// @notice Verifies an empty-revert initCall is wrapped as InitCallFailed(index) (L-01 complement)
@@ -149,14 +149,14 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      token; MockB20 has no fallback, so Solidity's dispatcher reverts with empty data.
     ///      Without this carve-out the caller would receive a generic "" revert with no signal
     ///      about which init index failed.
-    function test_createToken_revert_initCallFailed_wrapsEmptyRevert(address caller, bytes32 salt) public {
+    function test_createB20_revert_initCallFailed_wrapsEmptyRevert(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         bytes[] memory initCalls = new bytes[](1);
         // Non-existent selector "0xdeadbeef" -> MockB20 dispatcher rejects with empty data.
         initCalls[0] = abi.encodeWithSelector(bytes4(0xdeadbeef));
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(ITokenFactory.InitCallFailed.selector, uint256(0)));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.InitCallFailed.selector, uint256(0)));
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
     }
 
     /// @notice Verifies bubble + index for the SECOND init call (L-01 index correctness)
@@ -164,7 +164,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      underlying error. A buggy impl that swallows revert data would mask not just
     ///      the error but also the implicit "which index" signal a developer needs to
     ///      debug a multi-call setup.
-    function test_createToken_revert_initCallFailed_bubblesFromLaterIndex(address caller, bytes32 salt) public {
+    function test_createB20_revert_initCallFailed_bubblesFromLaterIndex(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         bytes[] memory initCalls = new bytes[](2);
         // Index 0 is benign — set the supply cap to 100. Index 1 attempts to mint to
@@ -173,7 +173,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         initCalls[1] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
         vm.prank(caller);
         vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(_b20Params()), initCalls);
     }
 
     /// @notice Verifies a failing initCall leaves the deterministic address empty
@@ -182,17 +182,17 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      (variant, sender, salt) succeeds. After L-01 the revert reason is
     ///      bubbled (InvalidReceiver) rather than wrapped (InitCallFailed), but atomicity
     ///      is unchanged.
-    function test_createToken_revert_initCallFailed_revertsWholeCreation(address caller, bytes32 salt) public {
+    function test_createB20_revert_initCallFailed_revertsWholeCreation(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params();
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
+        IB20Factory.B20CreateParams memory p = _b20Params();
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, caller, salt);
 
         bytes[] memory initCalls = new bytes[](1);
         initCalls[0] = abi.encodeWithSelector(IB20.mint.selector, address(0), uint256(1));
 
         vm.prank(caller);
         vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
-        factory.createToken(ITokenFactory.TokenVariant.DEFAULT, salt, abi.encode(p), initCalls);
+        factory.createB20(IB20Factory.B20Variant.DEFAULT, salt, abi.encode(p), initCalls);
 
         // After the failed creation, the predicted address has no code,
         // and a fresh creation with the same args succeeds.
@@ -207,28 +207,28 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
     /// @notice Verifies createToken returns the predicted address for the default variant
     /// @dev Address determinism: returned address must equal getTokenAddress(DEFAULT, sender, salt)
-    function test_createToken_success_defaultMatchesPrediction(address caller, bytes32 salt) public {
+    function test_createB20_success_defaultMatchesPrediction(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("Test", "TST", admin);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
+        IB20Factory.B20CreateParams memory p = _b20Params("Test", "TST", admin);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, caller, salt);
         address actual = _createDefault(caller, salt, p, new bytes[](0));
         assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken returns the predicted address for the stablecoin variant
     /// @dev Address determinism: returned address must equal getTokenAddress(STABLECOIN, sender, salt)
-    function test_createToken_success_stablecoinMatchesPrediction(address caller, bytes32 salt) public {
+    function test_createB20_success_stablecoinMatchesPrediction(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, caller, salt);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, caller, salt);
         address actual = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
         assertEq(actual, predicted, "createToken address must match prediction");
     }
 
     /// @notice Verifies createToken returns the predicted address for the security variant
     /// @dev Address determinism: returned address must equal getTokenAddress(SECURITY, sender, salt)
-    function test_createToken_success_securityMatchesPrediction(address caller, bytes32 salt) public {
+    function test_createB20_success_securityMatchesPrediction(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, caller, salt);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
         address actual = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
         assertEq(actual, predicted, "createToken address must match prediction");
     }
@@ -238,11 +238,11 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      `base.b20.security` namespace and `minimumRedeemable` at the
     ///      `base.b20.redeem` namespace. Paired slot assertions confirm both fields
     ///      land at the expected slots with the correct encodings.
-    function test_createToken_success_securitySeedsInitialState(address caller, bytes32 salt, uint256 minRedeem)
+    function test_createB20_success_securitySeedsInitialState(address caller, bytes32 salt, uint256 minRedeem)
         public
     {
         _assumeValidCaller(caller);
-        ITokenFactory.B20SecurityCreateParams memory p =
+        IB20Factory.B20SecurityCreateParams memory p =
             _securityParams("Security Test", "SEC", admin, APPLE_ISIN, minRedeem);
         address token = _createSecurity(caller, salt, p, new bytes[](0));
 
@@ -264,7 +264,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @dev Creation-time initial state is written directly via vm.store and emits no event,
     ///      paralleling how stablecoin currency is seeded. Post-creation
     ///      `updateSecurityIdentifier` calls DO emit the event; that's covered separately.
-    function test_createToken_success_securitySeededIsinEmitsNoEvent(address caller, bytes32 salt) public {
+    function test_createB20_success_securitySeededIsinEmitsNoEvent(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         vm.recordLogs();
         _createSecurity(caller, salt, _securityParams(), new bytes[](0));
@@ -281,9 +281,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @dev Same zero-admin success behavior on the security variant. Paired slot assertions
     ///      cross-check both the base namespace (adminCount=0, initialized=true) and the variant
     ///      namespace (ISIN identifier present, minimumRedeemable set).
-    function test_createToken_success_zeroAdminGrantsNoRole_security(address caller, bytes32 salt) public {
+    function test_createB20_success_zeroAdminGrantsNoRole_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20SecurityCreateParams memory p =
+        IB20Factory.B20SecurityCreateParams memory p =
             _securityParams("NoOwner Security", "NOSEC", address(0), DEFAULT_ISIN, 0);
         address token = _createSecurity(caller, salt, p, new bytes[](0));
 
@@ -305,7 +305,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
     /// @notice Major reserve currencies (USD, EUR, JPY, GBP, CHF, CNY, CAD, AUD) are accepted.
     /// @dev Round-trip through `currency()` proves the string is stored verbatim.
-    function test_createToken_success_currency_acceptsMajorFiatCodes(address caller) public {
+    function test_createB20_success_currency_acceptsMajorFiatCodes(address caller) public {
         _assumeValidCaller(caller);
         string[8] memory majors = ["USD", "EUR", "JPY", "GBP", "CHF", "CNY", "CAD", "AUD"];
         for (uint256 i = 0; i < majors.length; i++) {
@@ -325,7 +325,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
     /// @notice Multi-country X-prefix fiat (XOF, XAF, XCD, XPF) is accepted.
     /// @dev Pins the deliberate carve-out: X-prefix is not a categorical exclusion.
-    function test_createToken_success_currency_acceptsMultiCountryXPrefix(address caller) public {
+    function test_createB20_success_currency_acceptsMultiCountryXPrefix(address caller) public {
         _assumeValidCaller(caller);
         string[4] memory xFiat = ["XOF", "XAF", "XCD", "XPF"];
         for (uint256 i = 0; i < xFiat.length; i++) {
@@ -346,28 +346,28 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Verifies createToken emits TokenCreated with the correct identity fields
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
-    ///      see test_createToken_success_emitsRoleGrantedForInitialAdmin for that.
-    function test_createToken_success_emitsTokenCreated(address caller, bytes32 salt) public {
+    ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that.
+    function test_createB20_success_emitsTokenCreated(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, caller, salt);
+        IB20Factory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.DEFAULT, "MyToken", "MYT", 18);
+        emit IB20Factory.TokenCreated(predicted, IB20Factory.B20Variant.DEFAULT, "MyToken", "MYT", 18);
         _createDefault(caller, salt, p, new bytes[](0));
     }
 
     /// @notice Verifies createToken emits TokenCreated with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
     ///      way the default emitter test pins decimals=18.
-    function test_createToken_success_emitsTokenCreated_security(address caller, bytes32 salt) public {
+    function test_createB20_success_emitsTokenCreated_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20SecurityCreateParams memory p =
+        IB20Factory.B20SecurityCreateParams memory p =
             _securityParams("Security Test", "SEC", admin, DEFAULT_ISIN, 0);
-        address predicted = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, caller, salt);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit ITokenFactory.TokenCreated(predicted, ITokenFactory.TokenVariant.SECURITY, "Security Test", "SEC", 6);
+        emit IB20Factory.TokenCreated(predicted, IB20Factory.B20Variant.SECURITY, "Security Test", "SEC", 6);
         _createSecurity(caller, salt, p, new bytes[](0));
     }
 
@@ -376,7 +376,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      not to RBAC. The factory is never granted any role on the token. We verify the bypass by passing
     ///      an initCall (grantRole) that would normally require DEFAULT_ADMIN_ROLE on the caller, and asserting
     ///      it took effect even though the factory has no role.
-    function test_createToken_success_executesInitCalls(address caller, bytes32 salt) public {
+    function test_createB20_success_executesInitCalls(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         bytes[] memory initCalls = new bytes[](1);
         // Grant MINT_ROLE to bob during the bootstrap window. This would normally
@@ -420,10 +420,10 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     }
 
     /// @notice Verifies TokenCreated fires before any state-change events from initCalls
-    /// @dev Log ordering invariant per ITokenFactory natspec: "Emits TokenCreated once the token's identity
+    /// @dev Log ordering invariant per IB20Factory natspec: "Emits TokenCreated once the token's identity
     ///      is sealed and BEFORE any initCalls are dispatched, so init-call effects appear strictly after
     ///      the creation event in the log order." Sanity check using vm.recordLogs.
-    function test_createToken_success_emitsTokenCreatedBeforeInitCallEvents(address caller, bytes32 salt) public {
+    function test_createB20_success_emitsTokenCreatedBeforeInitCallEvents(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         // Use an init call that emits a single, distinctive event we can find: grantRole emits RoleGranted.
         bytes[] memory initCalls = new bytes[](1);
@@ -436,7 +436,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         // Find indices of TokenCreated and RoleGranted. Since the storage-direct-write
         // factory emits no RoleGranted at bootstrap, the only RoleGranted in the log
         // is the one from the init call.
-        int256 tokenCreatedAt = _firstLogIndex(logs, ITokenFactory.TokenCreated.selector);
+        int256 tokenCreatedAt = _firstLogIndex(logs, IB20Factory.TokenCreated.selector);
         int256 roleGrantedAt = _firstLogIndex(logs, IB20.RoleGranted.selector);
         assertGt(tokenCreatedAt, -1, "TokenCreated must be present in the log");
         assertGt(roleGrantedAt, -1, "RoleGranted must be present in the log (from initCall)");
@@ -446,7 +446,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Verifies the factory has no persistent privilege after createToken returns
     /// @dev The bootstrap-window bypass closes when closeBootstrap flips initialized = true. A direct
     ///      call from the factory address after creation must hit the standard auth path and revert.
-    function test_createToken_success_factoryHasNoPersistentPrivilege(address caller, bytes32 salt) public {
+    function test_createB20_success_factoryHasNoPersistentPrivilege(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         address token = _createDefault(caller, salt, _b20Params(), new bytes[](0));
 
@@ -476,9 +476,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @dev "Demonstrate no owner" path: factory accepts zero admin, token has no admin afterward
     ///      (no role grants, policy changes, or pauses ever possible). Replaces the prior
     ///      _revert_zeroAdmin_default stub now that the design explicitly allows this.
-    function test_createToken_success_zeroAdminGrantsNoRole_default(address caller, bytes32 salt) public {
+    function test_createB20_success_zeroAdminGrantsNoRole_default(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("NoOwner", "NOWN", address(0));
+        IB20Factory.B20CreateParams memory p = _b20Params("NoOwner", "NOWN", address(0));
         address token = _createDefault(caller, salt, p, new bytes[](0));
 
         // No admin was granted. Any admin-gated call from any account reverts.
@@ -506,9 +506,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      Paired slot assertions cross-check both the base namespace
     ///      (adminCount=0, initialized=true) and the variant namespace
     ///      (currency slot holds the short-string encoding of "USD").
-    function test_createToken_success_zeroAdminGrantsNoRole_stablecoin(address caller, bytes32 salt) public {
+    function test_createB20_success_zeroAdminGrantsNoRole_stablecoin(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20StablecoinCreateParams memory p = _stablecoinParams("NoOwner USD", "NOUSD", address(0), "USD");
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("NoOwner USD", "NOUSD", address(0), "USD");
         address token = _createStablecoin(caller, salt, p, new bytes[](0));
 
         assertFalse(MockB20(token).hasRole(B20Constants.DEFAULT_ADMIN_ROLE, address(0)), "zero must not hold admin");
@@ -536,27 +536,27 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Verifies the variant byte at address position [10] matches the created variant
     /// @dev Address schema: byte [10] of the token address IS the variant; readable
     ///      statelessly off the address with no factory lookup.
-    function test_createToken_success_encodesVariantByte(address caller, bytes32 salt) public {
+    function test_createB20_success_encodesVariantByte(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
 
         address defaultToken = _createDefault(caller, salt, _b20Params(), new bytes[](0));
         assertEq(
             uint256(uint8(uint160(defaultToken) >> 72)),
-            uint256(ITokenFactory.TokenVariant.DEFAULT),
+            uint256(IB20Factory.B20Variant.DEFAULT),
             "default variant byte mismatch"
         );
 
         address stablecoinToken = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
         assertEq(
             uint256(uint8(uint160(stablecoinToken) >> 72)),
-            uint256(ITokenFactory.TokenVariant.STABLECOIN),
+            uint256(IB20Factory.B20Variant.STABLECOIN),
             "stablecoin variant byte mismatch"
         );
 
         address securityToken = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
         assertEq(
             uint256(uint8(uint160(securityToken) >> 72)),
-            uint256(ITokenFactory.TokenVariant.SECURITY),
+            uint256(IB20Factory.B20Variant.SECURITY),
             "security variant byte mismatch"
         );
     }
@@ -566,7 +566,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      The factory's _writeString handles both paths via vm.store; this test exercises
     ///      the long-string path explicitly. Short-string path is covered by every other
     ///      success test (default name "Test", symbol "TST" are both < 32 bytes).
-    function test_createToken_success_writesLongStrings(address caller, bytes32 salt) public {
+    function test_createB20_success_writesLongStrings(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         // Both strings are 40 bytes -> exercises the long-string storage encoding.
         string memory longName = "A token name that is forty bytes long!!!";
@@ -574,7 +574,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
         assertEq(bytes(longName).length, 40, "test setup: longName must be 40 bytes");
         assertEq(bytes(longSymbol).length, 40, "test setup: longSymbol must be 40 bytes");
 
-        ITokenFactory.B20CreateParams memory p = _b20Params(longName, longSymbol, admin);
+        IB20Factory.B20CreateParams memory p = _b20Params(longName, longSymbol, admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), longName, "long name must round-trip via storage");
@@ -601,14 +601,14 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      try to pack 32 bytes into a 31-byte short-string slot, silently losing data.
     ///      Paired slot assertions confirm both 32-byte and 33-byte slots hold
     ///      the long-string marker (low bit set).
-    function test_createToken_success_writesStringsAtEncodingBoundary(address caller, bytes32 salt) public {
+    function test_createB20_success_writesStringsAtEncodingBoundary(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         string memory name32 = "abcdefghijklmnopqrstuvwxyzABCDEF";
         string memory symbol33 = "abcdefghijklmnopqrstuvwxyzABCDEFG";
         assertEq(bytes(name32).length, 32, "test setup: name must be exactly 32 bytes");
         assertEq(bytes(symbol33).length, 33, "test setup: symbol must be exactly 33 bytes");
 
-        ITokenFactory.B20CreateParams memory p = _b20Params(name32, symbol33, admin);
+        IB20Factory.B20CreateParams memory p = _b20Params(name32, symbol33, admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), name32, "32-byte name must round-trip (long path)");
@@ -630,12 +630,12 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      actual paths share the same encoding choice. The Rust impl must agree on
     ///      abi.encode specifically; this test recomputes the address externally using
     ///      abi.encode and asserts the factory returns the same value.
-    function test_getTokenAddress_pinsDownAbiEncoding(address sender, bytes32 salt) public view {
+    function test_getB20Address_pinsDownAbiEncoding(address sender, bytes32 salt) public view {
         bytes9 expectedTail = bytes9(keccak256(abi.encode(sender, salt)));
-        uint160 expectedAddr = (uint160(0xB2) << 152) | (uint160(uint8(ITokenFactory.TokenVariant.DEFAULT)) << 72)
+        uint160 expectedAddr = (uint160(0xB2) << 152) | (uint160(uint8(IB20Factory.B20Variant.DEFAULT)) << 72)
             | uint160(uint72(expectedTail));
 
-        address actual = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, sender, salt);
+        address actual = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, sender, salt);
         assertEq(actual, address(expectedAddr), "factory must derive address via abi.encode of (sender, salt)");
     }
 
@@ -647,9 +647,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      reads the low bit (1 -> long string), then computes length as (3-1)/2 = 1, and reads
     ///      keccak256(slot) for content, returning garbage. The assertion below catches both the
     ///      length-1 long-string interpretation AND any future regressions of the same shape.
-    function test_createToken_success_emptyName_roundTripsAsEmpty(address caller, bytes32 salt) public {
+    function test_createB20_success_emptyName_roundTripsAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("", "ETH", admin);
+        IB20Factory.B20CreateParams memory p = _b20Params("", "ETH", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), "", "empty name must round-trip as empty");
@@ -664,9 +664,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     ///      reads past it, into whatever the next memory allocation placed there. Whether it's
     ///      garbage from the free-memory pointer or padded zeros depends on calling context; we
     ///      assert the result is the empty string regardless.
-    function test_createToken_success_emptySymbol_roundTripsAsEmpty(address caller, bytes32 salt) public {
+    function test_createB20_success_emptySymbol_roundTripsAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("Token", "", admin);
+        IB20Factory.B20CreateParams memory p = _b20Params("Token", "", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).symbol(), "", "empty symbol must round-trip as empty");
@@ -678,9 +678,9 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
     /// @notice Verifies both empty name and empty symbol round-trip correctly (regression test for L-04)
     /// @dev Belt-and-suspenders: both strings empty is the most degenerate case and would be
     ///      most likely to surface memory-layout assumptions in the writer.
-    function test_createToken_success_bothEmpty_roundTripAsEmpty(address caller, bytes32 salt) public {
+    function test_createB20_success_bothEmpty_roundTripAsEmpty(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
-        ITokenFactory.B20CreateParams memory p = _b20Params("", "", admin);
+        IB20Factory.B20CreateParams memory p = _b20Params("", "", admin);
         address tokenAddr = _createDefault(caller, salt, p, new bytes[](0));
 
         assertEq(MockB20(tokenAddr).name(), "", "empty name must round-trip as empty");
@@ -693,7 +693,7 @@ contract TokenFactoryCreateTokenTest is TokenFactoryTest {
 
     /// @notice Verifies decimals are fixed by variant and not encoded in address bytes
     /// @dev Default tokens return 18, stablecoin and security tokens return 6.
-    function test_createToken_success_decimalsFixedByVariant(address caller, bytes32 salt) public {
+    function test_createB20_success_decimalsFixedByVariant(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         address defaultToken = _createDefault(caller, salt, _b20Params("Test", "TST", admin), new bytes[](0));
         address stablecoinToken = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));

--- a/test/unit/B20Factory/getTokenAddress.t.sol
+++ b/test/unit/B20Factory/getTokenAddress.t.sol
@@ -1,37 +1,37 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ITokenFactory} from "src/interfaces/ITokenFactory.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 
-import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
-contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
-    /// @notice Wraps an arbitrary uint8 into a valid TokenVariant ordinal.
+contract B20FactoryGetTokenAddressTest is B20FactoryTest {
+    /// @notice Wraps an arbitrary uint8 into a valid B20Variant ordinal.
     /// @dev Bounds to the enum range (DEFAULT, STABLECOIN, SECURITY). The address derivation
     ///      is happy with the raw byte but Solidity reverts at function entry on an
     ///      out-of-range enum input from a fuzzer.
-    function _boundVariant(uint8 variantInt) internal pure returns (ITokenFactory.TokenVariant) {
+    function _boundVariant(uint8 variantInt) internal pure returns (IB20Factory.B20Variant) {
         return
-            ITokenFactory.TokenVariant(
-                uint8(bound(uint256(variantInt), 0, uint256(type(ITokenFactory.TokenVariant).max)))
+            IB20Factory.B20Variant(
+                uint8(bound(uint256(variantInt), 0, uint256(type(IB20Factory.B20Variant).max)))
             );
     }
 
     /// @notice Verifies getTokenAddress is deterministic for the same inputs
     /// @dev Pure view: repeated calls with identical args must return identical addresses
-    function test_getTokenAddress_success_deterministic(uint8 variantInt, address sender, bytes32 salt) public view {
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, sender, salt);
-        address b = factory.getTokenAddress(variant, sender, salt);
+    function test_getB20Address_success_deterministic(uint8 variantInt, address sender, bytes32 salt) public view {
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, sender, salt);
+        address b = factory.getB20Address(variant, sender, salt);
         assertEq(a, b, "address derivation must be deterministic");
     }
 
     /// @notice Verifies different variants produce different addresses for the same (sender, salt)
     /// @dev Variant byte at position [10] is part of the address derivation
-    function test_getTokenAddress_success_differentVariantDiffers(address sender, bytes32 salt) public view {
-        address asDefault = factory.getTokenAddress(ITokenFactory.TokenVariant.DEFAULT, sender, salt);
-        address asStablecoin = factory.getTokenAddress(ITokenFactory.TokenVariant.STABLECOIN, sender, salt);
-        address asSecurity = factory.getTokenAddress(ITokenFactory.TokenVariant.SECURITY, sender, salt);
+    function test_getB20Address_success_differentVariantDiffers(address sender, bytes32 salt) public view {
+        address asDefault = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, sender, salt);
+        address asStablecoin = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, sender, salt);
+        address asSecurity = factory.getB20Address(IB20Factory.B20Variant.SECURITY, sender, salt);
         assertTrue(asDefault != asStablecoin, "DEFAULT vs STABLECOIN must differ");
         assertTrue(asDefault != asSecurity, "DEFAULT vs SECURITY must differ");
         assertTrue(asStablecoin != asSecurity, "STABLECOIN vs SECURITY must differ");
@@ -39,36 +39,36 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
 
     /// @notice Verifies different senders produce different addresses for the same (variant, salt)
     /// @dev Sender is mixed into the trailing 9-byte hash at address bytes [11:20]
-    function test_getTokenAddress_success_differentSenderDiffers(uint8 variantInt, address s1, address s2, bytes32 salt)
+    function test_getB20Address_success_differentSenderDiffers(uint8 variantInt, address s1, address s2, bytes32 salt)
         public
         view
     {
         vm.assume(s1 != s2);
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, s1, salt);
-        address b = factory.getTokenAddress(variant, s2, salt);
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, s1, salt);
+        address b = factory.getB20Address(variant, s2, salt);
         assertTrue(a != b, "different senders must yield different addresses");
     }
 
     /// @notice Verifies different salts produce different addresses for the same (variant, sender)
     /// @dev Salt is mixed into the trailing 9-byte hash at address bytes [11:20]
-    function test_getTokenAddress_success_differentSaltDiffers(uint8 variantInt, address sender, bytes32 s1, bytes32 s2)
+    function test_getB20Address_success_differentSaltDiffers(uint8 variantInt, address sender, bytes32 s1, bytes32 s2)
         public
         view
     {
         vm.assume(s1 != s2);
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, sender, s1);
-        address b = factory.getTokenAddress(variant, sender, s2);
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, sender, s1);
+        address b = factory.getB20Address(variant, sender, s2);
         assertTrue(a != b, "different salts must yield different addresses");
     }
 
     /// @notice Verifies the first 10 bytes of the returned address match the B-20 prefix
     /// @dev Address schema: bytes [0:10] are the shared 0xB200...000 prefix
     ///      (byte [0] = 0xB2, bytes [1:9] = 0x00)
-    function test_getTokenAddress_success_prefixIsB20(uint8 variantInt, address sender, bytes32 salt) public view {
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, sender, salt);
+    function test_getB20Address_success_prefixIsB20(uint8 variantInt, address sender, bytes32 salt) public view {
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, sender, salt);
 
         // Drop the bottom 10 bytes; what remains should be 0xB2 followed by 9 zero bytes.
         uint160 topTenBytes = uint160(a) >> 80;
@@ -78,12 +78,12 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
 
     /// @notice Verifies byte [10] of the returned address equals the variant ordinal
     /// @dev Address schema: variant byte is readable statelessly off the address
-    function test_getTokenAddress_success_variantByteAtPosition10(uint8 variantInt, address sender, bytes32 salt)
+    function test_getB20Address_success_variantByteAtPosition10(uint8 variantInt, address sender, bytes32 salt)
         public
         view
     {
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, sender, salt);
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, sender, salt);
 
         // Byte [10] = bits [72..79]. Mask after shift.
         // forge-lint: disable-next-line(unsafe-typecast)
@@ -91,27 +91,27 @@ contract TokenFactoryGetTokenAddressTest is TokenFactoryTest {
         assertEq(byteAt10, uint8(variant), "address byte [10] must equal variant ordinal");
     }
 
-    /// @notice Pins the absolute numeric ordinals of TokenVariant
+    /// @notice Pins the absolute numeric ordinals of B20Variant
     /// @dev The variant byte at address[10] equals the enum ordinal (see
-    ///      test_getTokenAddress_success_variantByteAtPosition10), so the
+    ///      test_getB20Address_success_variantByteAtPosition10), so the
     ///      ordinals are part of the on-chain address contract. Any
     ///      deliberate reorder must update these constants; this test
     ///      exists so an accidental reorder (e.g. inserting a new
     ///      variant between existing ones) fails loudly instead of
     ///      silently shifting every deployed address.
     function test_tokenVariant_success_ordinalsPinned() public pure {
-        assertEq(uint8(ITokenFactory.TokenVariant.DEFAULT), 0, "DEFAULT ordinal must be 0");
-        assertEq(uint8(ITokenFactory.TokenVariant.STABLECOIN), 1, "STABLECOIN ordinal must be 1");
-        assertEq(uint8(ITokenFactory.TokenVariant.SECURITY), 2, "SECURITY ordinal must be 2");
+        assertEq(uint8(IB20Factory.B20Variant.DEFAULT), 0, "DEFAULT ordinal must be 0");
+        assertEq(uint8(IB20Factory.B20Variant.STABLECOIN), 1, "STABLECOIN ordinal must be 1");
+        assertEq(uint8(IB20Factory.B20Variant.SECURITY), 2, "SECURITY ordinal must be 2");
     }
 
     /// @notice Verifies byte [11] comes from the hash tail entropy
-    function test_getTokenAddress_success_byte11DerivedFromTailEntropy(uint8 variantInt, address sender, bytes32 salt)
+    function test_getB20Address_success_byte11DerivedFromTailEntropy(uint8 variantInt, address sender, bytes32 salt)
         public
         view
     {
-        ITokenFactory.TokenVariant variant = _boundVariant(variantInt);
-        address a = factory.getTokenAddress(variant, sender, salt);
+        IB20Factory.B20Variant variant = _boundVariant(variantInt);
+        address a = factory.getB20Address(variant, sender, salt);
 
         bytes9 tail = bytes9(keccak256(abi.encode(sender, salt)));
         uint8 expectedByte11 = uint8(uint72(tail) >> 64);

--- a/test/unit/B20Factory/isB20.t.sol
+++ b/test/unit/B20Factory/isB20.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenFactoryTest} from "test/lib/TokenFactoryTest.sol";
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
-contract TokenFactoryIsB20Test is TokenFactoryTest {
+contract B20FactoryIsB20Test is B20FactoryTest {
     /// @notice Verifies isB20 returns true for a freshly-created token
     /// @dev Recognition via address-prefix match; no storage read
     function test_isB20_success_trueForCreatedToken(bytes32 salt) public {

--- a/test/unit/B20Security/batch/batchBurn.t.sol
+++ b/test/unit/B20Security/batch/batchBurn.t.sol
@@ -27,7 +27,7 @@ contract B20SecurityBatchBurnTest is B20SecurityTest {
     ///      `batchBurn(...)` initCall: the call arrives at the token with `msg.sender == factory`
     ///      and `initialized == false`, but `onlyRoleStrict` requires the factory to actually
     ///      hold `BURN_FROM_ROLE` (which it never does), so the init-call reverts and the
-    ///      factory bubbles the inner AccessControlUnauthorizedAccount per ITokenFactory.InitCallFailed.
+    ///      factory bubbles the inner AccessControlUnauthorizedAccount per IB20Factory.InitCallFailed.
     function test_batchBurn_revert_factoryBootstrapBypassRejected(bytes32 salt) public {
         bytes[] memory initCalls = new bytes[](1);
         initCalls[0] = abi.encodeWithSelector(

--- a/test/unit/storage/B20FullLayout.t.sol
+++ b/test/unit/storage/B20FullLayout.t.sol
@@ -58,7 +58,7 @@ contract B20FullLayoutTest is B20Test {
 
         // ---------- Identity (slots 0..2) ----------
         // Bootstrap-default identity is "Test" / "TST" / "" from
-        // TokenFactoryTest._b20Params(). Empty contractURI is the
+        // B20FactoryTest._b20Params(). Empty contractURI is the
         // zero-slot encoding; "Test" and "TST" are short-string
         // encoded via _expectedStringFieldSlot.
         assertEq(vm.load(tokenAddr, MockB20Storage.nameSlot()), _expectedStringFieldSlot(token.name()), "slot 0: name");
@@ -184,7 +184,7 @@ contract B20FullLayoutTest is B20Test {
     function _populate() internal {
         // ---------- Identity ----------
         // name/symbol come from factory bootstrap ("Test" / "TST" via
-        // TokenFactoryTest._b20Params()). Set contractURI explicitly so
+        // B20FactoryTest._b20Params()). Set contractURI explicitly so
         // slot 2 has a non-zero value to assert.
         vm.prank(admin);
         token.updateContractURI("https://example.com/contract.json");

--- a/test/unit/storage/MockB20SlotHelpers.t.sol
+++ b/test/unit/storage/MockB20SlotHelpers.t.sol
@@ -284,7 +284,7 @@ contract MockB20SlotHelpersTest is B20Test {
     ///      against `bytes(name).length * 2` for the bootstrap-default name.
     function test_nameSlot_success_holdsShortStringEncoding() public view {
         bytes32 raw = vm.load(address(token), MockB20Storage.nameSlot());
-        // Bootstrap-default name from MockTokenFactory: empty string until
+        // Bootstrap-default name from MockB20Factory: empty string until
         // updateName is called, so encoding is the all-zero slot. We
         // also check the encoding is well-formed for whatever name is
         // currently set.


### PR DESCRIPTION
## Motivation

- Every other type uses the `B20` prefix: `IB20`, `IB20Stablecoin`, `IB20Security`, `MockB20`, `B20Token`, `B20SecurityStorage`, etc. The factory types were the one outlier.
- The factory's precompile address (`0xB20F00...000F`) already encodes `B20F`, and its query functions are already named `isB20` and `isB20Initialized`. The interface name should match.

## What changed

Renames:

- `ITokenFactory` -> `IB20Factory` (interface file and all references)
- `MockTokenFactory` -> `MockB20Factory`
- `TokenFactoryTest` -> `B20FactoryTest`
- `TokenVariant` -> `B20Variant`
- `createToken()` -> `createB20()`
- `getTokenAddress()` -> `getB20Address()`
- `TOKEN_FACTORY` / `TOKEN_FACTORY_ADDRESS` -> `B20_FACTORY` / `B20_FACTORY_ADDRESS` in `StdPrecompiles`
- `TokenCreated` event -> `B20Created`
- `test/unit/TokenFactory/` -> `test/unit/B20Factory/`

P0 fixes from review:

- `UnsupportedVersion(uint8 version)` -> `UnsupportedVersion(uint8 version, B20Variant variant)` so callers know which variant rejected their version byte
- `ActivationRegistryFeatureList.B20_FACTORY` key updated from `keccak256("base.token_factory")` to `keccak256("base.b20_factory")`

440 tests pass. No behavioral changes beyond the error payload addition.

## What was tried / considered

- `createB20Token`: rejected because `B20` already implies a token, making `Token` redundant.
- `createB20`: chosen because it treats the product name as the noun directly, making the full factory surface uniform: `createB20`, `getB20Address`, `isB20`, `isB20Initialized` all follow the same `verb + B20` pattern.
- Keeping `createToken`: within `IB20Factory` the name is already scoped to B20s, but consistency with the rest of the surface won out.
- A companion PR in base/base will rename the Rust-side `ITokenFactory`, `TokenFactoryStorage`, and `TokenVariant` to match.