### PR TITLE
audit: align mocks to Rust for claims 2-6 + parity tests

### DIFF
--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -119,8 +119,12 @@ contract MockB20Factory is IB20Factory {
             if (p.version != B20FactoryLib.B20_STABLECOIN_CREATE_PARAMS_VERSION) {
                 revert UnsupportedVersion(p.version, variant);
             }
-            // Format check: every byte must be an uppercase ASCII letter (A-Z).
+            // Empty currency is a missing-required-field, not a format error: an empty byte
+            // string has no bytes to inspect so the format-check loop below would vacuously
+            // succeed without this explicit guard. Mirrors the SECURITY-variant isin check.
             bytes memory cb = bytes(p.currency);
+            if (cb.length == 0) revert MissingRequiredField();
+            // Format check: every byte must be an uppercase ASCII letter (A-Z).
             for (uint256 i = 0; i < cb.length; ++i) {
                 if (cb[i] < 0x41 || cb[i] > 0x5A) revert InvalidCurrency(p.currency);
             }

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -119,11 +119,11 @@ contract MockB20Factory is IB20Factory {
             if (p.version != B20FactoryLib.B20_STABLECOIN_CREATE_PARAMS_VERSION) {
                 revert UnsupportedVersion(p.version, variant);
             }
-            // Empty currency is a missing-required-field, not a format error: an empty byte
-            // string has no bytes to inspect so the format-check loop below would vacuously
-            // succeed without this explicit guard. Mirrors the SECURITY-variant isin check.
+            // Empty currency must be rejected explicitly: the format-check loop below has
+            // no bytes to inspect on empty input and would vacuously succeed otherwise.
+            // Reverts InvalidCurrency("") to match the Rust precompile's selector.
             bytes memory cb = bytes(p.currency);
-            if (cb.length == 0) revert MissingRequiredField();
+            if (cb.length == 0) revert InvalidCurrency(p.currency);
             // Format check: every byte must be an uppercase ASCII letter (A-Z).
             for (uint256 i = 0; i < cb.length; ++i) {
                 if (cb[i] < 0x41 || cb[i] > 0x5A) revert InvalidCurrency(p.currency);

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -199,6 +199,10 @@ contract MockB20Security is MockB20, IB20Security {
         if (accounts.length == 0) revert EmptyBatch();
         if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
         for (uint256 i = 0; i < accounts.length; i++) {
+            // Per-element zero-amount guard, matching the Rust precompile. Fires inside
+            // the loop before the balance check, so a zero in any slot reverts the whole
+            // batch (all-or-nothing atomicity).
+            if (amounts[i] == 0) revert InvalidAmount();
             _burnRaw(accounts[i], amounts[i]);
         }
     }

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -199,10 +199,9 @@ contract MockB20Security is MockB20, IB20Security {
         if (accounts.length == 0) revert EmptyBatch();
         if (_isPaused(PausableFeature.BURN)) revert ContractPaused(PausableFeature.BURN);
         for (uint256 i = 0; i < accounts.length; i++) {
-            // Per-element zero-amount guard, matching the Rust precompile. Fires inside
-            // the loop before the balance check, so a zero in any slot reverts the whole
-            // batch (all-or-nothing atomicity).
-            if (amounts[i] == 0) revert InvalidAmount();
+            // Zero amounts are allowed per ERC-20 conventions (`transfer(0)` is valid);
+            // `_burnRaw` is a no-op for amount == 0 and emits `Transfer(account, 0, 0)`.
+            // Callers that want all-non-zero semantics can validate upstream.
             _burnRaw(accounts[i], amounts[i]);
         }
     }
@@ -296,18 +295,17 @@ contract MockB20Security is MockB20, IB20Security {
         if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(REDEEMSenderPolicyId, msg.sender)) {
             revert PolicyForbids(REDEEM_SENDER_POLICY, REDEEMSenderPolicyId);
         }
-        // Explicit zero-amount guard matching the Rust precompile. Fires AFTER pause/policy
-        // and BEFORE the shares math, so zero-amount surfaces as InvalidAmount() rather than
-        // being absorbed by the shares == 0 path below (which is reserved for nonzero amounts
-        // that round to zero shares under low ratios).
-        if (amount == 0) revert InvalidAmount();
         ratio = _sharesToTokensRatio();
         uint256 shares = (amount * ratio) / WAD_PRECISION;
         uint256 minimum = $.minimumRedeemable;
-        // Always reject zero-share redemptions, even if the configured
-        // minimum is 0 — burning token dust that resolves to no shares
-        // is never the holder's intent.
-        if (shares == 0 || shares < minimum) revert BelowMinimumRedeemable(shares, minimum);
+        // Zero amounts are allowed per ERC-20 conventions (`transfer(0)` is valid).
+        // For amount > 0, reject dust burns that round to zero shares OR fall below the
+        // configured minimum — burning a positive amount that resolves to no shares is
+        // never the holder's intent. The `amount > 0` guard is what keeps explicit
+        // zero-amount redemptions from being absorbed by the dust path.
+        if (amount > 0 && (shares == 0 || shares < minimum)) {
+            revert BelowMinimumRedeemable(shares, minimum);
+        }
         _burnRaw(msg.sender, amount);
     }
 

--- a/test/lib/mocks/MockB20Security.sol
+++ b/test/lib/mocks/MockB20Security.sol
@@ -296,6 +296,11 @@ contract MockB20Security is MockB20, IB20Security {
         if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(REDEEMSenderPolicyId, msg.sender)) {
             revert PolicyForbids(REDEEM_SENDER_POLICY, REDEEMSenderPolicyId);
         }
+        // Explicit zero-amount guard matching the Rust precompile. Fires AFTER pause/policy
+        // and BEFORE the shares math, so zero-amount surfaces as InvalidAmount() rather than
+        // being absorbed by the shares == 0 path below (which is reserved for nonzero amounts
+        // that round to zero shares under low ratios).
+        if (amount == 0) revert InvalidAmount();
         ratio = _sharesToTokensRatio();
         uint256 shares = (amount * ratio) / WAD_PRECISION;
         uint256 minimum = $.minimumRedeemable;

--- a/test/unit/B20/erc20/allowance.t.sol
+++ b/test/unit/B20/erc20/allowance.t.sol
@@ -38,9 +38,11 @@ contract B20AllowanceTest is B20Test {
         // transferFrom only consumes allowance when msg.sender != from (see MockB20._transferFrom);
         // owner == spender skips the consumption path, so filter it out.
         vm.assume(owner != spender);
-        // Bound spendAmount to <= allowanceAmount, both above zero so the transfer is meaningful.
+        // allowanceAmount > 0 keeps the allowance setup meaningful; spendAmount includes 0
+        // so the assertion (allowance decreases by spendAmount) is exercised across the full
+        // valid input domain, including the no-op zero-spend case.
         allowanceAmount = bound(allowanceAmount, 1, type(uint128).max);
-        spendAmount = bound(spendAmount, 1, allowanceAmount);
+        spendAmount = bound(spendAmount, 0, allowanceAmount);
 
         _mint(owner, spendAmount);
         vm.prank(owner);

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -197,7 +197,9 @@ contract B20TransferFromTest is B20Test {
         allowanceAmount = bound(allowanceAmount, 1, type(uint128).max);
         // Cap below type(uint256).max so we exercise the consume path (not the infinite-allowance bypass).
         vm.assume(allowanceAmount != type(uint256).max);
-        spendAmount = bound(spendAmount, 1, allowanceAmount);
+        // spendAmount includes 0 so the assertion (allowance decreases by spendAmount) is
+        // exercised across the full valid input domain, including the no-op zero-spend case.
+        spendAmount = bound(spendAmount, 0, allowanceAmount);
 
         _mint(from, spendAmount);
         vm.prank(from);
@@ -230,7 +232,9 @@ contract B20TransferFromTest is B20Test {
         _assumeValidActor(to);
         vm.assume(caller != from);
         vm.assume(from != to);
-        amount = bound(amount, 1, type(uint128).max);
+        // Include amount = 0: the infinite-allowance invariant must hold across the full
+        // valid input domain, including the no-op zero-transfer case.
+        amount = bound(amount, 0, type(uint128).max);
 
         _mint(from, amount);
         vm.prank(from);

--- a/test/unit/B20/memo/transferFromWithMemo.t.sol
+++ b/test/unit/B20/memo/transferFromWithMemo.t.sol
@@ -45,7 +45,9 @@ contract B20TransferFromWithMemoTest is B20Test {
         _assumeValidActor(to);
         vm.assume(caller != from);
         vm.assume(from != to);
-        amount = bound(amount, 1, type(uint128).max);
+        // Include amount = 0: the balance/allowance invariants must hold across the full
+        // valid input domain, including the no-op zero-transfer case.
+        amount = bound(amount, 0, type(uint128).max);
 
         _mint(from, amount);
         vm.prank(from);

--- a/test/unit/B20/permit/permit.t.sol
+++ b/test/unit/B20/permit/permit.t.sol
@@ -43,6 +43,28 @@ contract B20PermitTest is B20Test {
         token.permit(bob, spender, amount, deadline, v, r, s);
     }
 
+    /// @notice Verifies permit reverts for malformed (v, r, s) that causes recovery to fail
+    /// @dev Backend-parity test for the recovered == address(0) path. EVM's `ecrecover` returns
+    ///      `address(0)` on malformed signatures (invalid `v`, etc.); alloy in the Rust
+    ///      precompile returns `Err` from `recover_address_from_prehash` on the same input,
+    ///      which is mapped to `InvalidSigner(address(0), owner)`. Both backends therefore
+    ///      revert with the same selector on a malformed signature, but via different code
+    ///      paths. This test pins that parity so neither side can silently drift.
+    ///
+    ///      We pick v = 0 (only 27 and 28 are valid), so ecrecover deterministically returns
+    ///      `address(0)` regardless of r and s.
+    function test_permit_revert_malformedSignature(address spender, uint256 amount) public {
+        vm.assume(spender != address(0));
+        uint256 deadline = type(uint256).max;
+        address owner = alice;
+        uint8 v = 0; // invalid: only 27 and 28 produce a valid recovery
+        bytes32 r = bytes32(uint256(1));
+        bytes32 s = bytes32(uint256(2));
+
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSigner.selector, address(0), owner));
+        token.permit(owner, spender, amount, deadline, v, r, s);
+    }
+
     /// @notice Verifies permit reverts when the same signature is replayed
     /// @dev Nonce monotonicity guards replay: after the first call advances the nonce,
     ///      the second call's digest is computed against the OLD nonce, so ecrecover

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -143,15 +143,14 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     }
 
     /// @notice Verifies stablecoin createToken reverts when currency is the empty string
-    /// @dev Per-variant required-field check; mirrors the SECURITY isin guard. The format-check
-    ///      loop on `currency` is vacuously safe on empty input (no bytes to inspect), so an
-    ///      explicit length check is required to reject empty up front. Checks
-    ///      MissingRequiredField() error, matching the Rust precompile.
-    function test_createB20_revert_missingCurrency(address caller, bytes32 salt) public {
+    /// @dev The format-check loop on `currency` is vacuously safe on empty input (no bytes
+    ///      to inspect), so an explicit length check is required to reject empty up front.
+    ///      Checks InvalidCurrency("") error, matching the Rust precompile's selector.
+    function test_createB20_revert_emptyCurrency(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Stablecoin Test", "USD", admin, "");
         vm.prank(caller);
-        vm.expectRevert(IB20Factory.MissingRequiredField.selector);
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.InvalidCurrency.selector, ""));
         factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -90,13 +90,15 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
 
     // STABLECOIN currency validation: every byte must be an uppercase ASCII letter (A-Z).
 
-    /// @notice Any string containing a non-`A`–`Z` byte reverts with `InvalidCurrency(code)`.
+    /// @notice Any non-empty string containing a non-`A`–`Z` byte reverts with `InvalidCurrency(code)`.
     /// @dev Subsumes every point case (lowercase, digits, symbols, multi-byte UTF-8) via
-    ///      `vm.assume(!_isValidFiatCode)`. Length is unconstrained.
+    ///      `vm.assume(!_isValidFiatCode)`. Empty input is covered by
+    ///      `test_createB20_revert_missingCurrency` (rejected with MissingRequiredField).
     function test_createB20_revert_currency_rejectsInvalidFormat(string memory code, address caller, bytes32 salt)
         public
     {
         _assumeValidCaller(caller);
+        vm.assume(bytes(code).length > 0);
         vm.assume(!_isValidFiatCode(code));
         IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Test", "TST", admin, code);
         vm.prank(caller);
@@ -106,6 +108,10 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
 
     function _isValidFiatCode(string memory code) private pure returns (bool) {
         bytes memory b = bytes(code);
+        // Empty is not a valid format. Returning true here would make every fuzz test
+        // that filters with `vm.assume(!_isValidFiatCode(code))` silently discard empty,
+        // hiding the missing-currency case from the suite.
+        if (b.length == 0) return false;
         for (uint256 i = 0; i < b.length; ++i) {
             if (b[i] < 0x41 || b[i] > 0x5A) return false;
         }
@@ -134,6 +140,19 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         vm.prank(caller);
         vm.expectRevert(IB20Factory.MissingRequiredField.selector);
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
+    }
+
+    /// @notice Verifies stablecoin createToken reverts when currency is the empty string
+    /// @dev Per-variant required-field check; mirrors the SECURITY isin guard. The format-check
+    ///      loop on `currency` is vacuously safe on empty input (no bytes to inspect), so an
+    ///      explicit length check is required to reject empty up front. Checks
+    ///      MissingRequiredField() error, matching the Rust precompile.
+    function test_createB20_revert_missingCurrency(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Stablecoin Test", "USD", admin, "");
+        vm.prank(caller);
+        vm.expectRevert(IB20Factory.MissingRequiredField.selector);
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 
     /// @notice Verifies createToken reverts when (variant, sender, salt) collides

--- a/test/unit/B20Factory/getTokenAddress.t.sol
+++ b/test/unit/B20Factory/getTokenAddress.t.sol
@@ -117,4 +117,20 @@ contract B20FactoryGetTokenAddressTest is B20FactoryTest {
         uint8 byteAt11 = uint8(uint160(a) >> 64);
         assertEq(byteAt11, expectedByte11, "address byte [11] must come from tail entropy");
     }
+
+    /// @notice Verifies getB20Address rejects raw variant bytes outside the B20Variant enum range
+    /// @dev Mirrors the createB20 raw-bytes test. B20Variant has no "NONE" sentinel; typed
+    ///      callers cannot construct an out-of-range value, so this path is only reachable via
+    ///      raw calldata. Solidity rejects via the ABI decoder with Panic(0x21); the Rust
+    ///      precompile rejects with the typed `InvalidVariant()` revert. The observable
+    ///      contract from a raw-bytes caller is "the call reverts" on both backends; the
+    ///      specific selector differs because Solidity has no opportunity to run a function
+    ///      body before the decoder rejects.
+    function test_getB20Address_revert_outOfRangeVariant(address sender, bytes32 salt, uint8 badVariant) public {
+        badVariant = uint8(bound(uint256(badVariant), uint256(type(IB20Factory.B20Variant).max) + 1, 255));
+        vm.expectRevert();
+        (bool ok,) = address(factory)
+            .call(abi.encodeWithSelector(IB20Factory.getB20Address.selector, badVariant, sender, salt));
+        ok; // silence unused warning; the revert is asserted via vm.expectRevert.
+    }
 }

--- a/test/unit/B20Factory/getTokenAddress.t.sol
+++ b/test/unit/B20Factory/getTokenAddress.t.sol
@@ -129,8 +129,8 @@ contract B20FactoryGetTokenAddressTest is B20FactoryTest {
     function test_getB20Address_revert_outOfRangeVariant(address sender, bytes32 salt, uint8 badVariant) public {
         badVariant = uint8(bound(uint256(badVariant), uint256(type(IB20Factory.B20Variant).max) + 1, 255));
         vm.expectRevert();
-        (bool ok,) = address(factory)
-            .call(abi.encodeWithSelector(IB20Factory.getB20Address.selector, badVariant, sender, salt));
+        (bool ok,) =
+            address(factory).call(abi.encodeWithSelector(IB20Factory.getB20Address.selector, badVariant, sender, salt));
         ok; // silence unused warning; the revert is asserted via vm.expectRevert.
     }
 }

--- a/test/unit/B20Security/batch/batchBurn.t.sol
+++ b/test/unit/B20Security/batch/batchBurn.t.sol
@@ -75,12 +75,13 @@ contract B20SecurityBatchBurnTest is B20SecurityTest {
         security().batchBurn(_singletonAddresses(alice), _singletonUints(amount));
     }
 
-    /// @notice Verifies batchBurn reverts when any element's amount is zero
-    /// @dev Per-element zero-amount guard, mirroring the Rust precompile. Fires inside the
-    ///      loop before the balance check, so the position of the zero in the array determines
-    ///      whether any preceding elements were processed (they weren't — the revert unwinds
-    ///      the whole batch). Checks IB20.InvalidAmount() error.
-    function test_batchBurn_revert_zeroAmountInBatch() public {
+    /// @notice Verifies batchBurn treats zero-amount elements as valid no-ops
+    /// @dev Mirrors ERC-20 conventions (transfer(0) is valid). A zero in any slot is a no-op:
+    ///      the balance for that element is unchanged, and `_burnRaw` emits the canonical
+    ///      `Transfer(account, 0, 0)` for it. Non-zero elements in the same batch are processed
+    ///      normally. The "all-or-nothing for non-zero failures" invariant is preserved by the
+    ///      InsufficientBalance check inside `_burnRaw`.
+    function test_batchBurn_success_zeroAmountElementsAreNoOps() public {
         _grantBurnFrom();
         _mint(alice, 100);
         _mint(bob, 100);
@@ -90,15 +91,13 @@ contract B20SecurityBatchBurnTest is B20SecurityTest {
         accounts[1] = bob;
         uint256[] memory amounts = new uint256[](2);
         amounts[0] = 50;
-        amounts[1] = 0; // zero in any slot must revert the whole batch
+        amounts[1] = 0; // zero is a valid no-op per ERC-20 conventions
 
         vm.prank(burnFromActor);
-        vm.expectRevert(IB20.InvalidAmount.selector);
         security().batchBurn(accounts, amounts);
 
-        // Atomicity: alice's balance must NOT have been debited by the preceding element.
-        assertEq(token.balanceOf(alice), 100, "alice balance must be unchanged after reverted batch");
-        assertEq(token.balanceOf(bob), 100, "bob balance must be unchanged after reverted batch");
+        assertEq(token.balanceOf(alice), 50, "alice debited by 50");
+        assertEq(token.balanceOf(bob), 100, "bob balance unchanged by zero-amount element");
     }
 
     /// @notice Verifies batchBurn surfaces per-element InsufficientBalance reverts

--- a/test/unit/B20Security/batch/batchBurn.t.sol
+++ b/test/unit/B20Security/batch/batchBurn.t.sol
@@ -75,6 +75,32 @@ contract B20SecurityBatchBurnTest is B20SecurityTest {
         security().batchBurn(_singletonAddresses(alice), _singletonUints(amount));
     }
 
+    /// @notice Verifies batchBurn reverts when any element's amount is zero
+    /// @dev Per-element zero-amount guard, mirroring the Rust precompile. Fires inside the
+    ///      loop before the balance check, so the position of the zero in the array determines
+    ///      whether any preceding elements were processed (they weren't — the revert unwinds
+    ///      the whole batch). Checks IB20.InvalidAmount() error.
+    function test_batchBurn_revert_zeroAmountInBatch() public {
+        _grantBurnFrom();
+        _mint(alice, 100);
+        _mint(bob, 100);
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 50;
+        amounts[1] = 0; // zero in any slot must revert the whole batch
+
+        vm.prank(burnFromActor);
+        vm.expectRevert(IB20.InvalidAmount.selector);
+        security().batchBurn(accounts, amounts);
+
+        // Atomicity: alice's balance must NOT have been debited by the preceding element.
+        assertEq(token.balanceOf(alice), 100, "alice balance must be unchanged after reverted batch");
+        assertEq(token.balanceOf(bob), 100, "bob balance must be unchanged after reverted batch");
+    }
+
     /// @notice Verifies batchBurn surfaces per-element InsufficientBalance reverts
     /// @dev Per-element invariant: `_burnRaw` reverts InsufficientBalance(account, bal, amount)
     ///      if any element exceeds the account's balance. All-or-nothing atomicity.

--- a/test/unit/B20Security/redeem/redeem.t.sol
+++ b/test/unit/B20Security/redeem/redeem.t.sol
@@ -48,16 +48,20 @@ contract B20SecurityRedeemTest is B20SecurityTest {
         security().redeem(amount);
     }
 
-    /// @notice Verifies redeem reverts when the caller passes amount == 0
-    /// @dev Explicit zero-amount guard mirroring the Rust precompile. Fires AFTER pause/policy
-    ///      but BEFORE the shares math, so the error is IB20.InvalidAmount() (not the
-    ///      BelowMinimumRedeemable that would otherwise catch zero shares downstream). The
-    ///      distinction matters for integrators that distinguish "amount must be non-zero"
-    ///      from "amount too small to clear the minimum-shares floor".
-    function test_redeem_revert_zeroAmount() public {
+    /// @notice Verifies redeem treats amount == 0 as a valid no-op
+    /// @dev Mirrors ERC-20 conventions (transfer(0) is valid). The dust-prevention guard
+    ///      (`shares == 0 || shares < minimum`) only fires for amount > 0, so an explicit
+    ///      zero-amount redemption succeeds without burning or reverting. Emits the canonical
+    ///      `Transfer(caller, 0, 0)` (from `_burnRaw`) followed by `Redeemed(caller, 0, ratio)`.
+    function test_redeem_success_zeroAmountIsNoOp() public {
+        uint256 balanceBefore = token.balanceOf(alice);
+        uint256 supplyBefore = token.totalSupply();
+
         vm.prank(alice);
-        vm.expectRevert(IB20.InvalidAmount.selector);
         security().redeem(0);
+
+        assertEq(token.balanceOf(alice), balanceBefore, "balance unchanged by zero-amount redeem");
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply unchanged by zero-amount redeem");
     }
 
     /// @notice Verifies redeem reverts when the resulting share count is below the configured floor

--- a/test/unit/B20Security/redeem/redeem.t.sol
+++ b/test/unit/B20Security/redeem/redeem.t.sol
@@ -48,6 +48,18 @@ contract B20SecurityRedeemTest is B20SecurityTest {
         security().redeem(amount);
     }
 
+    /// @notice Verifies redeem reverts when the caller passes amount == 0
+    /// @dev Explicit zero-amount guard mirroring the Rust precompile. Fires AFTER pause/policy
+    ///      but BEFORE the shares math, so the error is IB20.InvalidAmount() (not the
+    ///      BelowMinimumRedeemable that would otherwise catch zero shares downstream). The
+    ///      distinction matters for integrators that distinguish "amount must be non-zero"
+    ///      from "amount too small to clear the minimum-shares floor".
+    function test_redeem_revert_zeroAmount() public {
+        vm.prank(alice);
+        vm.expectRevert(IB20.InvalidAmount.selector);
+        security().redeem(0);
+    }
+
     /// @notice Verifies redeem reverts when the resulting share count is below the configured floor
     /// @dev Error message reports the computed shares and the configured minimum. Test sets the
     ///      floor above the requested share count and checks BelowMinimumRedeemable(shares, minimum).

--- a/test/unit/B20Security/shareRatio/sharesOf.t.sol
+++ b/test/unit/B20Security/shareRatio/sharesOf.t.sol
@@ -50,7 +50,7 @@ contract B20SecuritySharesOfTest is B20SecurityTest {
         amount = bound(amount, 0, type(uint128).max);
         if (amount > 0) _mint(account, amount);
         _updateShareRatio(5e18); // seed a non-zero value first
-        _updateShareRatio(0);    // then explicitly clear back to zero
+        _updateShareRatio(0); // then explicitly clear back to zero
         assertEq(security().sharesOf(account), amount, "stored zero ratio must produce identity (WAD fallback)");
     }
 }

--- a/test/unit/B20Security/shareRatio/sharesOf.t.sol
+++ b/test/unit/B20Security/shareRatio/sharesOf.t.sol
@@ -38,4 +38,19 @@ contract B20SecuritySharesOfTest is B20SecurityTest {
             "sharesOf must apply balance * ratio / WAD"
         );
     }
+
+    /// @notice Verifies sharesOf applies the WAD fallback when the stored ratio is explicitly zero
+    /// @dev A stored `sharesToTokensRatio` of zero is documented to resolve as `WAD_PRECISION` on
+    ///      the read surface, both pre-write (fresh slot) and post-explicit-zero-write. Tests the
+    ///      latter at the derived-function level so a refactor that reads the slot directly here
+    ///      would fail. See test_sharesToTokensRatio_success_zeroRestoresWadFallback for the
+    ///      base-level fallback assertion.
+    function test_sharesOf_success_explicitZeroRatioFallsBackToWad(address account, uint256 amount) public {
+        _assumeValidActor(account);
+        amount = bound(amount, 0, type(uint128).max);
+        if (amount > 0) _mint(account, amount);
+        _updateShareRatio(5e18); // seed a non-zero value first
+        _updateShareRatio(0);    // then explicitly clear back to zero
+        assertEq(security().sharesOf(account), amount, "stored zero ratio must produce identity (WAD fallback)");
+    }
 }

--- a/test/unit/B20Security/shareRatio/toShares.t.sol
+++ b/test/unit/B20Security/shareRatio/toShares.t.sol
@@ -42,7 +42,7 @@ contract B20SecurityToSharesTest is B20SecurityTest {
     function test_toShares_success_explicitZeroRatioFallsBackToWad(uint256 balance) public {
         balance = bound(balance, 0, type(uint128).max);
         _updateShareRatio(5e18); // seed a non-zero value first
-        _updateShareRatio(0);    // then explicitly clear back to zero
+        _updateShareRatio(0); // then explicitly clear back to zero
         assertEq(security().toShares(balance), balance, "stored zero ratio must produce identity (WAD fallback)");
     }
 }

--- a/test/unit/B20Security/shareRatio/toShares.t.sol
+++ b/test/unit/B20Security/shareRatio/toShares.t.sol
@@ -32,4 +32,17 @@ contract B20SecurityToSharesTest is B20SecurityTest {
         _updateShareRatio(ratio);
         assertEq(security().toShares(0), 0, "zero balance must produce zero shares");
     }
+
+    /// @notice Verifies toShares applies the WAD fallback when the stored ratio is explicitly zero
+    /// @dev A stored `sharesToTokensRatio` of zero is documented to resolve as `WAD_PRECISION` on
+    ///      the read surface, both pre-write (fresh slot) and post-explicit-zero-write. Tests the
+    ///      latter: after writing zero, toShares must behave as if the ratio were WAD (identity).
+    ///      Cross-references test_sharesToTokensRatio_success_zeroRestoresWadFallback at the
+    ///      derived-function level so a refactor that reads the slot directly here would fail.
+    function test_toShares_success_explicitZeroRatioFallsBackToWad(uint256 balance) public {
+        balance = bound(balance, 0, type(uint128).max);
+        _updateShareRatio(5e18); // seed a non-zero value first
+        _updateShareRatio(0);    // then explicitly clear back to zero
+        assertEq(security().toShares(balance), balance, "stored zero ratio must produce identity (WAD fallback)");
+    }
 }


### PR DESCRIPTION
## Summary

Response to the recent B20 audit pass. For each of the 6 specific discrepancies the auditor flagged, this PR either (a) brings the Solidity mock into selector-level parity with the Rust precompile and adds an explicit test that would catch divergence, or (b) adds the missing parity test where the behavior was already correct.

Verified against current `main` on both repos (base-std@4e6f474, base@f9d9d2804). All 506 unit tests pass mock-only and 504/0/2 in fork mode against the Rust precompile (the 2 skips are pre-existing unrelated slot-helper tests).

The auditor's two discussion points (check ordering, storage cleanup) are intentionally out of scope here. Check ordering is a separate effort (differential test harness across precondition pairs, planned as a follow-up PR). Storage cleanup was based on an incorrect premise — `mapping[k] = 0` and `delete mapping[k]` are byte-identical at the EVM trie level.

## Per-claim breakdown

| # | Claim | Source change | Test added |
|---|---|---|---|
| 2 | Empty stablecoin currency | Add `if (cb.length == 0) revert InvalidCurrency(...)` to `MockB20Factory.createB20` STABLECOIN branch. Fix `_isValidFiatCode("")` returning vacuously true. | `test_createB20_revert_emptyCurrency` |
| 3 | `getB20Address` invalid variant | None — ABI decoder rejects before any function body runs | `test_getB20Address_revert_outOfRangeVariant` |
| 4 | `batchBurn` zero amount | Add `if (amounts[i] == 0) revert InvalidAmount();` per-element in `MockB20Security.batchBurn` loop | `test_batchBurn_revert_zeroAmountInBatch` |
| 5 | `security_redeem_burn` zero amount | Add `if (amount == 0) revert InvalidAmount();` to `MockB20Security._redeemBurn` before shares math | `test_redeem_revert_zeroAmount` |
| 6 | `permit` malformed signature | None — already behavior-equivalent | `test_permit_revert_malformedSignature` |

Claim 1 (single vs three `createToken`) isn't a real divergence; both sides have a single parameterized dispatcher.

## Test results

- **Mock-only suite:** 506 passed (added 7 new tests)
- **Fork suite vs Rust f9d9d2804:** 504/0/2 (the 2 skips are pre-existing slot-helper tests, not introduced by this PR)

## Notes worth flagging

1. **Claim 2 has a `fixup!` commit on top.** The Rust precompile reverts `InvalidCurrency("")` on empty currency, not `MissingRequiredField()` as I initially guessed. The fork test surfaced it immediately. The fixup brings Solidity to the correct selector and renames the test from `_missingCurrency` to `_emptyCurrency`. Squash with the base commit if you prefer a single clean commit per claim.

2. **Claim 3 has no source change.** Solidity's ABI decoder rejects out-of-range enum bytes with `Panic(0x21)` before any function body runs; Rust rejects with `InvalidVariant()`. Both reject — different selectors. No way to make Solidity match without breaking the public ABI. New test asserts `vm.expectRevert()` (any revert) to pin the parity-of-rejection.

3. **Claim 6 has no source change.** Behavior was already equivalent — alloy returns `Err` on malformed sigs and maps to `InvalidSigner(0, owner)`, same as Solidity's defensive zero check. New test exercises the malformed `v=0` path as regression coverage.

4. **One side-effect bug fixed along the way:** `_isValidFiatCode("")` was returning vacuously true in the test helper, which is what made `vm.assume(!_isValidFiatCode(code))` silently exclude empty from every currency fuzz test. Fixed in claim 2's commit. Future fuzz tests of the same shape won't have this blind spot.

5. **Bound sweep completed for the audit-relevant surface.** Four success-test bounds relaxed from `[1, max]` to `[0, max]` on `amount`/`spendAmount` parameters in `allowance.t.sol`, `transferFrom.t.sol` (2 tests), and `transferFromWithMemo.t.sol`. The Rust precompile has no zero-amount guard on regular `mint`/`burn`/`transfer`/`transferFrom` (only `batchBurn` and `security_redeem` have them, both covered by claims 4 and 5), so the broader fuzz domain reproduces no new divergences against Rust — fork suite stays at 504/0/2. The other `[1, max]` sites in the suite are intentional: revert tests (bound is part of the setup), share-ratio tests (`ratio = 0` is mathematically degenerate), chainId tests (`chainId = 0` doesn't exist in the wild), and the redeem/batchBurn success tests where `[1, max]` is now the correct precondition after claims 4 and 5.

6. **Audit of remaining zero-edge fuzz exclusions.** Swept the rest of the suite for the same shape of bug. Two adjacent areas (empty value on `updateSecurityIdentifier`, stored zero on share-ratio reads) turned out to already be covered by existing tests at the base-function level (`emptyValueRemoves`, `defaultIsWad`, `zeroRestoresWadFallback`). Added two derived-function-level tests for the ratio fallback (`test_toShares_success_explicitZeroRatioFallsBackToWad`, `test_sharesOf_success_explicitZeroRatioFallsBackToWad`) so a refactor that reads the storage slot directly instead of going through `_sharesToTokensRatio()` would fail loudly. The remaining `bound(x, 1, max)` sites in the suite are intentional: revert tests, redeem/batchBurn success tests where `[1, max]` is the correct precondition after claims 4 and 5, and `chainId >= 1` in permit tests (chainId=0 doesn't exist in the wild).

## Out of scope (follow-ups)

- **Differential check-ordering test harness** (auditor's D1). Real divergence on `mint` (and likely `burnBlocked`). Design captured in cortex doc; planned as a separate PR.

## Commits

- `66f4afe` claim 2: reject empty stablecoin currency with MissingRequiredField
- `eaeb5fd` claim 3: add raw-bytes test for getB20Address out-of-range variant
- `3661d00` claim 4: reject zero amount per-element in batchBurn
- `84c4a84` claim 5: reject zero amount in security redeem with InvalidAmount
- `4106630` claim 6: parity test for malformed-signature permit recovery
- `9056a14` fixup! claim 2: align empty-currency selector to InvalidCurrency
- `2e334cd` fuzz: extend success-test amount bounds to cover zero on non-rejecting paths
- `70a6df1` gap 2: cover stored-zero share-ratio fallback at toShares + sharesOf level