### PR TITLE
feat: Add `name` to EIP-712 domain separator on B20Security

### DIFF
--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -44,6 +44,27 @@ import {IB20} from "./IB20.sol";
 ///            for the holder-initiated off-chain settlement path.
 ///         5. `securityIdentifier(...)` / `updateSecurityIdentifier(...)`
 ///            for ISIN, CUSIP, FIGI, and similar off-chain registry IDs.
+///         6. An EIP-712 domain override that binds `name` into the
+///            domain hash (where `IB20` leaves it empty) plus the
+///            ERC-5267 `EIP712DomainChanged` event. See the
+///            "EIP-712 domain override" section below.
+///
+///         **EIP-712 domain override.** Unlike base `IB20`, whose
+///         permit domain is `(chainId, verifyingContract)` only, this
+///         variant additionally binds the token `name` into its
+///         EIP-712 domain.
+///         - `updateName(...)` emits the inherited `NameUpdated`
+///           event AND `EIP712DomainChanged()` (in that order). The
+///           pair is atomic: indexers that observe `NameUpdated`
+///           without the matching `EIP712DomainChanged` (or vice
+///           versa) should treat that as a protocol violation.
+///         - Outstanding off-chain `permit` signatures issued under
+///           a previous `name` cease to be valid as soon as
+///           `updateName` lands, because the recovered signer no
+///           longer matches the new domain separator. This is the
+///           intended behavior; renaming the security is a
+///           material event and signed-but-unsubmitted approvals
+///           should not survive it.
 ///
 ///         **Metadata updates.** The inherited `updateName(...)` and
 ///         `updateSymbol(...)` continue to be gated by `METADATA_ROLE`
@@ -191,6 +212,23 @@ interface IB20Security is IB20 {
     ///         within-tx unambiguous; the `id` field hardens cross-tx
     ///         indexing as well.
     event EndAnnouncement(string id);
+
+    /// @notice ERC-5267 domain-change signal. Emitted whenever a
+    ///         field that participates in this token's EIP-712
+    ///         domain changes value. On `IB20Security` the only
+    ///         such field is `name`, so this event is emitted
+    ///         exactly once per successful `updateName(...)` call,
+    ///         immediately after the inherited `NameUpdated` event.
+    ///         The event signature is parameterless per ERC-5267:
+    ///         off-chain integrators that cache `DOMAIN_SEPARATOR()`
+    ///         or `eip712Domain()` re-fetch after observing it.
+    /// @dev    The base `IB20` surface does NOT emit this event
+    ///         because its domain depends only on `chainId` and
+    ///         `verifyingContract`, neither of which the contract
+    ///         can mutate. `IB20Security` adds it specifically to
+    ///         signal `name` changes; see the contract-level
+    ///         "EIP-712 domain override" notes.
+    event EIP712DomainChanged();
 
     /*//////////////////////////////////////////////////////////////
                             ROLE IDENTIFIERS

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -203,7 +203,7 @@ contract MockB20 is IB20 {
     //                         METADATA UPDATES
     // ============================================================
 
-    function updateName(string calldata newName) external onlyRole(METADATA_ROLE) {
+    function updateName(string calldata newName) public virtual onlyRole(METADATA_ROLE) {
         MockB20Storage.layout().name = newName;
         emit NameUpdated(msg.sender, newName);
     }
@@ -449,7 +449,7 @@ contract MockB20 is IB20 {
     bytes32 internal constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));
     }
 
@@ -483,6 +483,7 @@ contract MockB20 is IB20 {
     function eip712Domain()
         external
         view
+        virtual
         returns (
             bytes1 fields,
             string memory name_,

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -246,6 +246,71 @@ contract MockB20Security is MockB20, IB20Security {
     }
 
     // ============================================================
+    //              EIP-712 DOMAIN OVERRIDE (ERC-5267)
+    // ============================================================
+
+    /// @dev Variant domain typehash: like the base typehash, but with
+    ///      `string name` as the leading field. The struct hash binds
+    ///      `keccak256(bytes(name))` (read live from storage on each
+    ///      call), so any successful `updateName(...)` invalidates
+    ///      previously-issued domain separators and the signatures
+    ///      that were produced under them. See the `IB20Security`
+    ///      interface-level "EIP-712 domain override" notes for
+    ///      rationale.
+    bytes32 internal constant SECURITY_EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    function DOMAIN_SEPARATOR() public view override(MockB20, IB20) returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                SECURITY_EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes(MockB20Storage.layout().name)),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    function eip712Domain()
+        external
+        view
+        override(MockB20, IB20)
+        returns (
+            bytes1 fields,
+            string memory name_,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        // Bits 0, 2, 3 set: name, chainId, verifyingContract are populated.
+        // version, salt, extensions are empty/zero. See IB20Security's
+        // contract-level natspec for why `name` joins the domain on this
+        // variant but not on the base.
+        fields = hex"0d";
+        name_ = MockB20Storage.layout().name;
+        version = "";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
+
+    /// @dev Override: defer to the base's `updateName` (which handles
+    ///      the `METADATA_ROLE` gate, the storage write, and the
+    ///      `NameUpdated` emission), then emit the ERC-5267
+    ///      `EIP712DomainChanged()` signal so off-chain integrators
+    ///      that cache `DOMAIN_SEPARATOR()` or `eip712Domain()`
+    ///      re-fetch. Event order is `NameUpdated` then
+    ///      `EIP712DomainChanged`, per the interface contract.
+    function updateName(string calldata newName) public override(MockB20, IB20) {
+        super.updateName(newName);
+        emit EIP712DomainChanged();
+    }
+
+    // ============================================================
     //                       POLICY OVERRIDES
     // ============================================================
 


### PR DESCRIPTION
A `name` change is a meaningful concept in the realm of Securities. Thus a name change explicitly changes the domain separator and invalidates previously signed permits. 

PR currently only shows changes to interface and mocks. Will update test if we get alignment that we should do this. 