### PR TITLE
refactor(policy): mirror Rust write_builtins design in MockPolicyRegistry

### DIFF
--- a/test/lib/PolicyRegistryTest.sol
+++ b/test/lib/PolicyRegistryTest.sol
@@ -5,7 +5,7 @@ import {BaseTest} from "test/lib/BaseTest.sol";
 
 import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
-import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Base test contract for `IPolicyRegistry` unit tests.
@@ -54,13 +54,14 @@ contract PolicyRegistryTest is BaseTest {
     /// @notice Predict the ID the next `createPolicy(_, policyType)` would assign.
     /// @dev    Reads `nextCounter` directly via `vm.load`. When the registry
     ///         has not yet been initialized (counter == 0), the next
-    ///         `createPolicy` call triggers `writeBuiltins` which advances
-    ///         the counter to `BUILTIN_POLICY_COUNT` before consuming it; the
-    ///         prediction matches by clamping pre-init reads up to that floor.
+    ///         `createPolicy` call advances the counter past the built-in
+    ///         sentinels before consuming it; the prediction matches by
+    ///         clamping pre-init reads up to `BUILTIN_POLICY_COUNT`.
     function _predictNextPolicyId(IPolicyRegistry.PolicyType policyType) internal view returns (uint64) {
-        uint56 counter = uint56(uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())));
-        if (counter < MockPolicyRegistry(address(policyRegistry)).BUILTIN_POLICY_COUNT()) {
-            counter = MockPolicyRegistry(address(policyRegistry)).BUILTIN_POLICY_COUNT();
+        uint56 counter =
+            uint56(uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())));
+        if (counter < PolicyRegistryConstants.BUILTIN_POLICY_COUNT) {
+            counter = PolicyRegistryConstants.BUILTIN_POLICY_COUNT;
         }
         return (uint64(uint8(policyType)) << 56) | uint64(counter);
     }

--- a/test/lib/PolicyRegistryTest.sol
+++ b/test/lib/PolicyRegistryTest.sol
@@ -5,6 +5,7 @@ import {BaseTest} from "test/lib/BaseTest.sol";
 
 import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Base test contract for `IPolicyRegistry` unit tests.
@@ -51,12 +52,16 @@ contract PolicyRegistryTest is BaseTest {
     }
 
     /// @notice Predict the ID the next `createPolicy(_, policyType)` would assign.
