### PR TITLE
feat(factory): add StablecoinCreated and SecurityCreated companion events

### DIFF
--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -199,9 +199,9 @@ interface IB20Factory {
 
     /// @notice Emitted once per `createToken` invocation. The fields
     ///         cover the universal token-identity surface only;
-    ///         variant-specific state changes (e.g. `currency`, `isin`,
-    ///         supply cap, policy slots) are observable via the
-    ///         token's own events as they're applied during `initCalls`.
+    ///         variant-specific immutable fields (`currency`, `isin`) are
+    ///         announced in the companion events below, emitted in the same
+    ///         transaction immediately after `B20Created`.
     /// @dev    The initial admin grant (when `initialAdmin != address(0)`)
     ///         is announced via the standard `RoleGranted(DEFAULT_ADMIN_ROLE,
     ///         admin, factory)` event emitted from the token's own
@@ -212,6 +212,27 @@ interface IB20Factory {
     ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
     ///         skips the grant and emits no `RoleGranted` at bootstrap.
     event B20Created(address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals);
+
+    /// @notice Emitted immediately after `B20Created` when the new token is
+    ///         a Stablecoin variant. Carries the immutable `currency` field
+    ///         that is set at creation and has no setter on the token.
+    ///         Stream-based indexers (e.g. those that cannot make mid-handler
+    ///         view calls) should subscribe to this event to populate a
+    ///         `currency` column on their stablecoin token tables.
+    /// @param token    The address of the newly created stablecoin token.
+    ///                 Matches the `token` field on the preceding `B20Created`.
+    /// @param currency The ISO 4217 currency identifier (e.g. `"USD"`, `"EUR"`).
+    ///                 Uppercase ASCII letters (`A`–`Z`); immutable after creation.
+    event StablecoinCreated(address indexed token, string currency);
+
+    /// @notice Emitted immediately after `B20Created` when the new token is
+    ///         a Security variant. Carries the immutable `isin` field that is
+    ///         set at creation; additional identifiers (CUSIP, FIGI, SEDOL) can
+    ///         be attached post-creation via `IB20Security.updateSecurityIdentifier`.
+    /// @param token The address of the newly created security token.
+    ///              Matches the `token` field on the preceding `B20Created`.
+    /// @param isin  The ISIN identifier written at creation (e.g. `"US0378331005"`).
+    event SecurityCreated(address indexed token, string isin);
 
     /*//////////////////////////////////////////////////////////////
                                  CREATE

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -172,8 +172,19 @@ contract MockB20Factory is IB20Factory {
 
         // -- 6. Emit B20Created. Identity-only signal; admin role
         //       assignment is announced via the standard RoleGranted
-        //       event from step 7.
+        //       event from step 7. Variant-specific immutable fields
+        //       follow in companion events.
         emit B20Created(token, variant, name_, symbol_, decimals);
+
+        // -- 6a. Emit variant-specific companion events carrying immutable
+        //        fields not included in B20Created. These are emitted
+        //        immediately after B20Created in the same transaction so
+        //        stream-based indexers can correlate them by block position.
+        if (variant == B20Variant.STABLECOIN) {
+            emit StablecoinCreated(token, currency_);
+        } else if (variant == B20Variant.SECURITY) {
+            emit SecurityCreated(token, isin_);
+        }
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/unit/B20Factory/variantCreatedEvents.t.sol
+++ b/test/unit/B20Factory/variantCreatedEvents.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+
+/// @notice Tests for the variant-specific companion events `StablecoinCreated` and
+///         `SecurityCreated` emitted immediately after `B20Created` in the same
+///         transaction. These events carry the immutable per-variant fields
+///         (`currency`, `isin`) that are not included in `B20Created` itself,
+///         enabling stream-based indexers to populate variant-specific columns
+///         without making mid-handler view calls.
+contract B20FactoryVariantCreatedEventsTest is B20FactoryTest {
+    // ============================================================
+    //                     StablecoinCreated
+    // ============================================================
+
+    /// @notice StablecoinCreated is emitted after B20Created with the correct currency.
+    function test_createB20_success_emitsStablecoinCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("USD Coin", "USDC", admin, "USD");
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, caller, salt);
+
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.StablecoinCreated(predicted, "USD");
+        _createStablecoin(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice StablecoinCreated carries the exact currency string written at creation.
+    function test_createB20_success_stablecoinCreatedCurrencyMatchesParams(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Euro Coin", "EUROC", admin, "EUR");
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, caller, salt);
+
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.StablecoinCreated(predicted, "EUR");
+        _createStablecoin(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice StablecoinCreated is emitted in the same transaction as B20Created, after it.
+    function test_createB20_success_stablecoinCreatedEmittedAfterB20Created(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("JPY Coin", "JPYC", admin, "JPY");
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, caller, salt);
+
+        vm.expectEmit(true, true, false, true, address(factory));
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.STABLECOIN, "JPY Coin", "JPYC", 6);
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.StablecoinCreated(predicted, "JPY");
+        _createStablecoin(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice Creating a DEFAULT variant does NOT emit StablecoinCreated.
+    function test_createB20_success_defaultVariantDoesNotEmitStablecoinCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        vm.recordLogs();
+        _createDefault(caller, salt, _b20Params(), new bytes[](0));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 stablecoinSig = IB20Factory.StablecoinCreated.selector;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != stablecoinSig, "StablecoinCreated must not fire for DEFAULT variant");
+        }
+    }
+
+    /// @notice Creating a SECURITY variant does NOT emit StablecoinCreated.
+    function test_createB20_success_securityVariantDoesNotEmitStablecoinCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        vm.recordLogs();
+        _createSecurity(caller, salt, _securityParams(), new bytes[](0));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 stablecoinSig = IB20Factory.StablecoinCreated.selector;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != stablecoinSig, "StablecoinCreated must not fire for SECURITY variant");
+        }
+    }
+
+    // ============================================================
+    //                      SecurityCreated
+    // ============================================================
+
+    /// @notice SecurityCreated is emitted after B20Created with the correct ISIN.
+    function test_createB20_success_emitsSecurityCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20SecurityCreateParams memory p =
+            _securityParams("Apple Inc.", "AAPL", admin, APPLE_ISIN, 0);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
+
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.SecurityCreated(predicted, APPLE_ISIN);
+        _createSecurity(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice SecurityCreated carries the exact ISIN string written at creation.
+    function test_createB20_success_securityCreatedIsinMatchesParams(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20SecurityCreateParams memory p =
+            _securityParams("Security Test", "SEC", admin, DEFAULT_ISIN, 0);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
+
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.SecurityCreated(predicted, DEFAULT_ISIN);
+        _createSecurity(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice SecurityCreated is emitted in the same transaction as B20Created, after it.
+    function test_createB20_success_securityCreatedEmittedAfterB20Created(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20SecurityCreateParams memory p =
+            _securityParams("Apple Inc.", "AAPL", admin, APPLE_ISIN, 0);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
+
+        vm.expectEmit(true, true, false, true, address(factory));
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.SECURITY, "Apple Inc.", "AAPL", 6);
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit IB20Factory.SecurityCreated(predicted, APPLE_ISIN);
+        _createSecurity(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice Creating a DEFAULT variant does NOT emit SecurityCreated.
+    function test_createB20_success_defaultVariantDoesNotEmitSecurityCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        vm.recordLogs();
+        _createDefault(caller, salt, _b20Params(), new bytes[](0));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 securitySig = IB20Factory.SecurityCreated.selector;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != securitySig, "SecurityCreated must not fire for DEFAULT variant");
+        }
+    }
+
+    /// @notice Creating a STABLECOIN variant does NOT emit SecurityCreated.
+    function test_createB20_success_stablecoinVariantDoesNotEmitSecurityCreated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        vm.recordLogs();
+        _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 securitySig = IB20Factory.SecurityCreated.selector;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != securitySig, "SecurityCreated must not fire for STABLECOIN variant");
+        }
+    }
+}


### PR DESCRIPTION
[BOP-158](https://linear.app/coinbase/issue/BOP-158)

## Motivation

Stablecoin `currency` and security `isin` are immutable post-creation with no setters, so they were unobservable from the event stream. Stream-based indexers (e.g. Coindexer) that cannot make mid-handler RPC calls had no way to index them.

## What changed

Two new events emitted immediately after `B20Created` in the same transaction:

- `StablecoinCreated(address indexed token, string currency)`
- `SecurityCreated(address indexed token, string isin)`

`B20Created` is unchanged. 10 new tests verify field values, ordering, and cross-variant isolation.

type=standard
risk=low
impact=sev5