### PR TITLE
feat(security): default REDEEM_SENDER_POLICY to ALWAYS_BLOCK_ID at creation

### DIFF
--- a/src/StdPrecompiles.sol
+++ b/src/StdPrecompiles.sol
@@ -14,7 +14,7 @@ library StdPrecompiles {
     ///      disjoint (B-20 tokens have `0x00` at byte [1]; the factory has `0x0F`),
     ///      so `isB20(B20_FACTORY_ADDRESS)` returns false unambiguously. The
     ///      trailing `0x0F` byte echoes the prefix for visual symmetry.
-    address internal constant B20_FACTORY_ADDRESS = 0xB20F000000000000000000000000000000000000;
+    address internal constant B20_FACTORY_ADDRESS = 0xB20f000000000000000000000000000000000000;
     address internal constant POLICY_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000002;
     address internal constant ACTIVATION_REGISTRY_ADDRESS = 0x8453000000000000000000000000000000000001;
 

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -8,6 +8,7 @@ import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {MockB20} from "test/lib/mocks/MockB20.sol";
 import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
 import {MockB20Security} from "test/lib/mocks/MockB20Security.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {
     MockB20Storage,
     MockB20StablecoinStorage,
@@ -285,16 +286,33 @@ contract MockB20Factory is IB20Factory {
     }
 
     /// @dev Writes the security variant's initial `identifiers["ISIN"]`
-    ///      entry at the `base.b20.security` namespace and the initial
-    ///      `minimumRedeemable` at the `base.b20.redeem` namespace.
+    ///      entry at the `base.b20.security` namespace, the initial
+    ///      `minimumRedeemable` at the `base.b20.redeem` namespace, and
+    ///      defaults the `REDEEM_SENDER_POLICY` slot to `ALWAYS_BLOCK_ID`.
     ///      Mirrors stablecoin's `currency` pattern: variant-specific
     ///      initial state is written directly without an event,
     ///      paralleling how base identity (name, symbol, supply cap) is
     ///      seeded. Post-creation identifier mutations go through
     ///      `updateSecurityIdentifier` and emit `SecurityIdentifierUpdated`.
+    ///
+    ///      The `REDEEM_SENDER_POLICY` default differs from the other
+    ///      four policy slots (which default to `ALWAYS_ALLOW_ID = 0`
+    ///      via the EVM zero-default of the slot): for security tokens,
+    ///      redemption is closed by default and admins must explicitly
+    ///      opt-in by pointing the slot at an allowlist or another
+    ///      policy. `ALWAYS_BLOCK_ID` lands in the bottom 64 bits of
+    ///      the packed `redeemPolicyIds` slot; the three reserved lanes
+    ///      above stay zero. To open redemption at creation, override
+    ///      the slot atomically via an
+    ///      `updatePolicy(REDEEM_SENDER_POLICY, <policyId>)` initCall.
     function _writeSecurityStorage(address token, string memory isin_, uint256 minimumRedeemable_) internal {
         _writeString(token, MockB20SecurityStorage.identifierSlot("ISIN"), isin_);
         _writeUint(token, MockB20RedeemStorage.minimumRedeemableSlot(), minimumRedeemable_);
+        _writeUint(
+            token,
+            MockB20RedeemStorage.redeemPolicyIdsSlot(),
+            uint256(PolicyRegistryConstants.ALWAYS_BLOCK_ID)
+        );
     }
 
     // ============================================================

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -10,6 +10,7 @@ import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 
 import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 import {MockB20Security} from "test/lib/mocks/MockB20Security.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {
     MockB20Storage,
     MockB20StablecoinStorage,
@@ -19,6 +20,11 @@ import {
 import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
 contract B20FactoryCreateB20Test is B20FactoryTest {
+    /// @dev Compile-time constant of the security-variant's REDEEM_SENDER_POLICY scope.
+    ///      Mirrors the `bytes32 public constant REDEEM_SENDER_POLICY = keccak256("REDEEM_SENDER_POLICY")`
+    ///      on `MockB20Security` so tests can reference the scope without a token instance.
+    bytes32 internal constant REDEEM_SENDER_POLICY = keccak256("REDEEM_SENDER_POLICY");
+
     // Role identifiers are accessed as `MINT_ROLE` etc. — these are
     // compile-time constants on the contract type, so they don't require an
     // instantiated token (relevant during createToken setup where the token
@@ -264,6 +270,106 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
             uint256(vm.load(token, MockB20RedeemStorage.minimumRedeemableSlot())),
             minRedeem,
             "minimumRedeemable slot must reflect the seeded value"
+        );
+    }
+
+    /// @notice Verifies security createToken defaults REDEEM_SENDER_POLICY to ALWAYS_BLOCK_ID
+    /// @dev Unlike the four base policy slots (which inherit the EVM zero default == ALWAYS_ALLOW_ID),
+    ///      the security variant's factory writes ALWAYS_BLOCK_ID into the REDEEM_SENDER_POLICY lane
+    ///      at creation time so redemption is closed by default. Admins must explicitly point the
+    ///      slot at an allowlist (or another policy) before any holder can call `redeem`. Paired
+    ///      slot assertion pins both the public surface (`policyId()`) and the underlying packed
+    ///      storage slot.
+    function test_createB20_success_securityDefaultsRedeemPolicyToBlock(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        address token = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
+
+        assertEq(
+            IB20Security(token).policyId(REDEEM_SENDER_POLICY),
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "REDEEM_SENDER_POLICY must default to ALWAYS_BLOCK_ID via the public surface"
+        );
+        // The packed slot's bottom 64 bits hold REDEEM_SENDER_POLICY; the three reserved
+        // lanes above stay zero on a fresh token.
+        uint256 packed = uint256(vm.load(token, MockB20RedeemStorage.redeemPolicyIdsSlot()));
+        assertEq(
+            uint64(packed),
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "redeemPolicyIds slot lane 0 must hold ALWAYS_BLOCK_ID"
+        );
+        assertEq(
+            packed >> 64,
+            uint256(0),
+            "redeemPolicyIds slot reserved lanes must be zero on a fresh token"
+        );
+    }
+
+    /// @notice Verifies the security REDEEM_SENDER_POLICY default does NOT leak into other
+    ///         policy slots — the four base scopes still default to ALWAYS_ALLOW_ID.
+    /// @dev Storage isolation: the factory's REDEEM_SENDER_POLICY write targets the redeem
+    ///      namespace (`base.b20.redeem`); the base packed policy slots (`transferPolicyIds`,
+    ///      `mintPolicyIds` in the base `base.b20` namespace) must remain at their EVM zero
+    ///      defaults so the four base scopes still read as ALWAYS_ALLOW_ID.
+    function test_createB20_success_securityOtherPolicySlotsDefaultToAllow(address caller, bytes32 salt)
+        public
+    {
+        _assumeValidCaller(caller);
+        address token = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
+
+        assertEq(
+            IB20Security(token).policyId(B20Constants.TRANSFER_SENDER_POLICY),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "TRANSFER_SENDER_POLICY must still default to ALWAYS_ALLOW_ID"
+        );
+        assertEq(
+            IB20Security(token).policyId(B20Constants.TRANSFER_RECEIVER_POLICY),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "TRANSFER_RECEIVER_POLICY must still default to ALWAYS_ALLOW_ID"
+        );
+        assertEq(
+            IB20Security(token).policyId(B20Constants.TRANSFER_EXECUTOR_POLICY),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "TRANSFER_EXECUTOR_POLICY must still default to ALWAYS_ALLOW_ID"
+        );
+        assertEq(
+            IB20Security(token).policyId(B20Constants.MINT_RECEIVER_POLICY),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "MINT_RECEIVER_POLICY must still default to ALWAYS_ALLOW_ID"
+        );
+        // Paired slot assertions: the base packed policy slots are at the EVM zero default.
+        assertEq(
+            vm.load(token, MockB20Storage.transferPolicyIdsSlot()),
+            bytes32(0),
+            "transferPolicyIds slot must be zero (default state)"
+        );
+        assertEq(
+            vm.load(token, MockB20Storage.mintPolicyIdsSlot()),
+            bytes32(0),
+            "mintPolicyIds slot must be zero (default state)"
+        );
+    }
+
+    /// @notice Verifies an `updatePolicy(REDEEM_SENDER_POLICY, ...)` initCall overrides the default
+    /// @dev Per `IB20Factory.B20SecurityCreateParams` natspec, admins can open redemption at
+    ///      creation time by including an `updatePolicy(REDEEM_SENDER_POLICY, <policyId>)` entry
+    ///      in `initCalls`. The privileged-window bypass on the token means the factory-originated
+    ///      call succeeds without the role check. Post-creation the slot reflects the overridden
+    ///      value, NOT the factory-seeded default.
+    function test_createB20_success_securityRedeemPolicyOverridableViaInitCall(address caller, bytes32 salt)
+        public
+    {
+        _assumeValidCaller(caller);
+        bytes[] memory initCalls = new bytes[](1);
+        initCalls[0] = abi.encodeWithSelector(
+            IB20.updatePolicy.selector, REDEEM_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_ALLOW_ID
+        );
+
+        address token = _createSecurity(caller, salt, _securityParams(), initCalls);
+
+        assertEq(
+            IB20Security(token).policyId(REDEEM_SENDER_POLICY),
+            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
+            "REDEEM_SENDER_POLICY must reflect the initCall override, not the factory default"
         );
     }
 

--- a/test/unit/B20Security/policy/policyId.t.sol
+++ b/test/unit/B20Security/policy/policyId.t.sol
@@ -7,12 +7,19 @@ import {B20Constants} from "src/lib/B20Constants.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityPolicyIdTest is B20SecurityTest {
-    /// @notice Verifies policyId(REDEEM_SENDER_POLICY) returns 0 on a fresh token
+    /// @notice Verifies policyId(REDEEM_SENDER_POLICY) returns ALWAYS_BLOCK_ID on a fresh token
     /// @dev The variant override `_readPolicyId` routes REDEEM_SENDER_POLICY to the
-    ///      `redeemPolicyIds` lane in the redeem namespace; uninitialised default is 0
-    ///      (ALWAYS_ALLOW_ID).
-    function test_policyId_success_redeemSenderDefaultIsZero() public view {
-        assertEq(token.policyId(REDEEM_SENDER_POLICY), uint64(0), "default REDEEM_SENDER_POLICY id must be 0");
+    ///      `redeemPolicyIds` lane in the redeem namespace. Unlike the four base policy
+    ///      slots (which default to the EVM zero state == ALWAYS_ALLOW_ID), the security
+    ///      variant's factory writes ALWAYS_BLOCK_ID into this lane at creation time so
+    ///      redemption is closed by default. Admins must opt-in by pointing the slot at
+    ///      an allowlist (or another policy) before any holder can call `redeem`.
+    function test_policyId_success_redeemSenderDefaultIsAlwaysBlock() public view {
+        assertEq(
+            token.policyId(REDEEM_SENDER_POLICY),
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "default REDEEM_SENDER_POLICY id must be ALWAYS_BLOCK_ID"
+        );
     }
 
     /// @notice Verifies policyId(REDEEM_SENDER_POLICY) reads back the last write

--- a/test/unit/B20Security/policy/updatePolicy.t.sol
+++ b/test/unit/B20Security/policy/updatePolicy.t.sol
@@ -117,11 +117,14 @@ contract B20SecurityUpdatePolicyTest is B20SecurityTest {
             "TRANSFER_SENDER write must persist"
         );
 
-        // And the redeem slot is untouched by a base-side write.
+        // And the redeem slot is untouched by a base-side write: still holds the
+        // factory-seeded ALWAYS_BLOCK_ID default (not the post-write ALWAYS_BLOCK_ID
+        // we just put into the base slot — they happen to share a value here, but the
+        // point is the SLOT didn't change).
         assertEq(
             token.policyId(REDEEM_SENDER_POLICY),
-            PolicyRegistryConstants.ALWAYS_ALLOW_ID,
-            "REDEEM_SENDER must not be affected by base writes"
+            PolicyRegistryConstants.ALWAYS_BLOCK_ID,
+            "REDEEM_SENDER must not be affected by base writes (still ALWAYS_BLOCK_ID default)"
         );
     }
 }