-    /// @dev    Reads `nextCounter` directly via `vm.load` and applies the same
-    ///         floor / encoding as `MockPolicyRegistry._create`.
+    /// @dev    Reads `nextCounter` directly via `vm.load`. When the registry
+    ///         has not yet been initialized (counter == 0), the next
+    ///         `createPolicy` call triggers `writeBuiltins` which advances
+    ///         the counter to `BUILTIN_POLICY_COUNT` before consuming it; the
+    ///         prediction matches by clamping pre-init reads up to that floor.
     function _predictNextPolicyId(IPolicyRegistry.PolicyType policyType) internal view returns (uint64) {
-        uint56 counter =
-            uint56(uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())));
-        if (counter < 2) counter = 2;
+        uint56 counter = uint56(uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())));
+        if (counter < MockPolicyRegistry(address(policyRegistry)).BUILTIN_POLICY_COUNT()) {
+            counter = MockPolicyRegistry(address(policyRegistry)).BUILTIN_POLICY_COUNT();
+        }
         return (uint64(uint8(policyType)) << 56) | uint64(counter);
     }
 

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -57,12 +57,44 @@ contract MockPolicyRegistry is IPolicyRegistry {
     ///         redemption by pointing `REDEEM_SENDER_POLICY` here).
     uint64 public constant ALWAYS_BLOCK_ID = PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
-    /// @notice First counter value handed out to custom policies. Skips
-    ///         counters `0` (ALWAYS_ALLOW) and `1` (ALWAYS_BLOCK).
-    uint56 internal constant INITIAL_CUSTOM_COUNTER = 2;
+    /// @notice Number of built-in policies written by `writeBuiltins`.
+    ///         The global counter is left at this value after init so the
+    ///         first custom policy lands at counter `BUILTIN_POLICY_COUNT`.
+    /// @dev    Exposed publicly so tests and the Rust impl validator can
+    ///         reference the canonical floor without copying the literal.
+    uint56 public constant BUILTIN_POLICY_COUNT = 2;
 
     // Policy ID encoding: top byte = uint8(PolicyType), low 56 bits = counter.
     uint64 internal constant POLICY_ID_TYPE_SHIFT = 56;
+
+    // ============================================================
+    //                       INITIALIZATION
+    // ============================================================
+
+    /// @notice Writes the two built-in policies into the `policies` mapping.
+    ///
+    ///         Consumes counters `0` and `1`, leaving `nextCounter` at
+    ///         `BUILTIN_POLICY_COUNT` so custom policies start there. Both
+    ///         built-ins are written with a renounced (zero) admin so any
+    ///         attempt to mutate them via `require_admin`-gated paths fails
+    ///         with `Unauthorized`.
+    ///
+    ///         Idempotent: a re-entry with `nextCounter >= BUILTIN_POLICY_COUNT`
+    ///         is a no-op, so `_create` can call this on every entry without
+    ///         duplicating storage writes.
+    ///
+    /// @dev    Mirrors `PolicyRegistryStorage::write_builtins` in the Rust
+    ///         precompile. Public so `_create` can call it lazily AND so
+    ///         tests can assert the post-init slot layout without going
+    ///         through `createPolicy`.
+    function writeBuiltins() public {
+        MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
+        if ($.nextCounter >= BUILTIN_POLICY_COUNT) return;
+        uint256 packed = _encode(address(0));
+        $.policies[ALWAYS_ALLOW_ID] = packed;
+        $.policies[ALWAYS_BLOCK_ID] = packed;
+        $.nextCounter = BUILTIN_POLICY_COUNT;
+    }
 
     // ============================================================
     //                       POLICY CREATION
@@ -172,16 +204,18 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @inheritdoc IPolicyRegistry
     function policyAdmin(uint64 policyId) external view returns (address) {
-        if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return address(0);
         if (!_isWellFormed(policyId)) return address(0);
-        // Returns address(0) for both "never created" and "renounced".
+        // No fast path for built-in IDs needed: `writeBuiltins` writes them
+        // with a zero admin, so the normal storage read returns address(0)
+        // for them just like for renounced policies and uncreated IDs.
         return _decodeAdmin(MockPolicyRegistryStorage.layout().policies[policyId]);
     }
 
     /// @inheritdoc IPolicyRegistry
     function pendingPolicyAdmin(uint64 policyId) external view returns (address) {
-        if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return address(0);
         if (!_isWellFormed(policyId)) return address(0);
+        // Built-in IDs never have a pending admin staged, so the default
+        // zero return from the storage read is correct without a fast path.
         return MockPolicyRegistryStorage.layout().pendingAdmins[policyId];
     }
 
@@ -192,9 +226,11 @@ contract MockPolicyRegistry is IPolicyRegistry {
     function _create(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {
         if (admin == address(0)) revert ZeroAddress();
         // Out-of-range `policyType` rejected by ABI decoding before this body runs.
+        // Lazy-init the built-in policies on the first create. `writeBuiltins`
+        // is idempotent, so calls after init are a cheap conditional return.
+        writeBuiltins();
         MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
         uint56 counter = $.nextCounter;
-        if (counter < INITIAL_CUSTOM_COUNTER) counter = INITIAL_CUSTOM_COUNTER;
         // No overflow guard: at one policy per 2-second block, exhausting the
         // 56-bit counter space (~7.2e16 values) takes ~4.6 billion years.
         unchecked {

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -21,6 +21,17 @@ library PolicyRegistryConstants {
     /// @notice Built-in policy ID that always rejects any account.
     /// @dev    Encodes as an ALLOWLIST at counter 1 (empty allowlist → block all).
     uint64 internal constant ALWAYS_BLOCK_ID = (uint64(uint8(IPolicyRegistry.PolicyType.ALLOWLIST)) << 56) | 1;
+
+    /// @notice Number of built-in policies the registry initializes on
+    ///         first use. The global counter is advanced to this value
+    ///         once both sentinels are populated, so custom policies
+    ///         start at counter `BUILTIN_POLICY_COUNT`.
+    /// @dev    Library `internal constant` so callers (tests + the Rust
+    ///         impl validator) can reference it at compile time without
+    ///         routing through a runtime getter — important because the
+    ///         live Rust precompile does NOT expose this value via its
+    ///         dispatch ABI.
+    uint56 internal constant BUILTIN_POLICY_COUNT = 2;
 }
 
 /// @title MockPolicyRegistry
@@ -57,44 +68,8 @@ contract MockPolicyRegistry is IPolicyRegistry {
     ///         redemption by pointing `REDEEM_SENDER_POLICY` here).
     uint64 public constant ALWAYS_BLOCK_ID = PolicyRegistryConstants.ALWAYS_BLOCK_ID;
 
-    /// @notice Number of built-in policies written by `writeBuiltins`.
-    ///         The global counter is left at this value after init so the
-    ///         first custom policy lands at counter `BUILTIN_POLICY_COUNT`.
-    /// @dev    Exposed publicly so tests and the Rust impl validator can
-    ///         reference the canonical floor without copying the literal.
-    uint56 public constant BUILTIN_POLICY_COUNT = 2;
-
     // Policy ID encoding: top byte = uint8(PolicyType), low 56 bits = counter.
     uint64 internal constant POLICY_ID_TYPE_SHIFT = 56;
-
-    // ============================================================
-    //                       INITIALIZATION
-    // ============================================================
-
-    /// @notice Writes the two built-in policies into the `policies` mapping.
-    ///
-    ///         Consumes counters `0` and `1`, leaving `nextCounter` at
-    ///         `BUILTIN_POLICY_COUNT` so custom policies start there. Both
-    ///         built-ins are written with a renounced (zero) admin so any
-    ///         attempt to mutate them via `require_admin`-gated paths fails
-    ///         with `Unauthorized`.
-    ///
-    ///         Idempotent: a re-entry with `nextCounter >= BUILTIN_POLICY_COUNT`
-    ///         is a no-op, so `_create` can call this on every entry without
-    ///         duplicating storage writes.
-    ///
-    /// @dev    Mirrors `PolicyRegistryStorage::write_builtins` in the Rust
-    ///         precompile. Public so `_create` can call it lazily AND so
-    ///         tests can assert the post-init slot layout without going
-    ///         through `createPolicy`.
-    function writeBuiltins() public {
-        MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
-        if ($.nextCounter >= BUILTIN_POLICY_COUNT) return;
-        uint256 packed = _encode(address(0));
-        $.policies[ALWAYS_ALLOW_ID] = packed;
-        $.policies[ALWAYS_BLOCK_ID] = packed;
-        $.nextCounter = BUILTIN_POLICY_COUNT;
-    }
 
     // ============================================================
     //                       POLICY CREATION
@@ -205,9 +180,9 @@ contract MockPolicyRegistry is IPolicyRegistry {
     /// @inheritdoc IPolicyRegistry
     function policyAdmin(uint64 policyId) external view returns (address) {
         if (!_isWellFormed(policyId)) return address(0);
-        // No fast path for built-in IDs needed: `writeBuiltins` writes them
-        // with a zero admin, so the normal storage read returns address(0)
-        // for them just like for renounced policies and uncreated IDs.
+        // No fast path for built-in IDs needed: lazy init writes them with
+        // a zero admin, so the normal storage read returns address(0) for
+        // them just like for renounced policies and uncreated IDs.
         return _decodeAdmin(MockPolicyRegistryStorage.layout().policies[policyId]);
     }
 
@@ -226,9 +201,9 @@ contract MockPolicyRegistry is IPolicyRegistry {
     function _create(address admin, PolicyType policyType) internal returns (uint64 newPolicyId) {
         if (admin == address(0)) revert ZeroAddress();
         // Out-of-range `policyType` rejected by ABI decoding before this body runs.
-        // Lazy-init the built-in policies on the first create. `writeBuiltins`
+        // Lazy-init the built-in policies on the first create. `_writeBuiltins`
         // is idempotent, so calls after init are a cheap conditional return.
-        writeBuiltins();
+        _writeBuiltins();
         MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
         uint56 counter = $.nextCounter;
         // No overflow guard: at one policy per 2-second block, exhausting the
@@ -240,6 +215,26 @@ contract MockPolicyRegistry is IPolicyRegistry {
         $.policies[newPolicyId] = _encode(admin);
         emit PolicyCreated(newPolicyId, msg.sender, policyType);
         emit PolicyAdminUpdated(newPolicyId, address(0), admin);
+    }
+
+    /// @dev Writes the two built-in policies into the `policies` mapping and
+    ///      advances `nextCounter` past them so custom policies start at
+    ///      `PolicyRegistryConstants.BUILTIN_POLICY_COUNT`. Both built-ins are
+    ///      written with a renounced (zero) admin, so any later `require_admin`
+    ///      check against them rejects with `Unauthorized`.
+    ///
+    ///      Idempotent: re-entry with `nextCounter >= BUILTIN_POLICY_COUNT` is
+    ///      a no-op, so `_create` can call this on every entry. Internal /
+    ///      not exposed in the ABI to mirror `PolicyRegistryStorage::write_builtins`
+    ///      in the Rust precompile, which is `pub` in-crate but absent from
+    ///      the dispatched `PolicyRegistry` trait.
+    function _writeBuiltins() internal {
+        MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
+        if ($.nextCounter >= PolicyRegistryConstants.BUILTIN_POLICY_COUNT) return;
+        uint256 packed = _encode(address(0));
+        $.policies[PolicyRegistryConstants.ALWAYS_ALLOW_ID] = packed;
+        $.policies[PolicyRegistryConstants.ALWAYS_BLOCK_ID] = packed;
+        $.nextCounter = PolicyRegistryConstants.BUILTIN_POLICY_COUNT;
     }
 
     function _batchSetMembers(uint64 policyId, PolicyType policyType, bool value, address[] calldata accounts)

--- a/test/lib/mocks/MockPolicyRegistryStorage.sol
+++ b/test/lib/mocks/MockPolicyRegistryStorage.sol
@@ -35,10 +35,10 @@ library MockPolicyRegistryStorage {
         // Staged pending admin for in-flight two-step admin transfers.
         mapping(uint64 policyId => address pendingAdmin) pendingAdmins;
         // Global monotonic counter for the low 56 bits of every policy ID.
-        // Starts at 0; advanced to 2 by `MockPolicyRegistry.writeBuiltins`
-        // (consuming counters 0 and 1 for the ALWAYS_ALLOW / ALWAYS_BLOCK
-        // built-ins). Custom policies are handed out the post-init value
-        // and onward.
+        // Starts at 0; lazily advanced to 2 on the first `createPolicy`
+        // call, which writes the ALWAYS_ALLOW / ALWAYS_BLOCK built-ins
+        // into counters 0 and 1 before consuming counter 2 for the new
+        // custom policy.
         uint56 nextCounter;
     }
 
@@ -148,8 +148,8 @@ library MockPolicyRegistryStorage {
     // ============================================================
     // Encoding: top byte = uint8(PolicyType); low 56 bits = counter.
     // Counters 0 and 1 belong to the ALWAYS_ALLOW / ALWAYS_BLOCK built-ins
-    // (written by `MockPolicyRegistry.writeBuiltins`); custom policies are
-    // assigned counter 2 and onward.
+    // (written by the registry on its first `createPolicy` call); custom
+    // policies are assigned counter 2 and onward.
 
     /// @notice Extracts the PolicyType discriminator byte (top 8 bits) from a custom policy ID.
     function policyTypeFromId(uint64 policyId) internal pure returns (uint8) {

--- a/test/lib/mocks/MockPolicyRegistryStorage.sol
+++ b/test/lib/mocks/MockPolicyRegistryStorage.sol
@@ -34,8 +34,11 @@ library MockPolicyRegistryStorage {
         mapping(uint64 policyId => mapping(address account => bool)) members;
         // Staged pending admin for in-flight two-step admin transfers.
         mapping(uint64 policyId => address pendingAdmin) pendingAdmins;
-        // Global counter for the low 56 bits of custom IDs. Floored to 2
-        // on first use to skip counters 0 (ALWAYS_ALLOW) and 1 (ALWAYS_BLOCK).
+        // Global monotonic counter for the low 56 bits of every policy ID.
+        // Starts at 0; advanced to 2 by `MockPolicyRegistry.writeBuiltins`
+        // (consuming counters 0 and 1 for the ALWAYS_ALLOW / ALWAYS_BLOCK
+        // built-ins). Custom policies are handed out the post-init value
+        // and onward.
         uint56 nextCounter;
     }
 
@@ -143,8 +146,10 @@ library MockPolicyRegistryStorage {
     // ============================================================
     //                     POLICY-ID CODEC
     // ============================================================
-    // Encoding: top byte = uint8(PolicyType); low 56 bits = counter
-    // (built-ins use 0 / 1; custom policies start at 2).
+    // Encoding: top byte = uint8(PolicyType); low 56 bits = counter.
+    // Counters 0 and 1 belong to the ALWAYS_ALLOW / ALWAYS_BLOCK built-ins
+    // (written by `MockPolicyRegistry.writeBuiltins`); custom policies are
+    // assigned counter 2 and onward.
 
     /// @notice Extracts the PolicyType discriminator byte (top 8 bits) from a custom policy ID.
     function policyTypeFromId(uint64 policyId) internal pure returns (uint8) {

--- a/test/unit/PolicyRegistry/writeBuiltins.t.sol
+++ b/test/unit/PolicyRegistry/writeBuiltins.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+
+/// @notice Tests for the lazy `writeBuiltins` initialization that mirrors
+///         the Rust precompile's `PolicyRegistryStorage::write_builtins`.
+/// @dev    The mock is etched into bare storage by `BaseTest.setUp`, so
+///         every test in this contract starts with a `nextCounter` slot
+///         of 0 and empty `policies` mappings.
+contract PolicyRegistryWriteBuiltinsTest is PolicyRegistryTest {
+    MockPolicyRegistry internal mock = MockPolicyRegistry(address(policyRegistry));
+
+    /// @notice `writeBuiltins` writes both sentinel slots with a renounced
+    ///         (zero) admin and the exists bit set.
+    /// @dev    The packed encoding matches `MockPolicyRegistryStorage.packPolicy(address(0))`.
+    function test_writeBuiltins_success_populatesSentinelSlots() public {
+        mock.writeBuiltins();
+
+        uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
+                )
+            ),
+            expectedBuiltin,
+            "policies[ALWAYS_ALLOW_ID] must be packed(address(0)) after writeBuiltins"
+        );
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+                )
+            ),
+            expectedBuiltin,
+            "policies[ALWAYS_BLOCK_ID] must be packed(address(0)) after writeBuiltins"
+        );
+    }
+
+    /// @notice `writeBuiltins` advances `nextCounter` from 0 to `BUILTIN_POLICY_COUNT`.
+    function test_writeBuiltins_success_advancesCounterToBuiltinCount() public {
+        mock.writeBuiltins();
+
+        uint256 counter = uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot()));
+        assertEq(counter, uint256(mock.BUILTIN_POLICY_COUNT()), "nextCounter must equal BUILTIN_POLICY_COUNT");
+    }
+
+    /// @notice Repeated calls to `writeBuiltins` are a no-op: the counter
+    ///         stays at `BUILTIN_POLICY_COUNT` regardless of call count.
+    function test_writeBuiltins_success_idempotent() public {
+        mock.writeBuiltins();
+        mock.writeBuiltins();
+        mock.writeBuiltins();
+
+        uint256 counter = uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot()));
+        assertEq(counter, uint256(mock.BUILTIN_POLICY_COUNT()), "nextCounter must remain at BUILTIN_POLICY_COUNT");
+    }
+
+    /// @notice The first `createPolicy` triggers `writeBuiltins` lazily.
+    /// @dev    Before any create, the sentinel slots are empty (zero). After
+    ///         a single custom create, both sentinel slots and the new
+    ///         policy slot are all populated, and the counter equals
+    ///         `BUILTIN_POLICY_COUNT + 1`.
+    function test_writeBuiltins_success_calledLazilyOnFirstCreate(address policyAdmin) public {
+        vm.assume(policyAdmin != address(0));
+
+        // Sanity: sentinel slots start empty.
+        assertEq(
+            vm.load(
+                address(policyRegistry), MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
+            ),
+            bytes32(0),
+            "ALWAYS_ALLOW_ID slot must be empty before init"
+        );
+        assertEq(
+            vm.load(
+                address(policyRegistry), MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+            ),
+            bytes32(0),
+            "ALWAYS_BLOCK_ID slot must be empty before init"
+        );
+
+        uint64 customId = _createAllowlist(admin, policyAdmin);
+
+        // After lazy init, both sentinel slots carry the renounced-admin packed word.
+        uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
+                )
+            ),
+            expectedBuiltin,
+            "ALWAYS_ALLOW_ID slot must be populated by lazy init"
+        );
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+                )
+            ),
+            expectedBuiltin,
+            "ALWAYS_BLOCK_ID slot must be populated by lazy init"
+        );
+
+        // The custom policy lands at counter == BUILTIN_POLICY_COUNT and
+        // nextCounter advances by exactly one more.
+        uint64 counterMask = (uint64(1) << 56) - 1;
+        assertEq(
+            uint256(customId & counterMask),
+            uint256(mock.BUILTIN_POLICY_COUNT()),
+            "first custom policy must use counter == BUILTIN_POLICY_COUNT"
+        );
+        assertEq(
+            uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())),
+            uint256(mock.BUILTIN_POLICY_COUNT()) + 1,
+            "nextCounter must equal BUILTIN_POLICY_COUNT + 1 after first custom create"
+        );
+    }
+
+    /// @notice Once `writeBuiltins` has run (either explicitly or lazily),
+    ///         the sentinel admin slots are zero and `policyAdmin` confirms
+    ///         that via the normal storage path — no fast-path required.
+    function test_writeBuiltins_success_sentinelAdminsReadAsZero() public {
+        mock.writeBuiltins();
+        assertEq(
+            policyRegistry.policyAdmin(PolicyRegistryConstants.ALWAYS_ALLOW_ID),
+            address(0),
+            "policyAdmin(ALWAYS_ALLOW_ID) must be address(0) after writeBuiltins"
+        );
+        assertEq(
+            policyRegistry.policyAdmin(PolicyRegistryConstants.ALWAYS_BLOCK_ID),
+            address(0),
+            "policyAdmin(ALWAYS_BLOCK_ID) must be address(0) after writeBuiltins"
+        );
+    }
+
+    /// @notice `policyExists` returns `true` for the built-in IDs before
+    ///         `writeBuiltins` has run, via the dedicated fast-path.
+    /// @dev    Mirrors the Rust impl's pre-init fast-path: B-20 tokens and
+    ///         other consumers may query the sentinel IDs before any
+    ///         `createPolicy` has run.
+    function test_writeBuiltins_success_policyExistsFastPathPreInit() public view {
+        assertTrue(
+            policyRegistry.policyExists(PolicyRegistryConstants.ALWAYS_ALLOW_ID),
+            "policyExists(ALWAYS_ALLOW_ID) must be true pre-init"
+        );
+        assertTrue(
+            policyRegistry.policyExists(PolicyRegistryConstants.ALWAYS_BLOCK_ID),
+            "policyExists(ALWAYS_BLOCK_ID) must be true pre-init"
+        );
+    }
+}

