### PR TITLE
rename(b20): policyType -> policyScope in IB20 token interface

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -41,7 +41,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         detail; the public surface speaks only in `PausableFeature`
 ///         values.
 ///
-///         **Policy model.** Each supported `bytes32 policyType` resolves
+///         **Policy model.** Each supported `bytes32 policyName` resolves
 ///         to a dedicated storage slot on the token. The policy-type
 ///         identifier is the `keccak256` hash of its name. Four standard
 ///         types are exposed as constants on this base surface:
@@ -53,11 +53,11 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         Variants extend this set by adding their own dedicated slots
 ///         (e.g. `IB20Security` adds `REDEEM_SENDER_POLICY` for its `redeem`
 ///         path, stored in the variant's own namespaced storage). There
-///         is no generic catch-all mapping: every `policyType` either
+///         is no generic catch-all mapping: every `policyName` either
 ///         resolves to a real slot or doesn't exist at all. Both reads
-///         (`policyId`) and writes (`updatePolicy`) for a `policyType`
+///         (`policyId`) and writes (`updatePolicy`) for a `policyName`
 ///         not supported by the token (or its variant) revert
-///         `UnsupportedPolicyType` — an unsupported `policyType` is
+///         `UnsupportedPolicyType` — an unsupported `policyName` is
 ///         nonsense the token can't parse, so the registry never gets
 ///         consulted with it. (Reads stay strict, not silent-zero,
 ///         because a typo'd query returning `0` would masquerade as