--- a/test/unit/B20Security/redeem/redeem.t.sol
+++ b/test/unit/B20Security/redeem/redeem.t.sol
@@ -12,6 +12,19 @@ import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityRedeemTest is B20SecurityTest {
+    /// @notice Opens REDEEM_SENDER_POLICY for the redemption-path tests in this contract.
+    ///         Security tokens default REDEEM_SENDER_POLICY to ALWAYS_BLOCK_ID at creation
+    ///         time so admins must explicitly open redemption. Tests in this contract
+    ///         exercise the redemption code path itself (balance, minimum, ratio, events,
+    ///         ordering), not the policy guard — so we open the policy in setUp to let
+    ///         the path under test be the thing being asserted. The one test that pins
+    ///         the policy guard (`test_redeem_revert_senderPolicyForbids`) explicitly
+    ///         sets ALWAYS_BLOCK_ID itself.
+    function setUp() public virtual override {
+        super.setUp();
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+    }
+
     /// @notice Verifies redeem reverts when REDEEM feature is paused
     /// @dev Pause guard fires first in execution order; checks ContractPaused(REDEEM) error.
     function test_redeem_revert_whenRedeemPaused(uint256 amount) public {

--- a/test/unit/B20Security/redeem/redeemWithMemo.t.sol
+++ b/test/unit/B20Security/redeem/redeemWithMemo.t.sol
@@ -11,6 +11,17 @@ import {IB20Security} from "src/interfaces/IB20Security.sol";
 import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20SecurityRedeemWithMemoTest is B20SecurityTest {
+    /// @notice Opens REDEEM_SENDER_POLICY for the memo-path redemption tests in this
+    ///         contract. Same rationale as `B20SecurityRedeemTest.setUp`: tests here
+    ///         exercise the memo-path code (memo emission, log ordering, zero memo)
+    ///         rather than the policy guard, so we open the slot in setUp. The one
+    ///         test that pins the policy guard (`test_redeemWithMemo_revert_senderPolicyForbids`)
+    ///         explicitly sets ALWAYS_BLOCK_ID itself.
+    function setUp() public virtual override {
+        super.setUp();
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+    }
+
     /// @notice Verifies redeemWithMemo reverts when REDEEM feature is paused
     /// @dev Pause guard fires first; memo path inherits the same guard as the bare `redeem`.
     function test_redeemWithMemo_revert_whenRedeemPaused(uint256 amount, bytes32 memo) public {


### PR DESCRIPTION
## Summary

Closes redemption by default for security tokens (BOP-152). The factory
now writes `ALWAYS_BLOCK_ID` into the `REDEEM_SENDER_POLICY` slot at
creation time, matching the `IB20Factory.B20SecurityCreateParams` natspec
that said it should already do this. Admins must explicitly open
redemption by pointing the slot at an allowlist (or another policy) — or
override at creation time via an `updatePolicy(REDEEM_SENDER_POLICY, ...)`
entry in `initCalls`.

The other four policy slots (`TRANSFER_SENDER`, `TRANSFER_RECEIVER`,
`TRANSFER_EXECUTOR`, `MINT_RECEIVER`) still default to `ALWAYS_ALLOW_ID`
via the EVM zero state — only `REDEEM_SENDER_POLICY` is special-cased.

A corresponding base/base change is in flight to mirror this on the
Rust precompile side.

## Changes

- `MockB20Factory._writeSecurityStorage` writes `ALWAYS_BLOCK_ID` into
  the bottom 64 bits of the packed `redeemPolicyIds` slot. Three
  reserved lanes stay zero.
- Existing redemption-path tests in `redeem.t.sol` / `redeemWithMemo.t.sol`
  open the policy in their `setUp` so the tests stay focused on the path
  under test (balance, minimum, ratio, event ordering). The two tests
  that explicitly pin the policy guard already set `ALWAYS_BLOCK_ID`
  themselves and are unaffected.
- `test_policyId_success_redeemSenderDefaultIsZero` → renamed to
  `...redeemSenderDefaultIsAlwaysBlock`, assertion flipped to match.
- `test_updatePolicy_success_baseTypesStillRouteThroughSuper` — updated
  REDEEM read-back to expect `ALWAYS_BLOCK_ID` (the factory-seeded
  default).
- Three new dedicated tests in `createToken.t.sol`:
  - `test_createB20_success_securityDefaultsRedeemPolicyToBlock` —
    pins the public surface + paired slot encoding
  - `test_createB20_success_securityOtherPolicySlotsDefaultToAllow` —
    confirms the change is scoped (the four base scopes still
    default to `ALWAYS_ALLOW_ID`, base packed slots stay zero)
  - `test_createB20_success_securityRedeemPolicyOverridableViaInitCall` —
    pins the override path documented in the natspec

## Inline unblock

`StdPrecompiles.sol:17` had a checksum-invalid address literal
(`0xB20F0000...` — should be `0xB20f0000...`) that broke `forge build`
on `main`. Included a 1-char fix so this PR can run CI; can pull out
into a separate PR if preferred.

## Tests

456 passed / 0 failed (453 baseline + 3 new). The 13 pre-existing tests
that assumed redemption was open by default were updated as part of
this change.