### PR TITLE
chore: add all pause constant

### DIFF
--- a/src/lib/B20Constants.sol
+++ b/src/lib/B20Constants.sol
@@ -27,4 +27,6 @@ library B20Constants {
     bytes32 internal constant TRANSFER_RECEIVER_POLICY = keccak256("TRANSFER_RECEIVER_POLICY");
     bytes32 internal constant TRANSFER_EXECUTOR_POLICY = keccak256("TRANSFER_EXECUTOR_POLICY");
     bytes32 internal constant MINT_RECEIVER_POLICY = keccak256("MINT_RECEIVER_POLICY");
+
+    uint8 internal constant ALL_FEATURES_PAUSED = 15;
 }


### PR DESCRIPTION
uint8 with all four bits set == 15
```solidity
        uint8 ALL_PAUSED = uint8(
            (1 << uint8(IB20.PausableFeature.TRANSFER)) | (1 << uint8(IB20.PausableFeature.MINT))
                | (1 << uint8(IB20.PausableFeature.BURN)) | (1 << uint8(IB20.PausableFeature.REDEEM))
        );
```