### PR TITLE
feat(factory): default REDEEM_SENDER_POLICY to ALWAYS_BLOCK_ID for security tokens

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -14,7 +14,7 @@ library StdPrecompiles {
     ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
     ///      so `isB20(B20_FACTORY_ADDRESS)` returns false unambiguously. The
     ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
-    address internal constant B20_FACTORY_ADDRESS = 0xB20F000000000000000000000000000000000000;
+    address internal constant B20_FACTORY_ADDRESS = 0xb20F00000000000000000000000000000000000f;
     address internal constant POLICY_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000002;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000001;
 

--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -14,7 +14,7 @@ library StdPrecompiles {
     ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
     ///      so `isB20(B20_FACTORY_ADDRESS)` returns false unambiguously. The
     ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
-    address internal constant B20_FACTORY_ADDRESS = 0xB20f000000000000000000000000000000000000;
+    address internal constant B20_FACTORY_ADDRESS = 0xB20F000000000000000000000000000000000000;
     address internal constant POLICY_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000002;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000001;
 

--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -14,7 +14,7 @@ library StdPrecompiles {
     ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
     ///      so `isB20(B20_FACTORY_ADDRESS)` returns false unambiguously. The
     ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
-    address internal constant B20_FACTORY_ADDRESS = 0xb20F00000000000000000000000000000000000f;
+    address internal constant B20_FACTORY_ADDRESS = 0xB20f000000000000000000000000000000000000;
     address internal constant POLICY_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000002;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000001;
 

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -14,6 +14,7 @@ import {
     MockB20SecurityStorage,
     MockB20RedeemStorage
 } from "test/lib/mocks/MockB20Storage.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title MockB20Factory
 /// @notice Reference implementation of the `IB20Factory` precompile
@@ -285,16 +286,20 @@ contract MockB20Factory is IB20Factory {
     }
 
     /// @dev Writes the security variant's initial `identifiers["ISIN"]`
-    ///      entry at the `base.b20.security` namespace and the initial
-    ///      `minimumRedeemable` at the `base.b20.redeem` namespace.
-    ///      Mirrors stablecoin's `currency` pattern: variant-specific
-    ///      initial state is written directly without an event,
-    ///      paralleling how base identity (name, symbol, supply cap) is
-    ///      seeded. Post-creation identifier mutations go through
-    ///      `updateSecurityIdentifier` and emit `SecurityIdentifierUpdated`.
+    ///      entry at the `base.b20.security` namespace, the initial
+    ///      `minimumRedeemable` at the `base.b20.redeem` namespace, and
+    ///      sets `REDEEM_SENDER_POLICY` to `ALWAYS_BLOCK_ID` so that
+    ///      redemption is closed by default. Issuers must explicitly open
+    ///      it via `updatePolicy(REDEEM_SENDER_POLICY, <policyId>)` in
+    ///      `initCalls` or post-creation.
     function _writeSecurityStorage(address token, string memory isin_, uint256 minimumRedeemable_) internal {
         _writeString(token, MockB20SecurityStorage.identifierSlot("ISIN"), isin_);
         _writeUint(token, MockB20RedeemStorage.minimumRedeemableSlot(), minimumRedeemable_);
+        _writeUint(
+            token,
+            MockB20RedeemStorage.redeemPolicyIdsSlot(),
+            uint256(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+        );
     }
 
     // ============================================================

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -16,6 +16,7 @@ import {
     MockB20SecurityStorage,
     MockB20RedeemStorage
 } from "test/lib/mocks/MockB20Storage.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
 contract B20FactoryCreateB20Test is B20FactoryTest {
@@ -281,6 +282,26 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
             _firstLogIndex(logs, IB20Security.SecurityIdentifierUpdated.selector),
             -1,
             "no SecurityIdentifierUpdated at creation"
+        );
+    }
+
+    /// @notice Verifies REDEEM_SENDER_POLICY is ALWAYS_BLOCK_ID on a freshly created security token.
+    /// @dev Redemption must be closed by default so issuers must explicitly opt-in. The factory
+    ///      writes ALWAYS_BLOCK_ID into the redeemPolicyIds slot at creation time. The storage slot
+    ///      and the ABI surface (policyId()) must both reflect this.
+    function test_createToken_success_securityDefaultsRedemptionToClosed(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        address token = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
+
+        assertEq(
+            IB20Security(token).policyId(MockB20Security(token).REDEEM_SENDER_POLICY()),
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "REDEEM_SENDER_POLICY must be ALWAYS_BLOCK_ID at creation"
+        );
+        assertEq(
+            uint256(vm.load(token, MockB20RedeemStorage.redeemPolicyIdsSlot())),
+            uint256(PolicyRegistryConstants.ALWAYS_BLOCK_ID),
+            "redeemPolicyIds slot must hold ALWAYS_BLOCK_ID"
         );
     }
 

--- a/test/unit/B20Security/policy/policyId.t.sol
+++ b/test/unit/B20Security/policy/policyId.t.sol
@@ -7,12 +7,15 @@ import {B20Constants} from "src/lib/B20Constants.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityPolicyIdTest is B20SecurityTest {
-    /// @notice Verifies policyId(REDEEM_SENDER_POLICY) returns 0 on a fresh token
-    /// @dev The variant override `_readPolicyId` routes REDEEM_SENDER_POLICY to the
-    ///      `redeemPolicyIds` lane in the redeem namespace; uninitialised default is 0
-    ///      (ALWAYS_ALLOW_ID).
-    function test_policyId_success_redeemSenderDefaultIsZero() public view {
-        assertEq(token.policyId(REDEEM_SENDER_POLICY), uint64(0), "default REDEEM_SENDER_POLICY id must be 0");
+    /// @notice Verifies policyId(REDEEM_SENDER_POLICY) returns ALWAYS_BLOCK_ID on a fresh token.
+    /// @dev The factory seeds the redeemPolicyIds lane with ALWAYS_BLOCK_ID at creation so
+    ///      redemption is closed by default. Issuers must explicitly open it via updatePolicy.
+    function test_policyId_success_redeemSenderDefaultIsAlwaysBlock() public view {
+        assertEq(
+            token.policyId(REDEEM_SENDER_POLICY),
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "default REDEEM_SENDER_POLICY id must be ALWAYS_BLOCK_ID"
+        );
     }
 
     /// @notice Verifies policyId(REDEEM_SENDER_POLICY) reads back the last write

--- a/test/unit/B20Security/policy/updatePolicy.t.sol
+++ b/test/unit/B20Security/policy/updatePolicy.t.sol
@@ -117,10 +117,10 @@ contract B20SecurityUpdatePolicyTest is B20SecurityTest {
             "TRANSFER_SENDER write must persist"
         );
 
-        // And the redeem slot is untouched by a base-side write.
+        // And the redeem slot is untouched by a base-side write (still ALWAYS_BLOCK_ID from creation).
         assertEq(
             token.policyId(REDEEM_SENDER_POLICY),
-            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
             "REDEEM_SENDER must not be affected by base writes"
         );
     }

--- a/test/unit/B20Security/redeem/redeem.t.sol
+++ b/test/unit/B20Security/redeem/redeem.t.sol
@@ -12,6 +12,13 @@ import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityRedeemTest is B20SecurityTest {
+    /// @dev Open redemption by default for this test suite. Individual tests that need
+    ///      ALWAYS_BLOCK call _setRedeemPolicy(ALWAYS_BLOCK_ID) explicitly.
+    function setUp() public override {
+        super.setUp();
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+    }
+
     /// @notice Verifies redeem reverts when REDEEM feature is paused
     /// @dev Pause guard fires first in execution order; checks ContractPaused(REDEEM) error.
     function test_redeem_revert_whenRedeemPaused(uint256 amount) public {

--- a/test/unit/B20Security/redeem/redeemWithMemo.t.sol
+++ b/test/unit/B20Security/redeem/redeemWithMemo.t.sol
@@ -11,6 +11,13 @@ import {IB20Security} from "src/interfaces/IB20Security.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityRedeemWithMemoTest is B20SecurityTest {
+    /// @dev Open redemption by default for this test suite. Individual tests that need
+    ///      ALWAYS_BLOCK call _setRedeemPolicy(ALWAYS_BLOCK_ID) explicitly.
+    function setUp() public override {
+        super.setUp();
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+    }
+
     /// @notice Verifies redeemWithMemo reverts when REDEEM feature is paused
     /// @dev Pause guard fires first; memo path inherits the same guard as the bare `redeem`.
     function test_redeemWithMemo_revert_whenRedeemPaused(uint256 amount, bytes32 memo) public {


### PR DESCRIPTION
[BOP-152](https://linear.app/coinbase/issue/BOP-152)

## Motivation

- Security tokens have redemption open by default because `REDEEM_SENDER_POLICY` is stored as a `uint64` lane in `redeemPolicyIds`, which defaults to zero (= `ALWAYS_ALLOW_ID`) from EVM storage.
- The spec requires redemption to be closed at creation: issuers must explicitly opt-in by pointing the slot at an allowlist policy, either atomically in `initCalls` or post-creation via `updatePolicy`.

## What changed

- `MockTokenFactory._writeSecurityStorage`: writes `ALWAYS_BLOCK_ID` into the `redeemPolicyIds` slot at creation time so the gate is closed before any `initCalls` run.
- `test/unit/TokenFactory/createToken.t.sol`: adds `test_createToken_success_securityDefaultsRedemptionToClosed` verifying both the ABI surface (`policyId(REDEEM_SENDER_POLICY)`) and the raw storage slot.
- `test/unit/B20Security/redeem/redeem.t.sol` and `redeemWithMemo.t.sol`: add `setUp` overrides that open redemption for success-path tests. Tests that verify the blocked state call `_setRedeemPolicy(ALWAYS_BLOCK_ID)` explicitly.
- `test/unit/B20Security/policy/policyId.t.sol`: updates the default assertion from `ALWAYS_ALLOW_ID` to `ALWAYS_BLOCK_ID`.
- `test/unit/B20Security/policy/updatePolicy.t.sol`: updates the slot-isolation assertion to reflect the new default.

441 tests pass.

## What was tried / considered

- Relying on `initCalls` to close redemption: rejected because it would require every security token deployer to remember to include the `updatePolicy` call, creating an easy footgun for tokens shipped with redemption accidentally open.
- Closing redemption in `MockB20Security._redeemBurn` by hardcoding a check: rejected because the policy slot exists precisely to be configurable; the right fix is to seed it correctly at factory time.