### PR TITLE
feat: gate updateContractURI on METADATA_ROLE instead of DEFAULT_ADMIN_ROLE

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -311,10 +311,10 @@ interface IB20 {
     ///         previousAdmin)` event. Signals the irreversible
     ///         transition of the token to a permanently adminless
     ///         state: no `grantRole`, `revokeRole`, `setRoleAdmin`,
-    ///         `updatePolicy`, `updateSupplyCap`, or `updateContractURI` call
-    ///         can ever succeed again. Existing role holders
-    ///         (`MINT_ROLE`, `BURN_ROLE`, `METADATA_ROLE`, etc.) retain
-    ///         their abilities, but no new grants are possible.
+    ///         `updatePolicy`, or `updateSupplyCap` call can ever
+    ///         succeed again. Existing role holders (`MINT_ROLE`,
+    ///         `BURN_ROLE`, `METADATA_ROLE`, etc.) retain their
+    ///         abilities, but no new grants are possible.
     ///         Indexers should treat this event as a one-way state
     ///         transition.
     event LastAdminRenounced(address indexed previousAdmin);
@@ -374,9 +374,9 @@ interface IB20 {
     /// @notice The default top-level admin role, equal to `bytes32(0)` per
     ///         the OpenZeppelin AccessControl convention. The admin
     ///         manages all other roles via `grantRole`, `revokeRole`, and
-    ///         `setRoleAdmin`. The admin can also `updatePolicy`,
-    ///         `updateSupplyCap`, and `updateContractURI`. Name and symbol
-    ///         updates are gated by `METADATA_ROLE`, not by this role.
+    ///         `setRoleAdmin`. The admin can also `updatePolicy` and
+    ///         `updateSupplyCap`. Name, symbol, and `contractURI` updates
+    ///         are gated by `METADATA_ROLE`, not by this role.
     /// @dev    There is NO two-step delay-protected transfer for this
     ///         role. `grantRole(DEFAULT_ADMIN_ROLE, ...)` and
     ///         `revokeRole(DEFAULT_ADMIN_ROLE, ...)` work uniformly.
@@ -412,13 +412,14 @@ interface IB20 {
     ///         action than the pause itself.
     function UNPAUSE_ROLE() external view returns (bytes32);
 
-    /// @notice Required to call `updateName` and `updateSymbol`. Held
-    ///         separately from `DEFAULT_ADMIN_ROLE` so the authority to
-    ///         re-brand or legally-restructure the token can be
-    ///         delegated to a metadata operator (e.g. corporate-actions
-    ///         desk for security tokens) without granting the broader
-    ///         admin powers (role grants, policy changes, supply-cap
-    ///         changes, etc.).
+    /// @notice Required to call `updateName`, `updateSymbol`, and
+    ///         `updateContractURI`. Held separately from
+    ///         `DEFAULT_ADMIN_ROLE` so the authority to re-brand or
+    ///         legally-restructure the token can be delegated to a
+    ///         metadata operator (e.g. corporate-actions desk for
+    ///         security tokens) without granting the broader admin
+    ///         powers (role grants, policy changes, supply-cap changes,
+    ///         etc.).
     function METADATA_ROLE() external view returns (bytes32);
 
     /*//////////////////////////////////////////////////////////////
@@ -659,10 +660,10 @@ interface IB20 {
     ///         reinstated: `grantRole(DEFAULT_ADMIN_ROLE, ...)` would
     ///         require an admin caller and there is none. All
     ///         admin-gated operations (`updatePolicy`, `updateSupplyCap`,
-    ///         `updateContractURI`, and any `grantRole` / `revokeRole` /
-    ///         `setRoleAdmin` for other roles) become permanently
-    ///         uncallable. Operations gated by other roles
-    ///         (`updateName` / `updateSymbol` via `METADATA_ROLE`, `mint` via
+    ///         and any `grantRole` / `revokeRole` / `setRoleAdmin` for
+    ///         other roles) become permanently uncallable. Operations
+    ///         gated by other roles (`updateName` / `updateSymbol` /
+    ///         `updateContractURI` via `METADATA_ROLE`, `mint` via
     ///         `MINT_ROLE`, etc.) remain callable by their existing
     ///         role holders, but no new grants for those roles are
     ///         possible.
@@ -825,7 +826,7 @@ interface IB20 {
     ///         this token, per ERC-7572.
     function contractURI() external view returns (string memory);
 
-    /// @notice Updates `contractURI`. Requires `DEFAULT_ADMIN_ROLE`. Emits
+    /// @notice Updates `contractURI`. Requires `METADATA_ROLE`. Emits
     ///         the parameterless `ContractURIUpdated` event per ERC-7572;
     ///         integrators re-fetch `contractURI()` after observing it.
     function updateContractURI(string calldata newURI) external;

--- a/src/interfaces/IB20Security.sol
+++ b/src/interfaces/IB20Security.sol
@@ -70,9 +70,9 @@ import {IB20} from "./IB20.sol";
 ///         **Announcement pairing.** Every state-changing operator
 ///         call that affects holder-visible token semantics
 ///         (`updateShareRatio`, `updateSecurityIdentifier`, `updateName`,
-///         `updateSymbol`, `batchMint`, `batchBurn`, and admin-level
-///         changes such as `updatePolicy` / `updateSupplyCap` /
-///         `updateContractURI` / `pause` / `unpause`) SHOULD be issued by
+///         `updateSymbol`, `updateContractURI`, `batchMint`, `batchBurn`,
+///         and admin-level changes such as `updatePolicy` /
+///         `updateSupplyCap` / `pause` / `unpause`) SHOULD be issued by
 ///         encoding the call into the `internalCalls` parameter of
 ///         `announce(...)`. The token then:
 ///         1. emits `Announcement(caller, id, description, uri)`,

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -528,7 +528,7 @@ contract MockB20 is IB20 {
         return MockB20Storage.layout().contractURI;
     }
 
-    function updateContractURI(string calldata newURI) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function updateContractURI(string calldata newURI) external onlyRole(METADATA_ROLE) {
         MockB20Storage.layout().contractURI = newURI;
         emit ContractURIUpdated();
     }

--- a/test/unit/B20/metadata/contractURI.t.sol
+++ b/test/unit/B20/metadata/contractURI.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {B20Test} from "test/lib/B20Test.sol";
+import {B20Constants} from "test/lib/mocks/MockB20.sol";
 
 contract B20ContractURITest is B20Test {
     /// @notice Verifies contractURI returns the value set at token creation
@@ -15,6 +16,7 @@ contract B20ContractURITest is B20Test {
     /// @notice Verifies contractURI reflects updates made via updateContractURI
     /// @dev Mutable-metadata readback; canonical setter test lives in updateContractURI.t.sol
     function test_contractURI_success_reflectsSetContractURI(string calldata newURI) public {
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.updateContractURI(newURI);
         assertEq(token.contractURI(), newURI, "contractURI must reflect updateContractURI");

--- a/test/unit/B20/metadata/updateContractURI.t.sol
+++ b/test/unit/B20/metadata/updateContractURI.t.sol
@@ -8,17 +8,19 @@ import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
 
 contract B20UpdateContractURITest is B20Test {
-    /// @notice Verifies updateContractURI reverts when caller lacks DEFAULT_ADMIN_ROLE
-    /// @dev Access control: only admin may update the URI; checks AccessControlUnauthorizedAccount
+    /// @notice Verifies updateContractURI reverts when caller lacks METADATA_ROLE
+    /// @dev Access control: only METADATA_ROLE holders may update the URI (separated
+    ///      from DEFAULT_ADMIN_ROLE per IB20 spec so metadata authority can be
+    ///      delegated to a corporate-actions desk). Checks AccessControlUnauthorizedAccount.
     function test_updateContractURI_revert_unauthorized(address caller, string calldata newURI) public {
         _assumeValidCaller(caller);
-        vm.assume(caller != admin);
+        // Admin doesn't hold METADATA_ROLE by default either; only filter out callers we've
+        // explicitly granted the role.
+        vm.assume(!token.hasRole(B20Constants.METADATA_ROLE, caller));
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
-            )
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.METADATA_ROLE)
         );
         token.updateContractURI(newURI);
     }
@@ -28,6 +30,7 @@ contract B20UpdateContractURITest is B20Test {
     ///      Paired slot assertion: the `contractURI` field slot holds
     ///      the Solidity-encoded string value byte-for-byte.
     function test_updateContractURI_success_updatesURI(string calldata newURI) public {
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.updateContractURI(newURI);
         assertEq(token.contractURI(), newURI, "contractURI() must return the new value");
@@ -41,6 +44,7 @@ contract B20UpdateContractURITest is B20Test {
     /// @notice Verifies updateContractURI emits ContractURIUpdated()
     /// @dev ERC-7572 convention: the event is argument-free; integrators refetch via contractURI()
     function test_updateContractURI_success_emitsContractURIUpdated(string calldata newURI) public {
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.expectEmit(false, false, false, false, address(token));
         emit IB20.ContractURIUpdated();
         vm.prank(admin);

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -69,8 +69,10 @@ contract B20RenounceLastAdminTest is B20Test {
     /// @notice Verifies admin-gated operations revert after renounceLastAdmin
     /// @dev    Permanent-immutability invariant. updatePolicy is the canonical example;
     ///         the same mechanism (no admin holder → AccessControlUnauthorizedAccount on
-    ///         any DEFAULT_ADMIN_ROLE-gated call) covers updateSupplyCap, updateContractURI,
-    ///         updateName, updateSymbol, grantRole / revokeRole / setRoleAdmin for any role.
+    ///         any DEFAULT_ADMIN_ROLE-gated call) covers updateSupplyCap and grantRole /
+    ///         revokeRole / setRoleAdmin for any role. (updateContractURI / updateName /
+    ///         updateSymbol are gated by METADATA_ROLE, not DEFAULT_ADMIN_ROLE, so existing
+    ///         METADATA_ROLE holders can keep calling them after renunciation.)
     ///         No test should be able to reinstate an admin after this transition.
     function test_renounceLastAdmin_success_subsequentAdminCallsRevert(bytes32 policyType, uint64 newPolicyId) public {
         // Use a built-in policy ID so updatePolicy gets past policyExists() and would

--- a/test/unit/storage/B20FullLayout.t.sol
+++ b/test/unit/storage/B20FullLayout.t.sol
@@ -193,6 +193,7 @@ contract B20FullLayoutTest is B20Test {
         // name/symbol come from factory bootstrap ("Test" / "TST" via
         // B20FactoryTest._b20Params()). Set contractURI explicitly so
         // slot 2 has a non-zero value to assert.
+        _grantRole(B20Constants.METADATA_ROLE, admin);
         vm.prank(admin);
         token.updateContractURI("https://example.com/contract.json");
 


### PR DESCRIPTION
## Summary

- `updateContractURI` now requires `METADATA_ROLE` rather than `DEFAULT_ADMIN_ROLE`. Aligns it with the other metadata setters (`updateName`, `updateSymbol`) so a metadata operator (e.g. corporate-actions desk) can manage the ERC-7572 contract URI without holding broader admin powers (role grants, policy changes, supply-cap changes).
- Updates `IB20` natspec on `updateContractURI`, `METADATA_ROLE`, `DEFAULT_ADMIN_ROLE`, the `LastAdminRenounced` event, and `renounceLastAdmin` to reflect the new gating. The renunciation doc now correctly notes that `updateContractURI` survives adminless transition (callable by remaining `METADATA_ROLE` holders), the same as `updateName` / `updateSymbol`.
- Regroups `updateContractURI` next to `updateName` / `updateSymbol` in the `IB20Security` announcement-pairing list (no longer "admin-level").
- Updates `MockB20.updateContractURI` to `onlyRole(METADATA_ROLE)`.
- Test updates:
  - `updateContractURI.t.sol`: unauthorized test expects `METADATA_ROLE` in the revert and uses the `hasRole`-filter pattern from `updateName.t.sol`; success tests grant `METADATA_ROLE` to `admin` before pranking.
  - `contractURI.t.sol` and `B20FullLayout.t.sol`: grant `METADATA_ROLE` before mutating.
  - `renounceLastAdmin.t.sol`: doc comment corrected — `updateContractURI` / `updateName` / `updateSymbol` are METADATA-gated, not admin-gated.

## Test plan

- [x] `forge build`
- [x] `forge test` — 440 passed, 0 failed

Made with [Cursor](https://cursor.com)