@@ -172,24 +172,24 @@ interface IB20 {
     /// @notice The mint would push `totalSupply` past the configured cap.
     error SupplyCapExceeded(uint256 cap, uint256 attempted);
 
-    /// @notice A policy slot denied the operation. `policyType` identifies
+    /// @notice A policy slot denied the operation. `policyName` identifies
     ///         which slot (e.g. `TRANSFER_SENDER_POLICY`, `MINT_RECEIVER_POLICY`) and
     ///         `policyId` is the ID currently set in that slot.
-    error PolicyForbids(bytes32 policyType, uint64 policyId);
+    error PolicyForbids(bytes32 policyName, uint64 policyId);
 
     /// @notice The provided policy ID does not exist in the policy
     ///         registry.
     error PolicyNotFound(uint64 policyId);
 
     /// @notice `policyId` or `updatePolicy` was called with a
-    ///         `policyType` that this token (and its variant, if any)
+    ///         `policyName` that this token (and its variant, if any)
     ///         does not recognize. Each token implementation defines a
     ///         fixed set of supported policy types; both reads and
     ///         writes for anything outside that set revert here so a
     ///         typo'd query can never be silently interpreted as
     ///         "no restriction", and an admin can never assign a policy
     ///         to a slot that doesn't exist.
-    error UnsupportedPolicyType(bytes32 policyType);
+    error UnsupportedPolicyType(bytes32 policyName);
 
     /// @notice `burnBlocked` was called against a `from` address that is
     ///         currently authorized under the active `TRANSFER_SENDER_POLICY`
@@ -318,12 +318,12 @@ interface IB20 {
     event Unpaused(address indexed updater, PausableFeature[] features);
 
     /// @notice Emitted by `updatePolicy` when a token's policy slot is
-    ///         changed. `policyType` is one of the standard policy-type
+    ///         changed. `policyName` is one of the standard policy-type
     ///         identifiers (e.g. `TRANSFER_SENDER_POLICY()`); `oldPolicyId` and
     ///         `newPolicyId` are the prior and current registry IDs for
     ///         that slot. Initial slot assignment at creation is also
     ///         emitted via `PolicyUpdated` with `oldPolicyId == 0`.
-    event PolicyUpdated(bytes32 indexed policyType, uint64 oldPolicyId, uint64 newPolicyId);
+    event PolicyUpdated(bytes32 indexed policyName, uint64 oldPolicyId, uint64 newPolicyId);
 
     /// @notice Emitted by `updateSupplyCap`. Includes the prior cap for
     ///         indexer convenience.
@@ -686,10 +686,10 @@ interface IB20 {
                                  POLICY
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The current policy ID configured for `policyType`. Returns
+    /// @notice The current policy ID configured for `policyName`. Returns
     ///         `0` (always-allow built-in) for any policy slot that has
     ///         never been assigned. Reverts `UnsupportedPolicyType` for
-    ///         a `policyType` not supported by this token (or its
+    ///         a `policyName` not supported by this token (or its
     ///         variant). Standard policy types are exposed as the
     ///         role-identifier constants `TRANSFER_SENDER_POLICY()`,
     ///         `TRANSFER_RECEIVER_POLICY()`, `TRANSFER_EXECUTOR_POLICY()`,
@@ -702,15 +702,15 @@ interface IB20 {
     ///         hard-deny a slot (e.g. disabling redemption on a
     ///         non-redeemable token), point it at the ALWAYS_BLOCK
     ///         sentinel.
-    function policyId(bytes32 policyType) external view returns (uint64);
+    function policyId(bytes32 policyName) external view returns (uint64);
 
-    /// @notice Updates the policy ID assigned to `policyType`. Requires
+    /// @notice Updates the policy ID assigned to `policyName`. Requires
     ///         `DEFAULT_ADMIN_ROLE`. The target policy MUST exist in the
     ///         registry (or be one of the built-in IDs `0` or
     ///         `type(uint64).max`); otherwise reverts with
     ///         `PolicyNotFound`. Takes effect immediately for the next
     ///         operation that consults this slot. Emits `PolicyUpdated`.
-    function updatePolicy(bytes32 policyType, uint64 newPolicyId) external;
+    function updatePolicy(bytes32 policyName, uint64 newPolicyId) external;
 
     /*//////////////////////////////////////////////////////////////
                               SUPPLY CAP

--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -41,7 +41,7 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         detail; the public surface speaks only in `PausableFeature`
 ///         values.
 ///
-///         **Policy model.** Each supported `bytes32 policyName` resolves
+///         **Policy model.** Each supported `bytes32 policyScope` resolves
 ///         to a dedicated storage slot on the token. The policy-type
 ///         identifier is the `keccak256` hash of its name. Four standard
 ///         types are exposed as constants on this base surface:
@@ -53,11 +53,11 @@ pragma solidity >=0.8.20 <0.9.0;
 ///         Variants extend this set by adding their own dedicated slots
 ///         (e.g. `IB20Security` adds `REDEEM_SENDER_POLICY` for its `redeem`
 ///         path, stored in the variant's own namespaced storage). There
-///         is no generic catch-all mapping: every `policyName` either
+///         is no generic catch-all mapping: every `policyScope` either
 ///         resolves to a real slot or doesn't exist at all. Both reads
-///         (`policyId`) and writes (`updatePolicy`) for a `policyName`
+///         (`policyId`) and writes (`updatePolicy`) for a `policyScope`
 ///         not supported by the token (or its variant) revert
-///         `UnsupportedPolicyType` — an unsupported `policyName` is
+///         `UnsupportedPolicyType` — an unsupported `policyScope` is
 ///         nonsense the token can't parse, so the registry never gets
 ///         consulted with it. (Reads stay strict, not silent-zero,
 ///         because a typo'd query returning `0` would masquerade as
@@ -172,24 +172,24 @@ interface IB20 {
     /// @notice The mint would push `totalSupply` past the configured cap.
     error SupplyCapExceeded(uint256 cap, uint256 attempted);
 
-    /// @notice A policy slot denied the operation. `policyName` identifies
+    /// @notice A policy slot denied the operation. `policyScope` identifies
     ///         which slot (e.g. `TRANSFER_SENDER_POLICY`, `MINT_RECEIVER_POLICY`) and
     ///         `policyId` is the ID currently set in that slot.
-    error PolicyForbids(bytes32 policyName, uint64 policyId);
+    error PolicyForbids(bytes32 policyScope, uint64 policyId);
 
     /// @notice The provided policy ID does not exist in the policy
     ///         registry.
     error PolicyNotFound(uint64 policyId);
 
     /// @notice `policyId` or `updatePolicy` was called with a
-    ///         `policyName` that this token (and its variant, if any)
+    ///         `policyScope` that this token (and its variant, if any)
     ///         does not recognize. Each token implementation defines a
     ///         fixed set of supported policy types; both reads and
     ///         writes for anything outside that set revert here so a
     ///         typo'd query can never be silently interpreted as
     ///         "no restriction", and an admin can never assign a policy
     ///         to a slot that doesn't exist.
-    error UnsupportedPolicyType(bytes32 policyName);
+    error UnsupportedPolicyType(bytes32 policyScope);
 
     /// @notice `burnBlocked` was called against a `from` address that is
     ///         currently authorized under the active `TRANSFER_SENDER_POLICY`
@@ -318,12 +318,12 @@ interface IB20 {
     event Unpaused(address indexed updater, PausableFeature[] features);
 
     /// @notice Emitted by `updatePolicy` when a token's policy slot is
-    ///         changed. `policyName` is one of the standard policy-type
+    ///         changed. `policyScope` is one of the standard policy-type
     ///         identifiers (e.g. `TRANSFER_SENDER_POLICY()`); `oldPolicyId` and
     ///         `newPolicyId` are the prior and current registry IDs for
     ///         that slot. Initial slot assignment at creation is also
     ///         emitted via `PolicyUpdated` with `oldPolicyId == 0`.
-    event PolicyUpdated(bytes32 indexed policyName, uint64 oldPolicyId, uint64 newPolicyId);
+    event PolicyUpdated(bytes32 indexed policyScope, uint64 oldPolicyId, uint64 newPolicyId);
 
     /// @notice Emitted by `updateSupplyCap`. Includes the prior cap for
     ///         indexer convenience.
@@ -686,10 +686,10 @@ interface IB20 {
                                  POLICY
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The current policy ID configured for `policyName`. Returns
+    /// @notice The current policy ID configured for `policyScope`. Returns
     ///         `0` (always-allow built-in) for any policy slot that has
     ///         never been assigned. Reverts `UnsupportedPolicyType` for
-    ///         a `policyName` not supported by this token (or its
+    ///         a `policyScope` not supported by this token (or its
     ///         variant). Standard policy types are exposed as the
     ///         role-identifier constants `TRANSFER_SENDER_POLICY()`,
     ///         `TRANSFER_RECEIVER_POLICY()`, `TRANSFER_EXECUTOR_POLICY()`,
@@ -702,15 +702,15 @@ interface IB20 {
     ///         hard-deny a slot (e.g. disabling redemption on a
     ///         non-redeemable token), point it at the ALWAYS_BLOCK
     ///         sentinel.
-    function policyId(bytes32 policyName) external view returns (uint64);
+    function policyId(bytes32 policyScope) external view returns (uint64);
 
-    /// @notice Updates the policy ID assigned to `policyName`. Requires
+    /// @notice Updates the policy ID assigned to `policyScope`. Requires
     ///         `DEFAULT_ADMIN_ROLE`. The target policy MUST exist in the
     ///         registry (or be one of the built-in IDs `0` or
     ///         `type(uint64).max`); otherwise reverts with
     ///         `PolicyNotFound`. Takes effect immediately for the next
     ///         operation that consults this slot. Emits `PolicyUpdated`.
-    function updatePolicy(bytes32 policyName, uint64 newPolicyId) external;
+    function updatePolicy(bytes32 policyScope, uint64 newPolicyId) external;
 
     /*//////////////////////////////////////////////////////////////
                               SUPPLY CAP

--- a/test/lib/B20SecurityTest.sol
+++ b/test/lib/B20SecurityTest.sol
@@ -116,9 +116,9 @@ contract B20SecurityTest is B20Test {
     ///      prank applies to `updatePolicy`, not to the view call that
     ///      resolves the constant.
     function _setRedeemPolicy(uint64 policyId) internal {
-        bytes32 policyName = security().REDEEM_SENDER_POLICY();
+        bytes32 policyScope = security().REDEEM_SENDER_POLICY();
         vm.prank(admin);
-        token.updatePolicy(policyName, policyId);
+        token.updatePolicy(policyScope, policyId);
     }
 
     // ============================================================
@@ -186,8 +186,8 @@ contract B20SecurityTest is B20Test {
 
     /// @notice Extends `_isKnownPolicyType` with the variant's own
     ///         redeem-side type.
-    function _isKnownSecurityPolicyType(bytes32 policyName) internal view returns (bool) {
-        return _isKnownPolicyType(policyName) || policyName == security().REDEEM_SENDER_POLICY();
+    function _isKnownSecurityPolicyType(bytes32 policyScope) internal view returns (bool) {
+        return _isKnownPolicyType(policyScope) || policyScope == security().REDEEM_SENDER_POLICY();
     }
 
     // ============================================================

--- a/test/lib/B20SecurityTest.sol
+++ b/test/lib/B20SecurityTest.sol
@@ -116,9 +116,9 @@ contract B20SecurityTest is B20Test {
     ///      prank applies to `updatePolicy`, not to the view call that
     ///      resolves the constant.
     function _setRedeemPolicy(uint64 policyId) internal {
-        bytes32 policyType = security().REDEEM_SENDER_POLICY();
+        bytes32 policyName = security().REDEEM_SENDER_POLICY();
         vm.prank(admin);
-        token.updatePolicy(policyType, policyId);
+        token.updatePolicy(policyName, policyId);
     }
 
     // ============================================================
@@ -186,8 +186,8 @@ contract B20SecurityTest is B20Test {
 
     /// @notice Extends `_isKnownPolicyType` with the variant's own
     ///         redeem-side type.
-    function _isKnownSecurityPolicyType(bytes32 policyType) internal view returns (bool) {
-        return _isKnownPolicyType(policyType) || policyType == security().REDEEM_SENDER_POLICY();
+    function _isKnownSecurityPolicyType(bytes32 policyName) internal view returns (bool) {
+        return _isKnownPolicyType(policyName) || policyName == security().REDEEM_SENDER_POLICY();
     }
 
     // ============================================================

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -361,22 +361,22 @@ contract MockB20 is IB20 {
     //                            POLICY
     // ============================================================
 
-    function policyId(bytes32 policyName) external view returns (uint64) {
-        return _readPolicyId(policyName);
+    function policyId(bytes32 policyScope) external view returns (uint64) {
+        return _readPolicyId(policyScope);
     }
 
-    function updatePolicy(bytes32 policyName, uint64 newPolicyId) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updatePolicy(bytes32 policyScope, uint64 newPolicyId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         // Read the old ID for the event payload. Reverts
         // `UnsupportedPolicyType` here if the type has no slot on this token.
-        uint64 oldPolicyId = _readPolicyId(policyName);
+        uint64 oldPolicyId = _readPolicyId(policyScope);
         // Existence check at write time is what lets `isAuthorized` skip
         // its own existence SLOAD on the hot path. `policyExists` rejects
         // both unknown and malformed IDs.
         if (!IPolicyRegistry(POLICY_REGISTRY).policyExists(newPolicyId)) {
             revert PolicyNotFound(newPolicyId);
         }
-        _writePolicyId(policyName, newPolicyId);
-        emit PolicyUpdated(policyName, oldPolicyId, newPolicyId);
+        _writePolicyId(policyScope, newPolicyId);
+        emit PolicyUpdated(policyScope, oldPolicyId, newPolicyId);
     }
 
     /// @dev Reads a policy ID from storage. Each supported policy type
@@ -387,13 +387,13 @@ contract MockB20 is IB20 {
     ///      masquerade as "no restriction". Variants that add their own
     ///      policy types override this to check their own slots before
     ///      falling through to `super`.
-    function _readPolicyId(bytes32 policyName) internal view virtual returns (uint64) {
+    function _readPolicyId(bytes32 policyScope) internal view virtual returns (uint64) {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
-        if (policyName == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);
-        if (policyName == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);
-        if (policyName == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);
-        if (policyName == MINT_RECEIVER_POLICY) return uint64($.mintPolicyIds);
-        revert UnsupportedPolicyType(policyName);
+        if (policyScope == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);
+        if (policyScope == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);
+        if (policyScope == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);
+        if (policyScope == MINT_RECEIVER_POLICY) return uint64($.mintPolicyIds);
+        revert UnsupportedPolicyType(policyScope);
     }
 
     /// @dev Writes a policy ID to storage. Hot-path types update their
@@ -403,19 +403,19 @@ contract MockB20 is IB20 {
     ///      Variants override to handle their own policy types before
     ///      falling through to `super`. Mask + shift are explicit so
     ///      the Rust impl can replicate the exact bit layout.
-    function _writePolicyId(bytes32 policyName, uint64 newPolicyId) internal virtual {
+    function _writePolicyId(bytes32 policyScope, uint64 newPolicyId) internal virtual {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         uint256 mask = uint256(type(uint64).max);
-        if (policyName == TRANSFER_SENDER_POLICY) {
+        if (policyScope == TRANSFER_SENDER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);
-        } else if (policyName == TRANSFER_RECEIVER_POLICY) {
+        } else if (policyScope == TRANSFER_RECEIVER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
-        } else if (policyName == TRANSFER_EXECUTOR_POLICY) {
+        } else if (policyScope == TRANSFER_EXECUTOR_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
-        } else if (policyName == MINT_RECEIVER_POLICY) {
+        } else if (policyScope == MINT_RECEIVER_POLICY) {
             $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);
         } else {
-            revert UnsupportedPolicyType(policyName);
+            revert UnsupportedPolicyType(policyScope);
         }
     }
 

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -361,22 +361,22 @@ contract MockB20 is IB20 {
     //                            POLICY
     // ============================================================
 
-    function policyId(bytes32 policyType) external view returns (uint64) {
-        return _readPolicyId(policyType);
+    function policyId(bytes32 policyName) external view returns (uint64) {
+        return _readPolicyId(policyName);
     }
 
-    function updatePolicy(bytes32 policyType, uint64 newPolicyId) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updatePolicy(bytes32 policyName, uint64 newPolicyId) external onlyRole(DEFAULT_ADMIN_ROLE) {
         // Read the old ID for the event payload. Reverts
         // `UnsupportedPolicyType` here if the type has no slot on this token.
-        uint64 oldPolicyId = _readPolicyId(policyType);
+        uint64 oldPolicyId = _readPolicyId(policyName);
         // Existence check at write time is what lets `isAuthorized` skip
         // its own existence SLOAD on the hot path. `policyExists` rejects
         // both unknown and malformed IDs.
         if (!IPolicyRegistry(POLICY_REGISTRY).policyExists(newPolicyId)) {
             revert PolicyNotFound(newPolicyId);
         }
-        _writePolicyId(policyType, newPolicyId);
-        emit PolicyUpdated(policyType, oldPolicyId, newPolicyId);
+        _writePolicyId(policyName, newPolicyId);
+        emit PolicyUpdated(policyName, oldPolicyId, newPolicyId);
     }
 
     /// @dev Reads a policy ID from storage. Each supported policy type
@@ -387,13 +387,13 @@ contract MockB20 is IB20 {
     ///      masquerade as "no restriction". Variants that add their own
     ///      policy types override this to check their own slots before
     ///      falling through to `super`.
-    function _readPolicyId(bytes32 policyType) internal view virtual returns (uint64) {
+    function _readPolicyId(bytes32 policyName) internal view virtual returns (uint64) {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
-        if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);
-        if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);
-        if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);
-        if (policyType == MINT_RECEIVER_POLICY) return uint64($.mintPolicyIds);
-        revert UnsupportedPolicyType(policyType);
+        if (policyName == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);
+        if (policyName == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);
+        if (policyName == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);
+        if (policyName == MINT_RECEIVER_POLICY) return uint64($.mintPolicyIds);
+        revert UnsupportedPolicyType(policyName);
     }
 
     /// @dev Writes a policy ID to storage. Hot-path types update their
@@ -403,19 +403,19 @@ contract MockB20 is IB20 {
     ///      Variants override to handle their own policy types before
     ///      falling through to `super`. Mask + shift are explicit so
     ///      the Rust impl can replicate the exact bit layout.
-    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual {
+    function _writePolicyId(bytes32 policyName, uint64 newPolicyId) internal virtual {
         MockB20Storage.Layout storage $ = MockB20Storage.layout();
         uint256 mask = uint256(type(uint64).max);
-        if (policyType == TRANSFER_SENDER_POLICY) {
+        if (policyName == TRANSFER_SENDER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);
-        } else if (policyType == TRANSFER_RECEIVER_POLICY) {
+        } else if (policyName == TRANSFER_RECEIVER_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);
-        } else if (policyType == TRANSFER_EXECUTOR_POLICY) {
+        } else if (policyName == TRANSFER_EXECUTOR_POLICY) {
             $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);
-        } else if (policyType == MINT_RECEIVER_POLICY) {
+        } else if (policyName == MINT_RECEIVER_POLICY) {
             $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);
         } else {
-            revert UnsupportedPolicyType(policyType);
+            revert UnsupportedPolicyType(policyName);
         }
     }
 

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -253,21 +253,21 @@ contract MockB20Security is MockB20, IB20Security {
     ///      this variant's own packed slot; everything else falls
     ///      through to the base. The base's UnsupportedPolicyType
     ///      revert is the terminal case.
-    function _readPolicyId(bytes32 policyName) internal view virtual override returns (uint64) {
-        if (policyName == REDEEM_SENDER_POLICY) {
+    function _readPolicyId(bytes32 policyScope) internal view virtual override returns (uint64) {
+        if (policyScope == REDEEM_SENDER_POLICY) {
             return uint64(MockB20RedeemStorage.layout().redeemPolicyIds);
         }
-        return super._readPolicyId(policyName);
+        return super._readPolicyId(policyScope);
     }
 
-    function _writePolicyId(bytes32 policyName, uint64 newPolicyId) internal virtual override {
-        if (policyName == REDEEM_SENDER_POLICY) {
+    function _writePolicyId(bytes32 policyScope, uint64 newPolicyId) internal virtual override {
+        if (policyScope == REDEEM_SENDER_POLICY) {
             MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
             uint256 mask = uint256(type(uint64).max);
             $.redeemPolicyIds = ($.redeemPolicyIds & ~mask) | uint256(newPolicyId);
             return;
         }
-        super._writePolicyId(policyName, newPolicyId);
+        super._writePolicyId(policyScope, newPolicyId);
     }
 
     // ============================================================

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -253,21 +253,21 @@ contract MockB20Security is MockB20, IB20Security {
     ///      this variant's own packed slot; everything else falls
     ///      through to the base. The base's UnsupportedPolicyType
     ///      revert is the terminal case.
-    function _readPolicyId(bytes32 policyType) internal view virtual override returns (uint64) {
-        if (policyType == REDEEM_SENDER_POLICY) {
+    function _readPolicyId(bytes32 policyName) internal view virtual override returns (uint64) {
+        if (policyName == REDEEM_SENDER_POLICY) {
             return uint64(MockB20RedeemStorage.layout().redeemPolicyIds);
         }
-        return super._readPolicyId(policyType);
+        return super._readPolicyId(policyName);
     }
 
-    function _writePolicyId(bytes32 policyType, uint64 newPolicyId) internal virtual override {
-        if (policyType == REDEEM_SENDER_POLICY) {
+    function _writePolicyId(bytes32 policyName, uint64 newPolicyId) internal virtual override {
+        if (policyName == REDEEM_SENDER_POLICY) {
             MockB20RedeemStorage.Layout storage $ = MockB20RedeemStorage.layout();
             uint256 mask = uint256(type(uint64).max);
             $.redeemPolicyIds = ($.redeemPolicyIds & ~mask) | uint256(newPolicyId);
             return;
         }
-        super._writePolicyId(policyType, newPolicyId);
+        super._writePolicyId(policyName, newPolicyId);
     }
 
     // ============================================================

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -10,9 +10,9 @@ contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns 0 (always-allow built-in) for any supported slot before configuration
     /// @dev Default state: newly-created tokens are unrestricted across all supported policy slots
     function test_policyId_success_zeroByDefault(uint8 typeIdx) public view {
-        bytes32 policyName = _knownPolicyType(typeIdx);
+        bytes32 policyScope = _knownPolicyType(typeIdx);
         assertEq(
-            token.policyId(policyName),
+            token.policyId(policyScope),
             PolicyRegistryConstants.ALWAYS_ALLOW_ID,
             "unconfigured supported slot must default to ALWAYS_ALLOW_ID (0)"
         );
@@ -21,22 +21,22 @@ contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns the value most recently set via updatePolicy
     /// @dev Read-after-write across all supported policy types
     function test_policyId_success_reflectsUpdatePolicy(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
+        bytes32 policyScope = _knownPolicyType(typeIdx);
         // MockPolicyRegistry only knows the two built-in sentinel ids.
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
-        _setPolicy(policyName, newPolicyId);
-        assertEq(token.policyId(policyName), newPolicyId, "slot must reflect updatePolicy");
+        _setPolicy(policyScope, newPolicyId);
+        assertEq(token.policyId(policyScope), newPolicyId, "slot must reflect updatePolicy");
     }
 
-    /// @notice Verifies policyId reverts UnsupportedPolicyType for any policyName
+    /// @notice Verifies policyId reverts UnsupportedPolicyType for any policyScope
     ///         outside the token's supported set.
     /// @dev Reads are strict: there is no fallback storage, and silently returning
     ///      0 (ALWAYS_ALLOW) for an unsupported type would let a typo'd query
     ///      masquerade as "no restriction". Both reads and writes revert symmetrically.
-    function test_policyId_revert_unsupportedPolicyType(bytes32 policyName) public {
-        vm.assume(!_isKnownPolicyType(policyName));
-        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyName));
-        token.policyId(policyName);
+    function test_policyId_revert_unsupportedPolicyType(bytes32 policyScope) public {
+        vm.assume(!_isKnownPolicyType(policyScope));
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyScope));
+        token.policyId(policyScope);
     }
 }

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -10,9 +10,9 @@ contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns 0 (always-allow built-in) for any supported slot before configuration
     /// @dev Default state: newly-created tokens are unrestricted across all supported policy slots
     function test_policyId_success_zeroByDefault(uint8 typeIdx) public view {
-        bytes32 policyType = _knownPolicyType(typeIdx);
+        bytes32 policyName = _knownPolicyType(typeIdx);
         assertEq(
-            token.policyId(policyType),
+            token.policyId(policyName),
             PolicyRegistryConstants.ALWAYS_ALLOW_ID,
             "unconfigured supported slot must default to ALWAYS_ALLOW_ID (0)"
         );
@@ -21,22 +21,22 @@ contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns the value most recently set via updatePolicy
     /// @dev Read-after-write across all supported policy types
     function test_policyId_success_reflectsUpdatePolicy(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
+        bytes32 policyName = _knownPolicyType(typeIdx);
         // MockPolicyRegistry only knows the two built-in sentinel ids.
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
-        _setPolicy(policyType, newPolicyId);
-        assertEq(token.policyId(policyType), newPolicyId, "slot must reflect updatePolicy");
+        _setPolicy(policyName, newPolicyId);
+        assertEq(token.policyId(policyName), newPolicyId, "slot must reflect updatePolicy");
     }
 
-    /// @notice Verifies policyId reverts UnsupportedPolicyType for any policyType
+    /// @notice Verifies policyId reverts UnsupportedPolicyType for any policyName
     ///         outside the token's supported set.
     /// @dev Reads are strict: there is no fallback storage, and silently returning
     ///      0 (ALWAYS_ALLOW) for an unsupported type would let a typo'd query
     ///      masquerade as "no restriction". Both reads and writes revert symmetrically.
-    function test_policyId_revert_unsupportedPolicyType(bytes32 policyType) public {
-        vm.assume(!_isKnownPolicyType(policyType));
-        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyType));
-        token.policyId(policyType);
+    function test_policyId_revert_unsupportedPolicyType(bytes32 policyName) public {
+        vm.assume(!_isKnownPolicyType(policyName));
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyName));
+        token.policyId(policyName);
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -10,7 +10,7 @@ import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPo
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Reads the policy id stored in the slot lane that
-    ///         corresponds to `policyName`, via raw `vm.load` and the
+    ///         corresponds to `policyScope`, via raw `vm.load` and the
     ///         per-lane decoder helpers on `MockB20Storage`.
     /// @dev    The four base-token policy types are packed across two
     ///         slots:
@@ -18,19 +18,19 @@ contract B20UpdatePolicyTest is B20Test {
     ///         - `mintPolicyIds` (lane 0: RECEIVER)
     ///         This helper routes to the right slot + lane decoder so
     ///         tests can assert the slot reflects the surface
-    ///         `policyId(policyName)` return.
-    function _readPolicyLane(bytes32 policyName) internal view returns (uint64) {
-        if (policyName == B20Constants.MINT_RECEIVER_POLICY) {
+    ///         `policyId(policyScope)` return.
+    function _readPolicyLane(bytes32 policyScope) internal view returns (uint64) {
+        if (policyScope == B20Constants.MINT_RECEIVER_POLICY) {
             return
                 MockB20Storage.mintReceiverPolicyId(
                     uint256(vm.load(address(token), MockB20Storage.mintPolicyIdsSlot()))
                 );
         }
         uint256 transferPacked = uint256(vm.load(address(token), MockB20Storage.transferPolicyIdsSlot()));
-        if (policyName == B20Constants.TRANSFER_SENDER_POLICY) {
+        if (policyScope == B20Constants.TRANSFER_SENDER_POLICY) {
             return MockB20Storage.transferSenderPolicyId(transferPacked);
         }
-        if (policyName == B20Constants.TRANSFER_RECEIVER_POLICY) {
+        if (policyScope == B20Constants.TRANSFER_RECEIVER_POLICY) {
             return MockB20Storage.transferReceiverPolicyId(transferPacked);
         }
         // TRANSFER_EXECUTOR — the four supported types are exhaustive
@@ -42,7 +42,7 @@ contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only the admin may reassign policy slots; checks AccessControlUnauthorizedAccount.
     ///      Auth fires before policy-type / registry checks, so any bytes32 fuzz is fine here.
-    function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyName, uint64 newPolicyId) public {
+    function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyScope, uint64 newPolicyId) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);
 
@@ -52,7 +52,7 @@ contract B20UpdatePolicyTest is B20Test {
                 IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
             )
         );
-        token.updatePolicy(policyName, newPolicyId);
+        token.updatePolicy(policyScope, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy reverts when the target policy id does not exist in the registry
@@ -60,40 +60,40 @@ contract B20UpdatePolicyTest is B20Test {
     ///      uncreated registry IDs so the registry-side malformed check passes and the
     ///      not-found path fires from MockB20.
     function test_updatePolicy_revert_policyNotFound(uint8 typeIdx, uint64 seed) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
+        bytes32 policyScope = _knownPolicyType(typeIdx);
         uint64 newPolicyId = _wellFormedUncreatedPolicyId(seed);
 
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));
-        token.updatePolicy(policyName, newPolicyId);
+        token.updatePolicy(policyScope, newPolicyId);
     }
 
-    /// @notice Verifies updatePolicy reverts when the policyName is not one of the base-token's
+    /// @notice Verifies updatePolicy reverts when the policyScope is not one of the base-token's
     ///         four supported types and is not added by a variant.
     /// @dev Strictness on writes: there is no fallback mapping, so unsupported policyTypes are
     ///      rejected explicitly. Uses a built-in policy id so the registry check passes; the
     ///      revert must come from `_writePolicyId`'s UnsupportedPolicyType branch.
-    function test_updatePolicy_revert_unsupportedPolicyType(bytes32 policyName, uint64 newPolicyIdSeed) public {
-        vm.assume(!_isKnownPolicyType(policyName));
+    function test_updatePolicy_revert_unsupportedPolicyType(bytes32 policyScope, uint64 newPolicyIdSeed) public {
+        vm.assume(!_isKnownPolicyType(policyScope));
         uint64 newPolicyId = newPolicyIdSeed % 2 == 0
             ? PolicyRegistryConstants.ALWAYS_ALLOW_ID
             : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.prank(admin);
-        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyName));
-        token.updatePolicy(policyName, newPolicyId);
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyScope));
+        token.updatePolicy(policyScope, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
     /// @dev Built-ins are always valid targets across all supported policy types.
     ///      Paired slot assertion: the packed slot lane corresponding
-    ///      to `policyName` reads back as ALWAYS_ALLOW_ID.
+    ///      to `policyScope` reads back as ALWAYS_ALLOW_ID.
     function test_updatePolicy_success_builtinAllow(uint8 typeIdx) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
-        _setPolicy(policyName, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
-        assertEq(token.policyId(policyName), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be ALWAYS_ALLOW_ID");
+        bytes32 policyScope = _knownPolicyType(typeIdx);
+        _setPolicy(policyScope, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        assertEq(token.policyId(policyScope), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be ALWAYS_ALLOW_ID");
         assertEq(
-            _readPolicyLane(policyName),
+            _readPolicyLane(policyScope),
             PolicyRegistryConstants.ALWAYS_ALLOW_ID,
             "packed-slot lane must hold ALWAYS_ALLOW_ID"
         );
@@ -103,27 +103,27 @@ contract B20UpdatePolicyTest is B20Test {
     /// @dev Built-ins are always valid targets across all supported policy types.
     ///      Paired slot assertion confirms the packed-slot lane reflects the write.
     function test_updatePolicy_success_builtinReject(uint8 typeIdx) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
-        _setPolicy(policyName, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        assertEq(token.policyId(policyName), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be ALWAYS_BLOCK_ID");
+        bytes32 policyScope = _knownPolicyType(typeIdx);
+        _setPolicy(policyScope, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        assertEq(token.policyId(policyScope), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be ALWAYS_BLOCK_ID");
         assertEq(
-            _readPolicyLane(policyName),
+            _readPolicyLane(policyScope),
             PolicyRegistryConstants.ALWAYS_BLOCK_ID,
             "packed-slot lane must hold ALWAYS_BLOCK_ID"
         );
     }
 
     /// @notice Verifies updatePolicy writes the new id to the slot
-    /// @dev Read-after-write: policyId(policyName) returns newPolicyId.
+    /// @dev Read-after-write: policyId(policyScope) returns newPolicyId.
     ///      Paired slot assertion confirms the packed-slot lane reflects newPolicyId.
     function test_updatePolicy_success_writesSlot(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
+        bytes32 policyScope = _knownPolicyType(typeIdx);
         // Bound to a registry-supported id.
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
-        _setPolicy(policyName, newPolicyId);
-        assertEq(token.policyId(policyName), newPolicyId, "slot must equal newPolicyId after write");
-        assertEq(_readPolicyLane(policyName), newPolicyId, "packed-slot lane must equal newPolicyId");
+        _setPolicy(policyScope, newPolicyId);
+        assertEq(token.policyId(policyScope), newPolicyId, "slot must equal newPolicyId after write");
+        assertEq(_readPolicyLane(policyScope), newPolicyId, "packed-slot lane must equal newPolicyId");
     }
 
     /// @notice Verifies updatePolicy on one lane leaves other lanes unchanged
@@ -190,16 +190,16 @@ contract B20UpdatePolicyTest is B20Test {
         );
     }
 
-    /// @notice Verifies updatePolicy emits PolicyUpdated(policyName, oldId, newId)
+    /// @notice Verifies updatePolicy emits PolicyUpdated(policyScope, oldId, newId)
     /// @dev Event integrity; canonical PolicyUpdated emission test.
     ///      Fresh slot has oldId == ALWAYS_ALLOW_ID (0); the first write transitions from there.
     function test_updatePolicy_success_emitsPolicyUpdated(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyName = _knownPolicyType(typeIdx);
+        bytes32 policyScope = _knownPolicyType(typeIdx);
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.expectEmit(true, false, false, true, address(token));
-        emit IB20.PolicyUpdated(policyName, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);
-        _setPolicy(policyName, newPolicyId);
+        emit IB20.PolicyUpdated(policyScope, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);
+        _setPolicy(policyScope, newPolicyId);
     }
 }

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -10,7 +10,7 @@ import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPo
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Reads the policy id stored in the slot lane that
-    ///         corresponds to `policyType`, via raw `vm.load` and the
+    ///         corresponds to `policyName`, via raw `vm.load` and the
     ///         per-lane decoder helpers on `MockB20Storage`.
     /// @dev    The four base-token policy types are packed across two
     ///         slots:
@@ -18,19 +18,19 @@ contract B20UpdatePolicyTest is B20Test {
     ///         - `mintPolicyIds` (lane 0: RECEIVER)
     ///         This helper routes to the right slot + lane decoder so
     ///         tests can assert the slot reflects the surface
-    ///         `policyId(policyType)` return.
-    function _readPolicyLane(bytes32 policyType) internal view returns (uint64) {
-        if (policyType == B20Constants.MINT_RECEIVER_POLICY) {
+    ///         `policyId(policyName)` return.
+    function _readPolicyLane(bytes32 policyName) internal view returns (uint64) {
+        if (policyName == B20Constants.MINT_RECEIVER_POLICY) {
             return
                 MockB20Storage.mintReceiverPolicyId(
                     uint256(vm.load(address(token), MockB20Storage.mintPolicyIdsSlot()))
                 );
         }
         uint256 transferPacked = uint256(vm.load(address(token), MockB20Storage.transferPolicyIdsSlot()));
-        if (policyType == B20Constants.TRANSFER_SENDER_POLICY) {
+        if (policyName == B20Constants.TRANSFER_SENDER_POLICY) {
             return MockB20Storage.transferSenderPolicyId(transferPacked);
         }
-        if (policyType == B20Constants.TRANSFER_RECEIVER_POLICY) {
+        if (policyName == B20Constants.TRANSFER_RECEIVER_POLICY) {
             return MockB20Storage.transferReceiverPolicyId(transferPacked);
         }
         // TRANSFER_EXECUTOR — the four supported types are exhaustive
@@ -42,7 +42,7 @@ contract B20UpdatePolicyTest is B20Test {
     /// @notice Verifies updatePolicy reverts when caller lacks DEFAULT_ADMIN_ROLE
     /// @dev Access control: only the admin may reassign policy slots; checks AccessControlUnauthorizedAccount.
     ///      Auth fires before policy-type / registry checks, so any bytes32 fuzz is fine here.
-    function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyType, uint64 newPolicyId) public {
+    function test_updatePolicy_revert_unauthorized(address caller, bytes32 policyName, uint64 newPolicyId) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);
 
@@ -52,7 +52,7 @@ contract B20UpdatePolicyTest is B20Test {
                 IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
             )
         );
-        token.updatePolicy(policyType, newPolicyId);
+        token.updatePolicy(policyName, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy reverts when the target policy id does not exist in the registry
@@ -60,40 +60,40 @@ contract B20UpdatePolicyTest is B20Test {
     ///      uncreated registry IDs so the registry-side malformed check passes and the
     ///      not-found path fires from MockB20.
     function test_updatePolicy_revert_policyNotFound(uint8 typeIdx, uint64 seed) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
+        bytes32 policyName = _knownPolicyType(typeIdx);
         uint64 newPolicyId = _wellFormedUncreatedPolicyId(seed);
 
         vm.prank(admin);
         vm.expectRevert(abi.encodeWithSelector(IB20.PolicyNotFound.selector, newPolicyId));
-        token.updatePolicy(policyType, newPolicyId);
+        token.updatePolicy(policyName, newPolicyId);
     }
 
-    /// @notice Verifies updatePolicy reverts when the policyType is not one of the base-token's
+    /// @notice Verifies updatePolicy reverts when the policyName is not one of the base-token's
     ///         four supported types and is not added by a variant.
     /// @dev Strictness on writes: there is no fallback mapping, so unsupported policyTypes are
     ///      rejected explicitly. Uses a built-in policy id so the registry check passes; the
     ///      revert must come from `_writePolicyId`'s UnsupportedPolicyType branch.
-    function test_updatePolicy_revert_unsupportedPolicyType(bytes32 policyType, uint64 newPolicyIdSeed) public {
-        vm.assume(!_isKnownPolicyType(policyType));
+    function test_updatePolicy_revert_unsupportedPolicyType(bytes32 policyName, uint64 newPolicyIdSeed) public {
+        vm.assume(!_isKnownPolicyType(policyName));
         uint64 newPolicyId = newPolicyIdSeed % 2 == 0
             ? PolicyRegistryConstants.ALWAYS_ALLOW_ID
             : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.prank(admin);
-        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyType));
-        token.updatePolicy(policyType, newPolicyId);
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, policyName));
+        token.updatePolicy(policyName, newPolicyId);
     }
 
     /// @notice Verifies updatePolicy succeeds for built-in id 0 (always-allow)
     /// @dev Built-ins are always valid targets across all supported policy types.
     ///      Paired slot assertion: the packed slot lane corresponding
-    ///      to `policyType` reads back as ALWAYS_ALLOW_ID.
+    ///      to `policyName` reads back as ALWAYS_ALLOW_ID.
     function test_updatePolicy_success_builtinAllow(uint8 typeIdx) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
-        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
-        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be ALWAYS_ALLOW_ID");
+        bytes32 policyName = _knownPolicyType(typeIdx);
+        _setPolicy(policyName, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        assertEq(token.policyId(policyName), PolicyRegistryConstants.ALWAYS_ALLOW_ID, "slot must be ALWAYS_ALLOW_ID");
         assertEq(
-            _readPolicyLane(policyType),
+            _readPolicyLane(policyName),
             PolicyRegistryConstants.ALWAYS_ALLOW_ID,
             "packed-slot lane must hold ALWAYS_ALLOW_ID"
         );
@@ -103,27 +103,27 @@ contract B20UpdatePolicyTest is B20Test {
     /// @dev Built-ins are always valid targets across all supported policy types.
     ///      Paired slot assertion confirms the packed-slot lane reflects the write.
     function test_updatePolicy_success_builtinReject(uint8 typeIdx) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
-        _setPolicy(policyType, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
-        assertEq(token.policyId(policyType), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be ALWAYS_BLOCK_ID");
+        bytes32 policyName = _knownPolicyType(typeIdx);
+        _setPolicy(policyName, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        assertEq(token.policyId(policyName), PolicyRegistryConstants.ALWAYS_BLOCK_ID, "slot must be ALWAYS_BLOCK_ID");
         assertEq(
-            _readPolicyLane(policyType),
+            _readPolicyLane(policyName),
             PolicyRegistryConstants.ALWAYS_BLOCK_ID,
             "packed-slot lane must hold ALWAYS_BLOCK_ID"
         );
     }
 
     /// @notice Verifies updatePolicy writes the new id to the slot
-    /// @dev Read-after-write: policyId(policyType) returns newPolicyId.
+    /// @dev Read-after-write: policyId(policyName) returns newPolicyId.
     ///      Paired slot assertion confirms the packed-slot lane reflects newPolicyId.
     function test_updatePolicy_success_writesSlot(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
+        bytes32 policyName = _knownPolicyType(typeIdx);
         // Bound to a registry-supported id.
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
-        _setPolicy(policyType, newPolicyId);
-        assertEq(token.policyId(policyType), newPolicyId, "slot must equal newPolicyId after write");
-        assertEq(_readPolicyLane(policyType), newPolicyId, "packed-slot lane must equal newPolicyId");
+        _setPolicy(policyName, newPolicyId);
+        assertEq(token.policyId(policyName), newPolicyId, "slot must equal newPolicyId after write");
+        assertEq(_readPolicyLane(policyName), newPolicyId, "packed-slot lane must equal newPolicyId");
     }
 
     /// @notice Verifies updatePolicy on one lane leaves other lanes unchanged
@@ -190,16 +190,16 @@ contract B20UpdatePolicyTest is B20Test {
         );
     }
 
-    /// @notice Verifies updatePolicy emits PolicyUpdated(policyType, oldId, newId)
+    /// @notice Verifies updatePolicy emits PolicyUpdated(policyName, oldId, newId)
     /// @dev Event integrity; canonical PolicyUpdated emission test.
     ///      Fresh slot has oldId == ALWAYS_ALLOW_ID (0); the first write transitions from there.
     function test_updatePolicy_success_emitsPolicyUpdated(uint8 typeIdx, uint64 newPolicyId) public {
-        bytes32 policyType = _knownPolicyType(typeIdx);
+        bytes32 policyName = _knownPolicyType(typeIdx);
         newPolicyId =
             newPolicyId % 2 == 0 ? PolicyRegistryConstants.ALWAYS_ALLOW_ID : PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
         vm.expectEmit(true, false, false, true, address(token));
-        emit IB20.PolicyUpdated(policyType, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);
-        _setPolicy(policyType, newPolicyId);
+        emit IB20.PolicyUpdated(policyName, PolicyRegistryConstants.ALWAYS_ALLOW_ID, newPolicyId);
+        _setPolicy(policyName, newPolicyId);
     }
 }

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -72,7 +72,7 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         any DEFAULT_ADMIN_ROLE-gated call) covers updateSupplyCap, updateContractURI,
     ///         updateName, updateSymbol, grantRole / revokeRole / setRoleAdmin for any role.
     ///         No test should be able to reinstate an admin after this transition.
-    function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyType, uint64 newPolicyId) public {
+    function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyName, uint64 newPolicyId) public {
         // Use a built-in policy ID so updatePolicy gets past policyExists() and would
         // otherwise succeed; the revert here is from the role check, not policy validation.
         newPolicyId =
@@ -88,7 +88,7 @@ contract B20RenounceLastAdminTest is B20Test {
                 IB20.AccessControlUnauthorizedAccount.selector, admin, B20Constants.DEFAULT_ADMIN_ROLE
             )
         );
-        token.updatePolicy(policyType, newPolicyId);
+        token.updatePolicy(policyName, newPolicyId);
     }
 
     /// @notice Verifies grantRole(DEFAULT_ADMIN_ROLE, ...) cannot succeed post-renunciation

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -72,7 +72,7 @@ contract B20RenounceLastAdminTest is B20Test {
     ///         any DEFAULT_ADMIN_ROLE-gated call) covers updateSupplyCap, updateContractURI,
     ///         updateName, updateSymbol, grantRole / revokeRole / setRoleAdmin for any role.
     ///         No test should be able to reinstate an admin after this transition.
-    function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyName, uint64 newPolicyId) public {
+    function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyScope, uint64 newPolicyId) public {
         // Use a built-in policy ID so updatePolicy gets past policyExists() and would
         // otherwise succeed; the revert here is from the role check, not policy validation.
         newPolicyId =
@@ -88,7 +88,7 @@ contract B20RenounceLastAdminTest is B20Test {
                 IB20.AccessControlUnauthorizedAccount.selector, admin, B20Constants.DEFAULT_ADMIN_ROLE
             )
         );
-        token.updatePolicy(policyName, newPolicyId);
+        token.updatePolicy(policyScope, newPolicyId);
     }
 
     /// @notice Verifies grantRole(DEFAULT_ADMIN_ROLE, ...) cannot succeed post-renunciation

--- a/test/unit/B20Security/policy/updatePolicy.t.sol
+++ b/test/unit/B20Security/policy/updatePolicy.t.sol
@@ -12,7 +12,7 @@ import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 contract B20SecurityUpdatePolicyTest is B20SecurityTest {
     /// @notice Verifies updatePolicy(REDEEM_SENDER_POLICY, ...) reverts when caller lacks admin
     /// @dev Access control inherited from base: updatePolicy is `onlyRole(DEFAULT_ADMIN_ROLE)`
-    ///      regardless of which policyType is being written.
+    ///      regardless of which policyName is being written.
     function test_updatePolicy_revert_unauthorized_redeemSender(address caller, bool useBlock) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);

--- a/test/unit/B20Security/policy/updatePolicy.t.sol
+++ b/test/unit/B20Security/policy/updatePolicy.t.sol
@@ -12,7 +12,7 @@ import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 contract B20SecurityUpdatePolicyTest is B20SecurityTest {
     /// @notice Verifies updatePolicy(REDEEM_SENDER_POLICY, ...) reverts when caller lacks admin
     /// @dev Access control inherited from base: updatePolicy is `onlyRole(DEFAULT_ADMIN_ROLE)`
-    ///      regardless of which policyName is being written.
+    ///      regardless of which policyScope is being written.
     function test_updatePolicy_revert_unauthorized_redeemSender(address caller, bool useBlock) public {
         _assumeValidCaller(caller);
         vm.assume(caller != admin);


### PR DESCRIPTION
## Motivation

- The `bytes32 policyType` parameter on the token side (the slot identifier passed to `policyId()` and `updatePolicy()`) collides semantically with `PolicyType` in `IPolicyRegistry`, which is a `BLOCKLIST`/`ALLOWLIST` enum.
- They are completely unrelated: the registry's `PolicyType` describes the membership mechanism; the token's `policyType` identifies which authorization gate is being configured (e.g. `keccak256("TRANSFER_SENDER_POLICY")`).
- The collision makes reading cross-interface code confusing — the same word means two different things depending on which interface you're looking at.

## What changed

- `bytes32 policyType` -> `bytes32 policyScope` in `IB20.sol` and `IB20Security.sol` (function params, event fields, error fields, NatSpec).
- Same rename in `MockB20.sol`, `MockB20Security.sol`, and all `test/unit/B20/policy/` tests.
- `IPolicyRegistry.sol` and its `PolicyType` enum are untouched.

440 tests pass unchanged.

## What was tried / considered

- `policySlot`: accurate (it is a storage slot identifier) but slightly internal-sounding.
- `policyName`: conveys the named-key aspect but `policyScope` better captures that the identifier defines the *scope* or *domain* of authorization (transfer, mint, redeem) rather than just being a name label.
- `policyKey`: neutral and correct, but less descriptive than `policyScope`.
- Leaving it unchanged: the collision with `PolicyType` is subtle but real and creates confusion when reading code that spans both interfaces.