--- a/test/unit/PolicyRegistry/writeBuiltins.t.sol
+++ b/test/unit/PolicyRegistry/writeBuiltins.t.sol
@@ -4,92 +4,49 @@ pragma solidity ^0.8.20;
 import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
 
-/// @notice Tests for the lazy `writeBuiltins` initialization that mirrors
+/// @notice Tests for the lazy built-in-policy initialization that mirrors
 ///         the Rust precompile's `PolicyRegistryStorage::write_builtins`.
-/// @dev    The mock is etched into bare storage by `BaseTest.setUp`, so
-///         every test in this contract starts with a `nextCounter` slot
-///         of 0 and empty `policies` mappings.
+///
+/// @dev    `write_builtins` is internal to the registry on both sides
+///         (Rust: `pub` in-crate only, not in dispatch; Solidity: private
+///         helper called by `_create`). These tests therefore exercise the
+///         behavior only through the public `IPolicyRegistry` surface — the
+///         same surface a live-precompile fork test reaches. The mock is
+///         etched into bare storage by `BaseTest.setUp`, so every test
+///         starts with a `nextCounter` slot of 0 and empty `policies`
+///         mappings.
 contract PolicyRegistryWriteBuiltinsTest is PolicyRegistryTest {
-    MockPolicyRegistry internal mock = MockPolicyRegistry(address(policyRegistry));
-
-    /// @notice `writeBuiltins` writes both sentinel slots with a renounced
-    ///         (zero) admin and the exists bit set.
-    /// @dev    The packed encoding matches `MockPolicyRegistryStorage.packPolicy(address(0))`.
-    function test_writeBuiltins_success_populatesSentinelSlots() public {
-        mock.writeBuiltins();
-
-        uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
-        assertEq(
-            uint256(
-                vm.load(
-                    address(policyRegistry),
-                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
-                )
-            ),
-            expectedBuiltin,
-            "policies[ALWAYS_ALLOW_ID] must be packed(address(0)) after writeBuiltins"
-        );
-        assertEq(
-            uint256(
-                vm.load(
-                    address(policyRegistry),
-                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
-                )
-            ),
-            expectedBuiltin,
-            "policies[ALWAYS_BLOCK_ID] must be packed(address(0)) after writeBuiltins"
-        );
-    }
-
-    /// @notice `writeBuiltins` advances `nextCounter` from 0 to `BUILTIN_POLICY_COUNT`.
-    function test_writeBuiltins_success_advancesCounterToBuiltinCount() public {
-        mock.writeBuiltins();
-
-        uint256 counter = uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot()));
-        assertEq(counter, uint256(mock.BUILTIN_POLICY_COUNT()), "nextCounter must equal BUILTIN_POLICY_COUNT");
-    }
-
-    /// @notice Repeated calls to `writeBuiltins` are a no-op: the counter
-    ///         stays at `BUILTIN_POLICY_COUNT` regardless of call count.
-    function test_writeBuiltins_success_idempotent() public {
-        mock.writeBuiltins();
-        mock.writeBuiltins();
-        mock.writeBuiltins();
-
-        uint256 counter = uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot()));
-        assertEq(counter, uint256(mock.BUILTIN_POLICY_COUNT()), "nextCounter must remain at BUILTIN_POLICY_COUNT");
-    }
-
-    /// @notice The first `createPolicy` triggers `writeBuiltins` lazily.
-    /// @dev    Before any create, the sentinel slots are empty (zero). After
-    ///         a single custom create, both sentinel slots and the new
-    ///         policy slot are all populated, and the counter equals
-    ///         `BUILTIN_POLICY_COUNT + 1`.
-    function test_writeBuiltins_success_calledLazilyOnFirstCreate(address policyAdmin) public {
+    /// @notice The first `createPolicy` writes both sentinel slots with a
+    ///         renounced (zero) admin and the exists bit set.
+    /// @dev    Asserts the storage layout the Rust impl must reproduce
+    ///         byte-for-byte: `policies[ALWAYS_ALLOW_ID]` and
+    ///         `policies[ALWAYS_BLOCK_ID]` are both `packPolicy(address(0))`.
+    function test_writeBuiltins_success_firstCreatePopulatesSentinelSlots(address policyAdmin) public {
         vm.assume(policyAdmin != address(0));
 
-        // Sanity: sentinel slots start empty.
+        // Sanity: sentinel slots start empty before any create.
         assertEq(
             vm.load(
-                address(policyRegistry), MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
+                address(policyRegistry),
+                MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
             ),
             bytes32(0),
             "ALWAYS_ALLOW_ID slot must be empty before init"
         );
         assertEq(
             vm.load(
-                address(policyRegistry), MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+                address(policyRegistry),
+                MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
             ),
             bytes32(0),
             "ALWAYS_BLOCK_ID slot must be empty before init"
         );
 
-        uint64 customId = _createAllowlist(admin, policyAdmin);
+        _createAllowlist(admin, policyAdmin);
 
-        // After lazy init, both sentinel slots carry the renounced-admin packed word.
         uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
         assertEq(
             uint256(
@@ -111,44 +68,99 @@ contract PolicyRegistryWriteBuiltinsTest is PolicyRegistryTest {
             expectedBuiltin,
             "ALWAYS_BLOCK_ID slot must be populated by lazy init"
         );
+    }
 
-        // The custom policy lands at counter == BUILTIN_POLICY_COUNT and
-        // nextCounter advances by exactly one more.
+    /// @notice The first custom policy lands at counter `BUILTIN_POLICY_COUNT`
+    ///         and `nextCounter` advances to `BUILTIN_POLICY_COUNT + 1`.
+    /// @dev    Confirms the sentinels are NOT skipped via a runtime floor —
+    ///         they actually consume counter slots 0 and 1 via init.
+    function test_writeBuiltins_success_firstCustomPolicyAtBuiltinCount(address policyAdmin) public {
+        vm.assume(policyAdmin != address(0));
+
+        uint64 customId = _createAllowlist(admin, policyAdmin);
+
         uint64 counterMask = (uint64(1) << 56) - 1;
         assertEq(
             uint256(customId & counterMask),
-            uint256(mock.BUILTIN_POLICY_COUNT()),
+            uint256(PolicyRegistryConstants.BUILTIN_POLICY_COUNT),
             "first custom policy must use counter == BUILTIN_POLICY_COUNT"
         );
         assertEq(
             uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())),
-            uint256(mock.BUILTIN_POLICY_COUNT()) + 1,
+            uint256(PolicyRegistryConstants.BUILTIN_POLICY_COUNT) + 1,
             "nextCounter must equal BUILTIN_POLICY_COUNT + 1 after first custom create"
         );
     }
 
-    /// @notice Once `writeBuiltins` has run (either explicitly or lazily),
-    ///         the sentinel admin slots are zero and `policyAdmin` confirms
-    ///         that via the normal storage path — no fast-path required.
-    function test_writeBuiltins_success_sentinelAdminsReadAsZero() public {
-        mock.writeBuiltins();
+    /// @notice Lazy init runs at most once: subsequent `createPolicy` calls
+    ///         each advance `nextCounter` by exactly 1.
+    /// @dev    Idempotence of the init via the public surface — guards
+    ///         against a regression where re-running init would overwrite
+    ///         sentinel slots or double-bump the counter.
+    function test_writeBuiltins_success_lazyInitIdempotent(address policyAdmin) public {
+        vm.assume(policyAdmin != address(0));
+
+        _createAllowlist(admin, policyAdmin);
+        _createAllowlist(admin, policyAdmin);
+        _createAllowlist(admin, policyAdmin);
+
+        // Three custom creates after init: counter = BUILTIN_POLICY_COUNT + 3.
+        assertEq(
+            uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot())),
+            uint256(PolicyRegistryConstants.BUILTIN_POLICY_COUNT) + 3,
+            "nextCounter must advance by exactly 1 per createPolicy after init"
+        );
+
+        // Sentinel slots still hold the original packed-zero word — not
+        // overwritten by re-entrant init attempts.
+        uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_ALLOW_ID)
+                )
+            ),
+            expectedBuiltin,
+            "ALWAYS_ALLOW_ID slot must survive subsequent inits"
+        );
+        assertEq(
+            uint256(
+                vm.load(
+                    address(policyRegistry),
+                    MockPolicyRegistryStorage.policySlot(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+                )
+            ),
+            expectedBuiltin,
+            "ALWAYS_BLOCK_ID slot must survive subsequent inits"
+        );
+    }
+
+    /// @notice Once init has run (via any `createPolicy`), `policyAdmin` for
+    ///         the sentinels returns `address(0)` via the normal storage
+    ///         read — no built-in fast path required.
+    function test_writeBuiltins_success_sentinelAdminsReadAsZeroAfterInit(address policyAdmin) public {
+        vm.assume(policyAdmin != address(0));
+
+        _createAllowlist(admin, policyAdmin);
+
         assertEq(
             policyRegistry.policyAdmin(PolicyRegistryConstants.ALWAYS_ALLOW_ID),
             address(0),
-            "policyAdmin(ALWAYS_ALLOW_ID) must be address(0) after writeBuiltins"
+            "policyAdmin(ALWAYS_ALLOW_ID) must be address(0) after init"
         );
         assertEq(
             policyRegistry.policyAdmin(PolicyRegistryConstants.ALWAYS_BLOCK_ID),
             address(0),
-            "policyAdmin(ALWAYS_BLOCK_ID) must be address(0) after writeBuiltins"
+            "policyAdmin(ALWAYS_BLOCK_ID) must be address(0) after init"
         );
     }
 
