### PR TITLE
feat(factoryLib): Add helper for setting share ratio on token init

### DIFF
--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -348,6 +348,16 @@ library B20FactoryLib {
         return abi.encodeCall(IB20Security.updateSecurityIdentifier, (identifierType, value));
     }
 
+    /// @notice Encodes a call to `IB20Security.updateShareRatio(newShareRatio)`
+    ///         as a bootstrap initCall.
+    ///
+    /// @param  newShareRatio New share ratio.
+    ///
+    /// @return The ABI-encoded initCall blob.
+    function encodeUpdateShareRatio(uint256 newShareRatio) internal pure returns (bytes memory) {
+        return abi.encodeCall(IB20Security.updateShareRatio, (newShareRatio));
+    }
+
     /*//////////////////////////////////////////////////////////////
                        INIT-CALL ARRAY BUILDERS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
We want to be able to initialize B20Security Tokens with an updated share ratio (non 1:1). This helper enables integrators to cleanly access this privileged method on create. 