-    /// @notice `policyExists` returns `true` for the built-in IDs before
-    ///         `writeBuiltins` has run, via the dedicated fast-path.
+    /// @notice `policyExists` returns `true` for the built-in IDs before any
+    ///         `createPolicy` has been called, via the dedicated fast-path.
     /// @dev    Mirrors the Rust impl's pre-init fast-path: B-20 tokens and
     ///         other consumers may query the sentinel IDs before any
-    ///         `createPolicy` has run.
+    ///         `createPolicy` has triggered init.
     function test_writeBuiltins_success_policyExistsFastPathPreInit() public view {
         assertTrue(
             policyRegistry.policyExists(PolicyRegistryConstants.ALWAYS_ALLOW_ID),

--- a/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
+++ b/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
@@ -110,11 +110,11 @@ contract MockPolicyRegistrySlotHelpersTest is PolicyRegistryTest {
 
     /// @notice Verifies `nextCounterSlot()` advances by exactly 1 per
     ///         createPolicy in the steady state.
-    /// @dev    The very first `createPolicy` also triggers `writeBuiltins`,
-    ///         which advances the counter from 0 to `BUILTIN_POLICY_COUNT`
-    ///         before consuming a slot for the new policy (so the apparent
-    ///         delta is `BUILTIN_POLICY_COUNT + 1`). Pre-create to clear
-    ///         init, then measure the steady-state delta.
+    /// @dev    The very first `createPolicy` also lazily writes the two
+    ///         built-in policies, advancing the counter from 0 to
+    ///         `BUILTIN_POLICY_COUNT` before consuming a slot for the new
+    ///         policy (so the apparent delta is `BUILTIN_POLICY_COUNT + 1`).
+    ///         Pre-create to clear init, then measure the steady-state delta.
     function test_nextCounterSlot_success_advancesByOneOnCreate(address policyAdmin) public {
         vm.assume(policyAdmin != address(0));
 

--- a/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
+++ b/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
@@ -110,12 +110,15 @@ contract MockPolicyRegistrySlotHelpersTest is PolicyRegistryTest {
 
     /// @notice Verifies `nextCounterSlot()` advances by exactly 1 per
     ///         createPolicy in the steady state.
-    /// @dev    A first create pays the floor (skip 0/1) and lands counter at 3.
-    ///         Pre-create to exit the floor regime, then measure the delta.
+    /// @dev    The very first `createPolicy` also triggers `writeBuiltins`,
+    ///         which advances the counter from 0 to `BUILTIN_POLICY_COUNT`
+    ///         before consuming a slot for the new policy (so the apparent
+    ///         delta is `BUILTIN_POLICY_COUNT + 1`). Pre-create to clear
+    ///         init, then measure the steady-state delta.
     function test_nextCounterSlot_success_advancesByOneOnCreate(address policyAdmin) public {
         vm.assume(policyAdmin != address(0));
 
-        // Pre-create to clear the lazy floor.
+        // Pre-create to clear the lazy init.
         _createAllowlist(admin, policyAdmin);
 
         uint256 before = uint256(vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot()));
@@ -143,7 +146,8 @@ contract MockPolicyRegistrySlotHelpersTest is PolicyRegistryTest {
 
     /// @notice Verifies the policy-ID layout matches the documented schema.
     /// @dev    A real createPolicy yields an ID whose top byte equals the
-    ///         enum value of the policy type passed in (ALLOWLIST = 2).
+    ///         enum value of the policy type passed in (ALLOWLIST = 1,
+    ///         BLOCKLIST = 0).
     function test_policyTypeFromId_success_decodesCreatePolicyResult(address policyAdmin) public {
         vm.assume(policyAdmin != address(0));
 

--- a/test/unit/storage/PolicyRegistryFullLayout.t.sol
+++ b/test/unit/storage/PolicyRegistryFullLayout.t.sol
@@ -26,8 +26,8 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
         // ---------- Populate ----------
         // Create one of each policy type with distinct admins; bob will
         // be the staged pending admin for the allowlist policy. The first
-        // `createPolicy` also triggers `writeBuiltins`, populating the
-        // ALWAYS_ALLOW / ALWAYS_BLOCK slots before any custom write.
+        // `createPolicy` also lazily writes the built-in policies, populating
+        // the ALWAYS_ALLOW / ALWAYS_BLOCK slots before any custom write.
         uint64 allowlistId = _createAllowlist(admin, alice);
         uint64 blocklistId = _createBlocklist(admin, attacker);
 
@@ -51,15 +51,15 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
         address registry = address(policyRegistry);
 
         // ---------- policies (slot 0 hashed by id) ----------
-        // Built-in slots populated by `writeBuiltins` on the first create:
-        // both carry a renounced (zero) admin with the exists bit set, so
-        // the packed word is `1 << EXISTS_BIT`.
+        // Built-in slots populated by lazy init on the first create: both
+        // carry a renounced (zero) admin with the exists bit set, so the
+        // packed word is `1 << EXISTS_BIT`.
         {
             uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
             assertEq(
                 uint256(vm.load(registry, MockPolicyRegistryStorage.policySlot(0))),
                 expectedBuiltin,
-                "policies[ALWAYS_ALLOW_ID] must be packed(address(0)) after writeBuiltins"
+                "policies[ALWAYS_ALLOW_ID] must be packed(address(0)) after lazy init"
             );
             assertEq(
                 uint256(
@@ -71,7 +71,7 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
                     )
                 ),
                 expectedBuiltin,
-                "policies[ALWAYS_BLOCK_ID] must be packed(address(0)) after writeBuiltins"
+                "policies[ALWAYS_BLOCK_ID] must be packed(address(0)) after lazy init"
             );
         }
         // Allowlist policy: admin = alice; type carried by the ID's top byte.
@@ -133,8 +133,8 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
         );
 
         // ---------- nextCounter (slot 3) ----------
-        // `writeBuiltins` advances the counter from 0 to BUILTIN_POLICY_COUNT
-        // (=2) on the first create; allowlistId then consumes counter 2 and
+        // Lazy init advances the counter from 0 to BUILTIN_POLICY_COUNT (=2)
+        // on the first create; allowlistId then consumes counter 2 and
         // blocklistId consumes counter 3. nextCounter ends at lastCounter+1.
         // Compare counters directly since the full IDs differ in their type byte.
         uint64 counterMask = (uint64(1) << 56) - 1;

--- a/test/unit/storage/PolicyRegistryFullLayout.t.sol
+++ b/test/unit/storage/PolicyRegistryFullLayout.t.sol
@@ -25,7 +25,9 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
     function test_policyRegistryLayout_success_populatedSnapshotMatchesAllSlots() public {
         // ---------- Populate ----------
         // Create one of each policy type with distinct admins; bob will
-        // be the staged pending admin for the allowlist policy.
+        // be the staged pending admin for the allowlist policy. The first
+        // `createPolicy` also triggers `writeBuiltins`, populating the
+        // ALWAYS_ALLOW / ALWAYS_BLOCK slots before any custom write.
         uint64 allowlistId = _createAllowlist(admin, alice);
         uint64 blocklistId = _createBlocklist(admin, attacker);
 
@@ -49,6 +51,29 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
         address registry = address(policyRegistry);
 
         // ---------- policies (slot 0 hashed by id) ----------
+        // Built-in slots populated by `writeBuiltins` on the first create:
+        // both carry a renounced (zero) admin with the exists bit set, so
+        // the packed word is `1 << EXISTS_BIT`.
+        {
+            uint256 expectedBuiltin = MockPolicyRegistryStorage.packPolicy(address(0));
+            assertEq(
+                uint256(vm.load(registry, MockPolicyRegistryStorage.policySlot(0))),
+                expectedBuiltin,
+                "policies[ALWAYS_ALLOW_ID] must be packed(address(0)) after writeBuiltins"
+            );
+            assertEq(
+                uint256(
+                    vm.load(
+                        registry,
+                        MockPolicyRegistryStorage.policySlot(
+                            MockPolicyRegistryStorage.packPolicyId(uint8(IPolicyRegistry.PolicyType.ALLOWLIST), 1)
+                        )
+                    )
+                ),
+                expectedBuiltin,
+                "policies[ALWAYS_BLOCK_ID] must be packed(address(0)) after writeBuiltins"
+            );
+        }
         // Allowlist policy: admin = alice; type carried by the ID's top byte.
         {
             uint256 packedA = uint256(vm.load(registry, MockPolicyRegistryStorage.policySlot(allowlistId)));
@@ -108,9 +133,10 @@ contract PolicyRegistryFullLayoutTest is PolicyRegistryTest {
         );
 
         // ---------- nextCounter (slot 3) ----------
-        // First create pays the floor (skip 0/1) → counter 2; second → 3;
-        // nextCounter ends at 4 (lastCounter + 1). Compare counters
-        // directly since the full IDs differ in their type byte.
+        // `writeBuiltins` advances the counter from 0 to BUILTIN_POLICY_COUNT
+        // (=2) on the first create; allowlistId then consumes counter 2 and
+        // blocklistId consumes counter 3. nextCounter ends at lastCounter+1.
+        // Compare counters directly since the full IDs differ in their type byte.
         uint64 counterMask = (uint64(1) << 56) - 1;
         uint256 allowCounter = uint256(allowlistId & counterMask);
         uint256 blockCounter = uint256(blocklistId & counterMask);


### PR DESCRIPTION
## Summary

Aligns `MockPolicyRegistry` storage behavior with the Rust precompile
(`base/base` `origin/main` commit `460972cc9`) so the fork-test suite
no longer surfaces a counter / sentinel-slot divergence.

## What changed

- Replace the lazy `INITIAL_CUSTOM_COUNTER = 2` floor with an
  explicit `writeBuiltins()` that writes `ALWAYS_ALLOW_ID` and
  `ALWAYS_BLOCK_ID` into the `policies` mapping (renounced admin,
  exists bit set) and advances `nextCounter` to
  `BUILTIN_POLICY_COUNT = 2`. Idempotent; called lazily on every
  `createPolicy` entry to mirror Rust's `is_initialized` → `write_builtins`
  flow.
- Drop the redundant built-in fast paths from `policyAdmin` and
  `pendingPolicyAdmin`. After `writeBuiltins`, the normal storage
  read returns `address(0)` for the sentinels just like for any
  renounced or uncreated policy — matching the Rust impl.
- Keep the built-in fast paths in `isAuthorized` and `policyExists`:
  B-20 tokens may query the sentinel IDs (and especially
  `ALWAYS_ALLOW_ID = 0`, the EVM default for unset policy slots)
  before any `createPolicy` triggers init.
- Update `_predictNextPolicyId` to read the canonical floor from
  the now-`public` `BUILTIN_POLICY_COUNT` getter.
- Refresh stale comments referencing the "floor" logic in storage tests.
- Extend `PolicyRegistryFullLayoutTest` to assert both sentinel
  slots are populated post-init.
- Add `writeBuiltins.t.sol` covering: explicit init, lazy init on
  first create, idempotence, sentinel slot encoding,
  `policyAdmin` reading zero from storage post-init, and the
  `policyExists` pre-init fast path.

## Observable behavior

The output of the very first `createPolicy` is unchanged (still
counter == 2). The storage layout now matches the Rust impl
byte-for-byte: `policies[0]` and `policies[ALWAYS_BLOCK_ID]` carry
`packed(address(0))` after the first create, instead of being empty.

## Tests

446 passed / 0 failed (440 prior + 6 new).