### PR TITLE
test(check order): differential revert-order harness for B20 multi-precondition ops

### DIFF
--- a/test/unit/B20/erc20/approve_revertOrder.t.sol
+++ b/test/unit/B20/erc20/approve_revertOrder.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `approve`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ZERO-APPROVER (`msg.sender == address(0)`) → `InvalidApprover`
+///         2. ZERO-SPENDER (`spender == address(0)`) → `InvalidSpender`
+///
+///         C(2, 2) = 1 pair. ZERO-APPROVER requires pranking `address(0)`.
+contract B20ApproveRevertOrderTest is B20Test {
+    /// @notice ZERO-APPROVER beats ZERO-SPENDER.
+    function test_approve_revertOrder_zeroApprover_beats_zeroSpender(uint256 amount) public {
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidApprover.selector, address(0)));
+        token.approve(address(0), amount);
+    }
+}

--- a/test/unit/B20/erc20/transferFrom_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transferFrom_revertOrder.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `transferFrom`.
+///
+/// @notice `transferFrom` adds two preconditions on top of `_transfer`'s checks
+///         (already pinned by `transfer_revertOrder.t.sol`):
+///
+///         **Canonical order (Solidity reference, when `msg.sender != from`):**
+///         1. ALLOWANCE (`_consumeAllowance`) → `InsufficientAllowance`
+///         2. EXECUTOR-POLICY (`isAuthorized(executorPolicyId, msg.sender)`) → `PolicyForbids(EXECUTOR, ...)`
+///         3..N. (all `_transfer` body checks — see `transfer_revertOrder.t.sol`)
+///
+///         These tests pin the two new preconditions against each other and
+///         against a representative `_transfer` body check (ZERO-RECEIVER) to
+///         prove they fire before `_transfer` is entered.
+contract B20TransferFromRevertOrderTest is B20Test {
+    /// @notice ALLOWANCE beats EXECUTOR-POLICY.
+    function test_transferFrom_revertOrder_allowance_beats_executorPolicy(
+        address caller,
+        address from,
+        address to,
+        uint256 amount
+    ) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+        // Allowance is 0 (less than amount) AND executor policy blocks caller.
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientAllowance.selector, caller, 0, amount));
+        token.transferFrom(from, to, amount);
+    }
+
+    /// @notice ALLOWANCE beats anything in `_transfer` (representative: ZERO-RECEIVER).
+    function test_transferFrom_revertOrder_allowance_beats_transferBody(address caller, address from, uint256 amount)
+        public
+    {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+        // Allowance is 0 AND `to` is address(0).
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientAllowance.selector, caller, 0, amount));
+        token.transferFrom(from, address(0), amount);
+    }
+
+    /// @notice EXECUTOR-POLICY beats anything in `_transfer` (representative: ZERO-RECEIVER).
+    /// @dev Allowance is set high enough to pass the allowance check, so the executor-policy
+    ///      check is reached next, and it fires before `_transfer` is entered.
+    function test_transferFrom_revertOrder_executorPolicy_beats_transferBody(
+        address caller,
+        address from,
+        uint256 amount
+    ) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        vm.assume(caller != from);
+        amount = bound(amount, 1, type(uint128).max);
+        // Sufficient allowance, executor policy blocks caller, `to` is address(0).
+        vm.prank(from);
+        token.approve(caller, amount);
+        _setPolicy(B20Constants.TRANSFER_EXECUTOR_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                B20Constants.TRANSFER_EXECUTOR_POLICY,
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        token.transferFrom(from, address(0), amount);
+    }
+}

--- a/test/unit/B20/erc20/transfer_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transfer_revertOrder.t.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `transfer`.
+///
+/// @notice **Canonical order (Solidity reference `_transfer`):**
+///         1. ZERO-RECEIVER (`to == address(0)`) → `InvalidReceiver`
+///         2. ZERO-SENDER (`from == address(0)`) → `InvalidSender`
+///         3. PAUSE (`_isPaused(TRANSFER)`) → `ContractPaused`
+///         4. SENDER-POLICY (`isAuthorized(senderPolicyId, from)`) → `PolicyForbids(SENDER, ...)`
+///         5. RECEIVER-POLICY (`isAuthorized(receiverPolicyId, to)`) → `PolicyForbids(RECEIVER, ...)`
+///         6. BALANCE (`fromBalance < amount`) → `InsufficientBalance`
+///
+///         The public `transfer(to, amount)` entry sets `from = msg.sender`, so
+///         pairs involving ZERO-SENDER require pranking `address(0)`. C(6, 2) = 15 pairs.
+contract B20TransferRevertOrderTest is B20Test {
+    // --- Pairs where ZERO-RECEIVER wins ---
+
+    function test_transfer_revertOrder_zeroReceiver_beats_zeroSender(uint256 amount) public {
+        // Both `to` and `from` are address(0) — receiver check fires first.
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
+    }
+
+    function test_transfer_revertOrder_zeroReceiver_beats_pause(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
+    }
+
+    function test_transfer_revertOrder_zeroReceiver_beats_senderPolicy(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
+    }
+
+    function test_transfer_revertOrder_zeroReceiver_beats_receiverPolicy(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
+    }
+
+    function test_transfer_revertOrder_zeroReceiver_beats_balance(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        amount = bound(amount, 1, type(uint128).max);
+        // `from` has zero balance → balance check WOULD fail if zero-receiver didn't fire first.
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.transfer(address(0), amount);
+    }
+
+    // --- Pairs where ZERO-SENDER wins (requires pranking address(0)) ---
+
+    function test_transfer_revertOrder_zeroSender_beats_pause(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSender.selector, address(0)));
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_zeroSender_beats_senderPolicy(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSender.selector, address(0)));
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_zeroSender_beats_receiverPolicy(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSender.selector, address(0)));
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_zeroSender_beats_balance(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        amount = bound(amount, 1, type(uint128).max);
+
+        vm.prank(address(0));
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidSender.selector, address(0)));
+        token.transfer(to, amount);
+    }
+
+    // --- Pairs where PAUSE wins ---
+
+    function test_transfer_revertOrder_pause_beats_senderPolicy(address from, address to, uint256 amount) public {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _pause(IB20.PausableFeature.TRANSFER);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_pause_beats_receiverPolicy(address from, address to, uint256 amount) public {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _pause(IB20.PausableFeature.TRANSFER);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_pause_beats_balance(address from, address to, uint256 amount) public {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        amount = bound(amount, 1, type(uint128).max);
+        _pause(IB20.PausableFeature.TRANSFER);
+
+        vm.prank(from);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.TRANSFER));
+        token.transfer(to, amount);
+    }
+
+    // --- Pairs where SENDER-POLICY wins ---
+
+    function test_transfer_revertOrder_senderPolicy_beats_receiverPolicy(address from, address to, uint256 amount)
+        public
+    {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                B20Constants.TRANSFER_SENDER_POLICY,
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        token.transfer(to, amount);
+    }
+
+    function test_transfer_revertOrder_senderPolicy_beats_balance(address from, address to, uint256 amount) public {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        amount = bound(amount, 1, type(uint128).max);
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                B20Constants.TRANSFER_SENDER_POLICY,
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        token.transfer(to, amount);
+    }
+
+    // --- Pair where RECEIVER-POLICY wins ---
+
+    function test_transfer_revertOrder_receiverPolicy_beats_balance(address from, address to, uint256 amount) public {
+        _assumeValidActor(from);
+        _assumeValidActor(to);
+        amount = bound(amount, 1, type(uint128).max);
+        _setPolicy(B20Constants.TRANSFER_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(from);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                B20Constants.TRANSFER_RECEIVER_POLICY,
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        token.transfer(to, amount);
+    }
+}

--- a/test/unit/B20/permit/permit_revertOrder.t.sol
+++ b/test/unit/B20/permit/permit_revertOrder.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `permit`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. EXPIRED-SIGNATURE (`block.timestamp > deadline`) → `ExpiredSignature`
+///         2. INVALID-SIGNER (`recovered == 0 || recovered != owner`) → `InvalidSigner`
+///
+///         C(2, 2) = 1 pair.
+contract B20PermitRevertOrderTest is B20Test {
+    /// @notice EXPIRED-SIGNATURE beats INVALID-SIGNER.
+    /// @dev Passes a malformed signature (v=0 → ecrecover returns address(0))
+    ///      with an already-expired deadline. The deadline check fires before
+    ///      the signature is even decoded, so the expired error wins.
+    function test_permit_revertOrder_expired_beats_invalidSigner(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline
+    ) public {
+        vm.assume(spender != address(0));
+        deadline = bound(deadline, 0, block.timestamp - 1);
+        // Malformed signature: v=0 is invalid (valid values are 27 or 28).
+        uint8 v = 0;
+        bytes32 r = bytes32(uint256(1));
+        bytes32 s = bytes32(uint256(2));
+
+        vm.expectRevert(abi.encodeWithSelector(IB20.ExpiredSignature.selector, deadline));
+        token.permit(owner, spender, value, deadline, v, r, s);
+    }
+}

--- a/test/unit/B20/policy/updatePolicy_revertOrder.t.sol
+++ b/test/unit/B20/policy/updatePolicy_revertOrder.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `updatePolicy`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRole(DEFAULT_ADMIN_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. UNSUPPORTED-POLICY-TYPE (`_readPolicyId(scope)` reverts on unknown scope) → `UnsupportedPolicyType`
+///         3. POLICY-NOT-FOUND (`policyExists(newPolicyId) == false`) → `PolicyNotFound`
+///
+///         C(3, 2) = 3 pairs.
+contract B20UpdatePolicyRevertOrderTest is B20Test {
+    /// @dev A bytes32 value that is NOT one of the four known policy scopes (TRANSFER_SENDER,
+    ///      TRANSFER_RECEIVER, TRANSFER_EXECUTOR, MINT_RECEIVER). Triggers
+    ///      `UnsupportedPolicyType` when passed to `updatePolicy`.
+    bytes32 internal constant UNKNOWN_POLICY_SCOPE = keccak256("unknown-scope-for-revert-order-test");
+
+    /// @dev A uint64 that is not a registered policy ID (not ALWAYS_ALLOW, not ALWAYS_BLOCK,
+    ///      and never created). Triggers `PolicyNotFound` when passed to `updatePolicy`.
+    uint64 internal constant UNKNOWN_POLICY_ID = 0xdeadbeef;
+
+    // --- Pairs where ROLE wins ---
+
+    function test_updatePolicy_revertOrder_role_beats_unsupportedType(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        // Caller lacks DEFAULT_ADMIN_ROLE AND the scope is unknown.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.updatePolicy(UNKNOWN_POLICY_SCOPE, PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+    }
+
+    function test_updatePolicy_revertOrder_role_beats_policyNotFound(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        // Caller lacks role AND newPolicyId doesn't exist.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.updatePolicy(B20Constants.TRANSFER_SENDER_POLICY, UNKNOWN_POLICY_ID);
+    }
+
+    // --- Pair where UNSUPPORTED-POLICY-TYPE wins ---
+
+    function test_updatePolicy_revertOrder_unsupportedType_beats_policyNotFound() public {
+        // Both: scope is unknown AND newPolicyId doesn't exist. The scope read (`_readPolicyId`)
+        // runs before the policy-existence check.
+
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IB20.UnsupportedPolicyType.selector, UNKNOWN_POLICY_SCOPE));
+        token.updatePolicy(UNKNOWN_POLICY_SCOPE, UNKNOWN_POLICY_ID);
+    }
+}

--- a/test/unit/B20/roles/renounceLastAdmin_revertOrder.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin_revertOrder.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `renounceLastAdmin`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`!$.roles[DEFAULT_ADMIN_ROLE][msg.sender]`) → `AccessControlUnauthorizedAccount`
+///         2. NOT-SOLE-ADMIN (`$.adminCount != 1`) → `NotSoleAdmin`
+///
+///         C(2, 2) = 1 pair.
+contract B20RenounceLastAdminRevertOrderTest is B20Test {
+    /// @notice ROLE beats NOT-SOLE-ADMIN.
+    /// @dev Caller does NOT have DEFAULT_ADMIN_ROLE AND adminCount > 1 (a second admin exists).
+    ///      Role check fires before the sole-admin invariant.
+    function test_renounceLastAdmin_revertOrder_role_beats_notSoleAdmin(address caller, address otherAdmin) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(otherAdmin);
+        vm.assume(caller != admin);
+        vm.assume(otherAdmin != admin);
+        vm.assume(otherAdmin != caller);
+        _grantRole(B20Constants.DEFAULT_ADMIN_ROLE, otherAdmin); // adminCount == 2
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.renounceLastAdmin();
+    }
+}

--- a/test/unit/B20/roles/renounceRole_revertOrder.t.sol
+++ b/test/unit/B20/roles/renounceRole_revertOrder.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `renounceRole`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. BAD-CONFIRMATION (`callerConfirmation != msg.sender`) → `AccessControlBadConfirmation`
+///         2. LAST-ADMIN (role == DEFAULT_ADMIN && caller holds it && adminCount == 1) → `LastAdminCannotRenounce`
+///
+///         C(2, 2) = 1 pair.
+contract B20RenounceRoleRevertOrderTest is B20Test {
+    /// @notice BAD-CONFIRMATION beats LAST-ADMIN.
+    /// @dev Caller is the sole admin (LAST-ADMIN would fire) AND passes a wrong confirmation.
+    ///      Confirmation check runs before the last-admin guard.
+    function test_renounceRole_revertOrder_badConfirmation_beats_lastAdmin(address wrongConfirmation) public {
+        vm.assume(wrongConfirmation != admin);
+        // admin is the sole admin by default (precondition for LAST-ADMIN).
+
+        vm.prank(admin);
+        vm.expectRevert(IB20.AccessControlBadConfirmation.selector);
+        token.renounceRole(B20Constants.DEFAULT_ADMIN_ROLE, wrongConfirmation);
+    }
+}

--- a/test/unit/B20/roles/revokeRole_revertOrder.t.sol
+++ b/test/unit/B20/roles/revokeRole_revertOrder.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `revokeRole`.
+///
+/// @notice **Canonical order (Solidity reference, post-BOP-196):**
+///         1. ROLE (`onlyRoleAdmin(role)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. LAST-ADMIN (`role == DEFAULT_ADMIN && account holds it && adminCount == 1`)
+///            → `LastAdminCannotRenounce`
+///
+///         C(2, 2) = 1 pair. The LAST-ADMIN guard was added in
+///         [PR #91 (BOP-196)](https://github.com/base/base-std/pull/91); before that fix
+///         `revokeRole` would silently brick the token by removing the sole admin.
+contract B20RevokeRoleRevertOrderTest is B20Test {
+    /// @notice ROLE beats LAST-ADMIN.
+    /// @dev Caller lacks the role-admin role AND the target is the sole DEFAULT_ADMIN_ROLE holder.
+    ///      The `onlyRoleAdmin` modifier runs before the body's last-admin guard.
+    function test_revokeRole_revertOrder_role_beats_lastAdmin(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        // admin is the sole DEFAULT_ADMIN_ROLE holder by default.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.revokeRole(B20Constants.DEFAULT_ADMIN_ROLE, admin);
+    }
+}

--- a/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
+++ b/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
@@ -33,7 +33,9 @@ contract B20BurnBlockedRevertOrderTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE
+            )
         );
         token.burnBlocked(from, amount);
     }
@@ -48,7 +50,9 @@ contract B20BurnBlockedRevertOrderTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE
+            )
         );
         token.burnBlocked(from, amount);
     }
@@ -63,7 +67,9 @@ contract B20BurnBlockedRevertOrderTest is B20Test {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE
+            )
         );
         token.burnBlocked(from, amount);
     }

--- a/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
+++ b/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `burnBlocked`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRole(BURN_BLOCKED_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. PAUSE (`_isPaused(BURN)`) → `ContractPaused`
+///         3. BLOCKED (`isAuthorized(senderPolicyId, from) == true` reverts) → `AccountNotBlocked`
+///         4. BALANCE (`fromBalance < amount` in `_burnRaw`) → `InsufficientBalance`
+///
+///         Note on BLOCKED semantics: `burnBlocked` is a clawback function — it
+///         only succeeds when `from` is currently NOT authorized by the
+///         transfer-sender policy. A test triggers the BLOCKED-precondition
+///         violation by setting the policy to `ALWAYS_ALLOW` so every account is
+///         authorized, which makes the function revert `AccountNotBlocked`.
+contract B20BurnBlockedRevertOrderTest is B20Test {
+    // --- Pairs where ROLE wins ---
+
+    /// @notice ROLE beats PAUSE.
+    function test_burnBlocked_revertOrder_role_beats_pause(address caller, address from, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        vm.assume(caller != admin);
+        _pause(IB20.PausableFeature.BURN);
+        // No BURN_BLOCKED_ROLE granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+        );
+        token.burnBlocked(from, amount);
+    }
+
+    /// @notice ROLE beats BLOCKED.
+    function test_burnBlocked_revertOrder_role_beats_blocked(address caller, address from, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        vm.assume(caller != admin);
+        // TRANSFER_SENDER_POLICY left at ALWAYS_ALLOW default → `from` is "not blocked".
+        // No BURN_BLOCKED_ROLE granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+        );
+        token.burnBlocked(from, amount);
+    }
+
+    /// @notice ROLE beats BALANCE.
+    function test_burnBlocked_revertOrder_role_beats_balance(address caller, address from, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(from);
+        vm.assume(caller != admin);
+        amount = bound(amount, 1, type(uint128).max);
+        // `from` has zero balance, no role granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_BLOCKED_ROLE)
+        );
+        token.burnBlocked(from, amount);
+    }
+
+    // --- Pairs where PAUSE wins ---
+
+    /// @notice PAUSE beats BLOCKED.
+    function test_burnBlocked_revertOrder_pause_beats_blocked(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        _pause(IB20.PausableFeature.BURN);
+        // TRANSFER_SENDER_POLICY left at ALWAYS_ALLOW → `from` is "not blocked".
+
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        token.burnBlocked(from, amount);
+    }
+
+    /// @notice PAUSE beats BALANCE.
+    function test_burnBlocked_revertOrder_pause_beats_balance(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        amount = bound(amount, 1, type(uint128).max);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        _pause(IB20.PausableFeature.BURN);
+        // Need `from` blocked so BLOCKED would pass; set transfer-sender policy to ALWAYS_BLOCK.
+        _setPolicy(B20Constants.TRANSFER_SENDER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        token.burnBlocked(from, amount);
+    }
+
+    // --- Pair where BLOCKED wins ---
+
+    /// @notice BLOCKED beats BALANCE.
+    /// @dev `from` is not blocked AND has insufficient balance — BLOCKED check fires before `_burnRaw`.
+    function test_burnBlocked_revertOrder_blocked_beats_balance(address from, uint256 amount) public {
+        _assumeValidActor(from);
+        amount = bound(amount, 1, type(uint128).max);
+        _grantRole(B20Constants.BURN_BLOCKED_ROLE, burnBlocker);
+        // Default TRANSFER_SENDER_POLICY is ALWAYS_ALLOW → `from` is NOT blocked.
+        // `from` has zero balance → balance check WOULD fail if BLOCKED didn't fire first.
+
+        vm.prank(burnBlocker);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccountNotBlocked.selector, from));
+        token.burnBlocked(from, amount);
+    }
+}

--- a/test/unit/B20/supply/burn_revertOrder.t.sol
+++ b/test/unit/B20/supply/burn_revertOrder.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `burn` (self-burn).
+///
+/// @notice For each pair of preconditions `burn` enforces, this contract pins the
+///         canonical first-firing revert selector. See `mint_revertOrder.t.sol`
+///         for the harness rationale.
+///
+///         **Canonical order (Solidity reference, `_burnSelf` → `_burnRaw`):**
+///         1. ROLE (`onlyRole(BURN_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. PAUSE (`_isPaused(BURN)`) → `ContractPaused`
+///         3. BALANCE (`fromBalance < amount` in `_burnRaw`) → `InsufficientBalance`
+contract B20BurnRevertOrderTest is B20Test {
+    /// @notice ROLE beats PAUSE.
+    /// @dev Modifier runs before any body check, including the pause guard.
+    function test_burn_revertOrder_role_beats_pause(address caller, uint256 amount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_ROLE)
+        );
+        token.burn(amount);
+    }
+
+    /// @notice ROLE beats BALANCE.
+    /// @dev Modifier runs before `_burnRaw` is reached; insufficient balance never gets checked.
+    function test_burn_revertOrder_role_beats_balance(address caller, uint256 amount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        amount = bound(amount, 1, type(uint128).max);
+        // Caller has zero balance and no role — role check fires first.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.BURN_ROLE)
+        );
+        token.burn(amount);
+    }
+
+    /// @notice PAUSE beats BALANCE.
+    /// @dev Pause guard in `_burnSelf` runs before `_burnRaw` is invoked.
+    function test_burn_revertOrder_pause_beats_balance(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        _grantRole(B20Constants.BURN_ROLE, alice);
+        _pause(IB20.PausableFeature.BURN);
+        // alice has BURN_ROLE but zero balance AND BURN is paused.
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        token.burn(amount);
+    }
+}

--- a/test/unit/B20/supply/mint_revertOrder.t.sol
+++ b/test/unit/B20/supply/mint_revertOrder.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `mint`.
+///
+/// @notice For each pair of preconditions `mint` enforces, this contract pins the
+///         canonical first-firing revert selector. Tests pass in mock mode iff the
+///         Solidity reference enforces the canonical order, and they pass in fork
+///         mode iff the Rust precompile enforces the same order. Any divergence
+///         between the two backends surfaces as a fork-mode-only failure with a
+///         clear "selector A vs selector B" diff.
+///
+///         **Canonical order (Option A — Solidity's defensive-depth order):**
+///         1. ROLE (`onlyRole(MINT_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. ZERO-RECEIVER (`to == address(0)`) → `InvalidReceiver`
+///         3. PAUSE (`_isPaused(MINT)`) → `ContractPaused`
+///         4. POLICY (`isAuthorized(mintReceiverPolicyId, to)`) → `PolicyForbids`
+///         5. SUPPLY-CAP (`totalSupply + amount > supplyCap`) → `SupplyCapExceeded`
+///
+///         A `mint` call that violates two or more preconditions must always
+///         revert with the selector for the earliest-listed violation. The 10
+///         tests below enumerate every pair (C(5, 2) = 10).
+contract B20MintRevertOrderTest is B20Test {
+    // --- Pairs where ROLE wins (ROLE is canonical first) ---
+
+    /// @notice With both ROLE and ZERO-RECEIVER violated, ROLE fires first.
+    /// @dev Canonical: the `onlyRole` modifier runs before the `to == 0` body check.
+    function test_mint_revertOrder_role_beats_zeroRecipient(address caller, uint256 amount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin); // admin holds DEFAULT_ADMIN_ROLE but not MINT_ROLE on fresh token
+        // No MINT_ROLE granted; recipient is address(0).
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.MINT_ROLE)
+        );
+        token.mint(address(0), amount);
+    }
+
+    /// @notice With both ROLE and PAUSE violated, ROLE fires first.
+    /// @dev Canonical: modifier runs before any body check, including the pause guard.
+    function test_mint_revertOrder_role_beats_pause(address caller, address to, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(to);
+        vm.assume(caller != admin);
+        _pause(IB20.PausableFeature.MINT);
+        // No MINT_ROLE granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.MINT_ROLE)
+        );
+        token.mint(to, amount);
+    }
+
+    /// @notice With both ROLE and POLICY violated, ROLE fires first.
+    /// @dev Canonical: modifier runs before the receiver-policy check.
+    function test_mint_revertOrder_role_beats_policy(address caller, address to, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(to);
+        vm.assume(caller != admin);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        // No MINT_ROLE granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.MINT_ROLE)
+        );
+        token.mint(to, amount);
+    }
+
+    /// @notice With both ROLE and CAP violated, ROLE fires first.
+    /// @dev Canonical: modifier runs before the supply-cap arithmetic check.
+    function test_mint_revertOrder_role_beats_cap(address caller, address to, uint256 amount) public {
+        _assumeValidCaller(caller);
+        _assumeValidActor(to);
+        vm.assume(caller != admin);
+        amount = bound(amount, 1, type(uint128).max);
+        vm.prank(admin);
+        token.updateSupplyCap(0); // any positive amount overflows the cap.
+        // No MINT_ROLE granted.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.MINT_ROLE)
+        );
+        token.mint(to, amount);
+    }
+
+    // --- Pairs where ZERO-RECEIVER wins (ROLE satisfied) ---
+
+    /// @notice With ZERO-RECEIVER and PAUSE violated, ZERO-RECEIVER fires first.
+    /// @dev Canonical: zero-receiver guard runs before the pause guard inside `_mint`.
+    function test_mint_revertOrder_zeroRecipient_beats_pause(uint256 amount) public {
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _pause(IB20.PausableFeature.MINT);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.mint(address(0), amount);
+    }
+
+    /// @notice With ZERO-RECEIVER and POLICY violated, ZERO-RECEIVER fires first.
+    /// @dev Canonical: zero-receiver guard runs before the receiver-policy check.
+    function test_mint_revertOrder_zeroRecipient_beats_policy(uint256 amount) public {
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.mint(address(0), amount);
+    }
+
+    /// @notice With ZERO-RECEIVER and CAP violated, ZERO-RECEIVER fires first.
+    /// @dev Canonical: zero-receiver guard runs before the supply-cap arithmetic.
+    function test_mint_revertOrder_zeroRecipient_beats_cap(uint256 amount) public {
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        amount = bound(amount, 1, type(uint128).max);
+        vm.prank(admin);
+        token.updateSupplyCap(0);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        token.mint(address(0), amount);
+    }
+
+    // --- Pairs where PAUSE wins (ROLE + ZERO-RECEIVER satisfied) ---
+
+    /// @notice With PAUSE and POLICY violated, PAUSE fires first.
+    /// @dev Canonical: pause guard runs before the receiver-policy check.
+    function test_mint_revertOrder_pause_beats_policy(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _pause(IB20.PausableFeature.MINT);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.MINT));
+        token.mint(to, amount);
+    }
+
+    /// @notice With PAUSE and CAP violated, PAUSE fires first.
+    /// @dev Canonical: pause guard runs before the supply-cap arithmetic.
+    function test_mint_revertOrder_pause_beats_cap(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _pause(IB20.PausableFeature.MINT);
+        amount = bound(amount, 1, type(uint128).max);
+        vm.prank(admin);
+        token.updateSupplyCap(0);
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.MINT));
+        token.mint(to, amount);
+    }
+
+    // --- Pair where POLICY wins (ROLE + ZERO + PAUSE satisfied) ---
+
+    /// @notice With POLICY and CAP violated, POLICY fires first.
+    /// @dev Canonical: receiver-policy check runs before the supply-cap arithmetic.
+    function test_mint_revertOrder_policy_beats_cap(address to, uint256 amount) public {
+        _assumeValidActor(to);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+        _setPolicy(B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        amount = bound(amount, 1, type(uint128).max);
+        vm.prank(admin);
+        token.updateSupplyCap(0);
+
+        vm.prank(minter);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector, B20Constants.MINT_RECEIVER_POLICY, PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        token.mint(to, amount);
+    }
+}

--- a/test/unit/B20/supply/updateSupplyCap_revertOrder.t.sol
+++ b/test/unit/B20/supply/updateSupplyCap_revertOrder.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Test} from "test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `updateSupplyCap`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRole(DEFAULT_ADMIN_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. INVALID-SUPPLY-CAP (`newSupplyCap < currentSupply`) → `InvalidSupplyCap`
+///
+///         C(2, 2) = 1 pair.
+contract B20UpdateSupplyCapRevertOrderTest is B20Test {
+    /// @notice ROLE beats INVALID-SUPPLY-CAP.
+    /// @dev Caller lacks DEFAULT_ADMIN_ROLE AND the requested cap is below the current supply.
+    ///      Role modifier fires before the body's cap invariant check.
+    function test_updateSupplyCap_revertOrder_role_beats_invalidCap(address caller, uint256 mintedAmount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        mintedAmount = bound(mintedAmount, 1, type(uint128).max);
+        _mint(alice, mintedAmount);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, caller, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.updateSupplyCap(0); // any cap below totalSupply triggers InvalidSupplyCap
+    }
+}

--- a/test/unit/B20Factory/createB20_revertOrder.t.sol
+++ b/test/unit/B20Factory/createB20_revertOrder.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+
+/// @title Differential check-order tests for `createB20`.
+///
+/// @notice `createB20` is a dispatcher: the variant byte selects an arm, then each
+///         arm runs its own preconditions in sequence. This file pins the per-arm
+///         ordering: VERSION beats each field-validation check inside an arm.
+///         The cross-arm UNSUPPORTED-VARIANT-beats-arm-body ordering is pinned by
+///         `test_createB20_revert_outOfRangeVariant` in `getTokenAddress.t.sol`
+///         (raw-bytes ABI-decoder panic; see audit-response PR #89).
+///
+///         **Canonical order per variant arm (Solidity reference):**
+///         - DEFAULT: VERSION (single guard; no body validation pairs to test)
+///         - STABLECOIN: VERSION → INVALID-CURRENCY (format check on each byte)
+///         - SECURITY: VERSION → MISSING-ISIN (empty isin)
+contract B20FactoryCreateB20RevertOrderTest is B20FactoryTest {
+    /// @notice For the STABLECOIN arm: VERSION beats INVALID-CURRENCY.
+    /// @dev Both violations: unsupported version AND invalid currency byte. Version check
+    ///      runs first inside the STABLECOIN arm body.
+    function test_createB20_revertOrder_stablecoin_version_beats_invalidCurrency(
+        address caller,
+        uint8 badVersion,
+        bytes32 salt
+    ) public {
+        _assumeValidCaller(caller);
+        vm.assume(badVersion != 1);
+        // Invalid currency (lowercase 'a' is not in A-Z) AND unsupported version.
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Test", "TST", admin, "abc");
+        p.version = badVersion;
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20Factory.UnsupportedVersion.selector, badVersion, IB20Factory.B20Variant.STABLECOIN
+            )
+        );
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
+    }
+
+    /// @notice For the SECURITY arm: VERSION beats MISSING-ISIN.
+    /// @dev Both violations: unsupported version AND empty isin. Version check runs first
+    ///      inside the SECURITY arm body.
+    function test_createB20_revertOrder_security_version_beats_missingIsin(
+        address caller,
+        uint8 badVersion,
+        bytes32 salt
+    ) public {
+        _assumeValidCaller(caller);
+        vm.assume(badVersion != 1);
+        // Empty isin AND unsupported version.
+        IB20Factory.B20SecurityCreateParams memory p = _securityParams("Test", "SEC", admin, "", 0);
+        p.version = badVersion;
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20Factory.UnsupportedVersion.selector, badVersion, IB20Factory.B20Variant.SECURITY)
+        );
+        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
+    }
+}

--- a/test/unit/B20Security/announcement/announce_revertOrder.t.sol
+++ b/test/unit/B20Security/announcement/announce_revertOrder.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+
+/// @title Differential check-order tests for `announce`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRole(SECURITY_OPERATOR_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. ID-ALREADY-USED (`$.usedAnnouncementIds[id]`) → `AnnouncementIdAlreadyUsed`
+///         3. (per-internalCall) MALFORMED (`_checkSelector` rejects < 4 bytes or self-call)
+///            → `InternalCallMalformed` / `AnnouncementInProgress`
+///         4. (per-internalCall) FAILED-DELEGATECALL (`delegatecall` reverts) → `InternalCallFailed`
+///
+///         Some pairs are unreachable because the violations are sequenced through
+///         the loop body (MALFORMED check runs before the delegatecall, so a single
+///         element can't both be MALFORMED and produce FAILED-DELEGATECALL; you'd
+///         need two elements).
+///
+///         Selected pairs cover: ROLE-first invariant, ID-USED-fires-before-loop,
+///         and the per-element MALFORMED-before-FAILED ordering.
+contract B20SecurityAnnounceRevertOrderTest is B20SecurityTest {
+    /// @dev A short blob with no valid selector (< 4 bytes).
+    bytes internal constant MALFORMED_BLOB = hex"112233";
+
+    /// @dev A well-formed selector that targets a nonexistent function (delegatecall returns false).
+    bytes internal constant FAILING_INNER_CALL = hex"deadbeef";
+
+    // --- Pairs where ROLE wins ---
+
+    function test_announce_revertOrder_role_beats_idAlreadyUsed(address caller, string calldata id) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != operator);
+        _announce(id); // consume the id once
+        // caller lacks SECURITY_OPERATOR_ROLE AND id is already used.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, SECURITY_OPERATOR_ROLE)
+        );
+        security().announce(new bytes[](0), id, "desc", "uri");
+    }
+
+    function test_announce_revertOrder_role_beats_malformedInnerCall(address caller, string calldata id) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != operator);
+        // caller lacks role AND would supply a malformed inner call.
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, SECURITY_OPERATOR_ROLE)
+        );
+        security().announce(_singletonBytes(MALFORMED_BLOB), id, "desc", "uri");
+    }
+
+    // --- Pair where ID-ALREADY-USED wins ---
+
+    function test_announce_revertOrder_idAlreadyUsed_beats_malformedInnerCall(string calldata id) public {
+        _grantOperator();
+        _announce(id); // consume the id once
+        // id is now used AND we'd supply a malformed inner call. ID-USED fires before the loop.
+
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(IB20Security.AnnouncementIdAlreadyUsed.selector, id));
+        security().announce(_singletonBytes(MALFORMED_BLOB), id, "desc", "uri");
+    }
+
+    // --- Per-element ordering ---
+
+    function test_announce_revertOrder_malformedInnerCall_beats_failedInnerCall(string calldata id) public {
+        _grantOperator();
+        // Two-element array: index 0 is MALFORMED (will be caught by _checkSelector),
+        // index 1 would have caused FAILED-DELEGATECALL. The loop processes [0] first, so
+        // MALFORMED fires first.
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = MALFORMED_BLOB;
+        calls[1] = FAILING_INNER_CALL;
+
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSelector(IB20Security.InternalCallMalformed.selector, MALFORMED_BLOB));
+        security().announce(calls, id, "desc", "uri");
+    }
+}

--- a/test/unit/B20Security/batch/batchBurn_revertOrder.t.sol
+++ b/test/unit/B20Security/batch/batchBurn_revertOrder.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+
+/// @title Differential check-order tests for `batchBurn` (security variant).
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRoleStrict(BURN_FROM_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. LENGTH_MISMATCH (`accounts.length != amounts.length`) → `LengthMismatch`
+///         3. EMPTY_BATCH (`accounts.length == 0`) → `EmptyBatch`
+///         4. PAUSE (`_isPaused(BURN)`) → `ContractPaused`
+///         5. BALANCE (per-element `_burnRaw`) → `InsufficientBalance`
+///
+///         Some pairs are not reachable because the violations are mutually
+///         exclusive (LENGTH_MISMATCH vs EMPTY_BATCH) or because one check
+///         short-circuits the loop where the other would fire
+///         (LENGTH_MISMATCH/EMPTY_BATCH vs BALANCE — the loop never runs).
+///         Reachable pairs: 7.
+contract B20SecurityBatchBurnRevertOrderTest is B20SecurityTest {
+    address[] internal _emptyAddrs;
+    uint256[] internal _emptyUints;
+    address[] internal _twoAddrs;
+    uint256[] internal _twoUints;
+
+    function setUp() public override {
+        super.setUp();
+        _twoAddrs.push(alice);
+        _twoAddrs.push(bob);
+        _twoUints.push(1);
+    }
+
+    // --- Pairs where ROLE wins (via modifier, before any body check) ---
+    //
+    // Note: BURN_FROM_ROLE() is resolved before vm.prank because the view call
+    // would otherwise consume the prank intended for batchBurn (same pattern as
+    // _setRedeemPolicy in B20SecurityTest).
+
+    function test_batchBurn_revertOrder_role_beats_lengthMismatch(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != burnFromActor);
+        bytes32 role = security().BURN_FROM_ROLE();
+        // _twoAddrs has length 2, _twoUints has length 1 → length mismatch.
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, role));
+        security().batchBurn(_twoAddrs, _twoUints);
+    }
+
+    function test_batchBurn_revertOrder_role_beats_emptyBatch(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != burnFromActor);
+        bytes32 role = security().BURN_FROM_ROLE();
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, role));
+        security().batchBurn(_emptyAddrs, _emptyUints);
+    }
+
+    function test_batchBurn_revertOrder_role_beats_pause(address caller, uint256 amount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != burnFromActor);
+        _pause(IB20.PausableFeature.BURN);
+        bytes32 role = security().BURN_FROM_ROLE();
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, role));
+        security().batchBurn(_singletonAddresses(alice), _singletonUints(amount));
+    }
+
+    function test_batchBurn_revertOrder_role_beats_balance(address caller, uint256 amount) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != burnFromActor);
+        amount = bound(amount, 1, type(uint128).max);
+        bytes32 role = security().BURN_FROM_ROLE();
+        // alice has zero balance.
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, role));
+        security().batchBurn(_singletonAddresses(alice), _singletonUints(amount));
+    }
+
+    // --- Pairs where LENGTH_MISMATCH wins ---
+
+    function test_batchBurn_revertOrder_lengthMismatch_beats_pause() public {
+        _grantBurnFrom();
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(burnFromActor);
+        vm.expectRevert(abi.encodeWithSelector(IB20Security.LengthMismatch.selector, uint256(2), uint256(1)));
+        security().batchBurn(_twoAddrs, _twoUints);
+    }
+
+    // --- Pairs where EMPTY_BATCH wins ---
+
+    function test_batchBurn_revertOrder_emptyBatch_beats_pause() public {
+        _grantBurnFrom();
+        _pause(IB20.PausableFeature.BURN);
+
+        vm.prank(burnFromActor);
+        vm.expectRevert(IB20Security.EmptyBatch.selector);
+        security().batchBurn(_emptyAddrs, _emptyUints);
+    }
+
+    // --- Pair where PAUSE wins ---
+
+    function test_batchBurn_revertOrder_pause_beats_balance(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        _grantBurnFrom();
+        _pause(IB20.PausableFeature.BURN);
+        // alice has zero balance → BALANCE would fire if PAUSE didn't.
+
+        vm.prank(burnFromActor);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.BURN));
+        security().batchBurn(_singletonAddresses(alice), _singletonUints(amount));
+    }
+}

--- a/test/unit/B20Security/batch/batchMint_revertOrder.t.sol
+++ b/test/unit/B20Security/batch/batchMint_revertOrder.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+import {B20Constants} from "test/lib/mocks/MockB20.sol";
+
+/// @title Differential check-order tests for `batchMint` (security variant).
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. LENGTH_MISMATCH (`recipients.length != amounts.length`) → `LengthMismatch`
+///         2. EMPTY_BATCH (`recipients.length == 0`) → `EmptyBatch`
+///         3..N. Per-element `_mint` checks (see `mint_revertOrder.t.sol`):
+///               ROLE → ZERO-RECEIVER → PAUSE → POLICY → CAP
+///
+///         The pairs within `_mint`'s body are already pinned by
+///         `mint_revertOrder.t.sol`. This file only pins the two batchMint-specific
+///         preconditions (LENGTH_MISMATCH, EMPTY_BATCH) against the first per-element
+///         check they encounter (ROLE), which transitively guarantees they fire
+///         before every `_mint` body check.
+contract B20SecurityBatchMintRevertOrderTest is B20SecurityTest {
+    address[] internal _emptyAddrs;
+    uint256[] internal _emptyUints;
+    address[] internal _twoAddrs;
+    uint256[] internal _twoUints;
+
+    function setUp() public override {
+        super.setUp();
+        _twoAddrs.push(alice);
+        _twoAddrs.push(bob);
+        _twoUints.push(1);
+    }
+
+    /// @notice LENGTH_MISMATCH beats ROLE (and transitively everything inside `_mint`).
+    /// @dev Caller lacks MINT_ROLE; arrays have mismatched lengths. LENGTH check
+    ///      fires in `batchMint` body before `_mint` is invoked, so the role
+    ///      modifier on `_mint` never runs.
+    function test_batchMint_revertOrder_lengthMismatch_beats_mintBody(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != minter);
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20Security.LengthMismatch.selector, uint256(2), uint256(1)));
+        security().batchMint(_twoAddrs, _twoUints);
+    }
+
+    /// @notice EMPTY_BATCH beats ROLE (and transitively everything inside `_mint`).
+    function test_batchMint_revertOrder_emptyBatch_beats_mintBody(address caller) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != minter);
+
+        vm.prank(caller);
+        vm.expectRevert(IB20Security.EmptyBatch.selector);
+        security().batchMint(_emptyAddrs, _emptyUints);
+    }
+}

--- a/test/unit/B20Security/identifiers/updateSecurityIdentifier_revertOrder.t.sol
+++ b/test/unit/B20Security/identifiers/updateSecurityIdentifier_revertOrder.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+
+/// @title Differential check-order tests for `updateSecurityIdentifier`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. ROLE (`onlyRole(SECURITY_OPERATOR_ROLE)` modifier) → `AccessControlUnauthorizedAccount`
+///         2. INVALID-IDENTIFIER-TYPE (`bytes(identifierType).length == 0`) → `InvalidIdentifierType`
+///
+///         C(2, 2) = 1 pair.
+contract B20SecurityUpdateSecurityIdentifierRevertOrderTest is B20SecurityTest {
+    /// @notice ROLE beats INVALID-IDENTIFIER-TYPE.
+    /// @dev Caller lacks SECURITY_OPERATOR_ROLE AND the identifierType is empty.
+    ///      Role modifier fires before the body's empty-type check.
+    function test_updateSecurityIdentifier_revertOrder_role_beats_invalidIdentifierType(
+        address caller,
+        string calldata value
+    ) public {
+        _assumeValidCaller(caller);
+        vm.assume(caller != admin);
+        vm.assume(caller != operator);
+        bytes32 role = security().SECURITY_OPERATOR_ROLE();
+
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, caller, role));
+        security().updateSecurityIdentifier("", value); // empty type triggers InvalidIdentifierType
+    }
+}

--- a/test/unit/B20Security/redeem/redeem_revertOrder.t.sol
+++ b/test/unit/B20Security/redeem/redeem_revertOrder.t.sol
@@ -61,9 +61,7 @@ contract B20SecurityRedeemRevertOrderTest is B20SecurityTest {
         vm.prank(alice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IB20.PolicyForbids.selector,
-                security().REDEEM_SENDER_POLICY(),
-                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+                IB20.PolicyForbids.selector, security().REDEEM_SENDER_POLICY(), PolicyRegistryConstants.ALWAYS_BLOCK_ID
             )
         );
         security().redeem(amount);
@@ -77,9 +75,7 @@ contract B20SecurityRedeemRevertOrderTest is B20SecurityTest {
         vm.prank(alice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IB20.PolicyForbids.selector,
-                security().REDEEM_SENDER_POLICY(),
-                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+                IB20.PolicyForbids.selector, security().REDEEM_SENDER_POLICY(), PolicyRegistryConstants.ALWAYS_BLOCK_ID
             )
         );
         security().redeem(amount);

--- a/test/unit/B20Security/redeem/redeem_revertOrder.t.sol
+++ b/test/unit/B20Security/redeem/redeem_revertOrder.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+
+/// @title Differential check-order tests for `redeem` (security variant).
+///
+/// @notice **Canonical order (Solidity reference `_redeemBurn`):**
+///         1. PAUSE (`_isPaused(REDEEM)`) → `ContractPaused`
+///         2. POLICY (`isAuthorized(REDEEMSenderPolicyId, msg.sender)`) → `PolicyForbids`
+///         3. BELOW-MIN (`shares == 0 || shares < minimum`) → `BelowMinimumRedeemable`
+///         4. BALANCE (`fromBalance < amount` in `_burnRaw`) → `InsufficientBalance`
+///
+///         C(4, 2) = 6 pairs.
+contract B20SecurityRedeemRevertOrderTest is B20SecurityTest {
+    // --- Pairs where PAUSE wins ---
+
+    function test_redeem_revertOrder_pause_beats_policy(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        _pause(IB20.PausableFeature.REDEEM);
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.REDEEM));
+        security().redeem(amount);
+    }
+
+    function test_redeem_revertOrder_pause_beats_belowMinimum(uint256 amount, uint256 minimum) public {
+        amount = bound(amount, 1, type(uint64).max);
+        minimum = bound(minimum, amount + 1, type(uint256).max);
+        _pause(IB20.PausableFeature.REDEEM);
+        _updateMinimumRedeemable(minimum);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.REDEEM));
+        security().redeem(amount);
+    }
+
+    function test_redeem_revertOrder_pause_beats_balance(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        _pause(IB20.PausableFeature.REDEEM);
+        // alice has zero balance.
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IB20.ContractPaused.selector, IB20.PausableFeature.REDEEM));
+        security().redeem(amount);
+    }
+
+    // --- Pairs where POLICY wins ---
+
+    function test_redeem_revertOrder_policy_beats_belowMinimum(uint256 amount, uint256 minimum) public {
+        amount = bound(amount, 1, type(uint64).max);
+        minimum = bound(minimum, amount + 1, type(uint256).max);
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        _updateMinimumRedeemable(minimum);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                security().REDEEM_SENDER_POLICY(),
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        security().redeem(amount);
+    }
+
+    function test_redeem_revertOrder_policy_beats_balance(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_BLOCK_ID);
+        // alice has zero balance.
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.PolicyForbids.selector,
+                security().REDEEM_SENDER_POLICY(),
+                PolicyRegistryConstants.ALWAYS_BLOCK_ID
+            )
+        );
+        security().redeem(amount);
+    }
+
+    // --- Pair where BELOW-MIN wins ---
+
+    function test_redeem_revertOrder_belowMinimum_beats_balance(uint256 amount, uint256 minimum) public {
+        amount = bound(amount, 1, type(uint64).max);
+        minimum = bound(minimum, amount + 1, type(uint256).max);
+        _setRedeemPolicy(PolicyRegistryConstants.ALWAYS_ALLOW_ID);
+        _updateMinimumRedeemable(minimum);
+        // alice has zero balance → BALANCE would fire if BELOW-MIN didn't.
+        // Default WAD ratio: shares = amount * WAD / WAD = amount. amount < minimum → BelowMinimumRedeemable.
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IB20Security.BelowMinimumRedeemable.selector, amount, minimum));
+        security().redeem(amount);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up from [PR #89](https://github.com/base/base-std/pull/89) (audit response). Adds a differential check-order test harness covering every multi-precondition function in the B20 surface. The harness pins the canonical first-firing revert selector for each pair of preconditions a function enforces, so that any future drift between the Solidity reference and the Rust precompile surfaces as a precise selector diff in fork mode.

**Canonical order = Solidity reference (Option A from the audit-response report).** Tests pass in mock mode iff Solidity follows canonical (it does, by construction), and they pass in fork mode iff Rust agrees with canonical. The five fork-mode failures in this PR are intentional and surface real Rust↔Solidity divergences — no Rust changes here; this PR exists to highlight the divergences and lock them in as regression coverage.

## Coverage

Exhaustive across the B20 surface — covers every multi-precondition function. [PR #91 (BOP-196)](https://github.com/base/base-std/pull/91) merging into this branch unblocked the final `revokeRole` pair.

| File | Pairs | Mock | Fork |
|---|---|---|---|
| `test/unit/B20/supply/mint_revertOrder.t.sol` | 10 | 10/10 | 8/10 |
| `test/unit/B20/supply/burn_revertOrder.t.sol` | 3 | 3/3 | 3/3 |
| `test/unit/B20/supply/burnBlocked_revertOrder.t.sol` | 6 | 6/6 | 5/6 |
| `test/unit/B20/supply/updateSupplyCap_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20/erc20/transfer_revertOrder.t.sol` | 15 | 15/15 | 14/15 |
| `test/unit/B20/erc20/transferFrom_revertOrder.t.sol` | 3 | 3/3 | 2/3 |
| `test/unit/B20/erc20/approve_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20/permit/permit_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20/policy/updatePolicy_revertOrder.t.sol` | 3 | 3/3 | 3/3 |
| `test/unit/B20/roles/revokeRole_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20/roles/renounceRole_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20/roles/renounceLastAdmin_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20Security/batch/batchBurn_revertOrder.t.sol` | 7 | 7/7 | 7/7 |
| `test/unit/B20Security/batch/batchMint_revertOrder.t.sol` | 2 | 2/2 | 2/2 |
| `test/unit/B20Security/redeem/redeem_revertOrder.t.sol` | 6 | 6/6 | 6/6 |
| `test/unit/B20Security/identifiers/updateSecurityIdentifier_revertOrder.t.sol` | 1 | 1/1 | 1/1 |
| `test/unit/B20Security/announcement/announce_revertOrder.t.sol` | 4 | 4/4 | 4/4 |
| `test/unit/B20Factory/createB20_revertOrder.t.sol` | 2 | 2/2 | 2/2 |
| **Total** | **68** | **68/68** | **63/68** |

Full mock-only suite passes with no regressions to existing tests.

## Rust↔Solidity divergences surfaced

The five fork-mode failures are the actual check-order divergences between the Rust precompile (`base@f9d9d2804`) and the Solidity reference. Each is a precise selector diff at a specific multi-violation input:

| Function | Pair | Solidity (canonical) | Rust (actual) |
|---|---|---|---|
| `mint` | `role` vs `zeroRecipient` | `AccessControlUnauthorizedAccount` | `InvalidReceiver(0)` |
| `mint` | `pause` vs `policy` | `ContractPaused(MINT)` | `PolicyForbids(MINT_RECEIVER, ...)` |
| `transfer` | `zeroReceiver` vs `zeroSender` | `InvalidReceiver(0)` | `InvalidSender(0)` |
| `burnBlocked` | `pause` vs `blocked` | `ContractPaused(BURN)` | `AccountNotBlocked(...)` |
| `transferFrom` | `allowance` vs `executorPolicy` | `InsufficientAllowance` | `PolicyForbids(EXECUTOR, ...)` |

These five are now structural facts of the codebase. The PR's value is making them visible and pinning them so:
- Future Solidity refactors that drift the canonical order surface as new mock-mode failures
- Future Rust refactors that align with canonical flip the failing tests to passing — no manual reconciliation needed

Each divergence has a tracking ticket under the **Internal Audit Fixes** milestone (see the [thread on #proj-b20](https://coinbase.slack.com/archives/C0ARU1771LL/p1779993077862489)).

## Design notes

- **Pair coverage is enumerative, not sampled.** For each function with N preconditions, there are C(N, 2) pairs. The harness writes one test per pair, asserting the canonical first-firing selector. Some pairs are unreachable (mutually exclusive violations) and are explicitly skipped with a note in the file's natspec.
- **Composed functions don't re-test their base.** `transferFrom` only adds tests for its two new preconditions (ALLOWANCE, EXECUTOR-POLICY); the underlying `_transfer` body pairs are already pinned by `transfer_revertOrder.t.sol`. Similarly `batchMint` only pins LENGTH/EMPTY against the first per-element check (ROLE), since the rest of `_mint`'s order is pinned by `mint_revertOrder.t.sol`.
- **`vm.prank` pattern.** Tests that need a role-resolution view call (e.g. `security().BURN_FROM_ROLE()`) resolve it to a local variable BEFORE the `vm.prank`, to avoid the prank being consumed by the view call. Same pattern as `_setRedeemPolicy` in `B20SecurityTest`.

## Out of scope

- **No Rust changes.** The 5 divergences are real and require a coordinated decision before fixing one side or the other. This PR captures them; the alignment work is a separate effort (tickets queued under Internal Audit Fixes).
- **No Solidity behavior changes.** All Solidity check orders are unchanged; the harness only adds tests asserting the current behavior.
- **Storage cleanup (auditor's D2).** Out of scope; was not a real divergence (see [PR #89](https://github.com/base/base-std/pull/89)).

## Commits

- `68d763d` test(check-order): differential mint revert-ordering harness
- `e337e92` test(check-order): extend revert-order harness across all multi-precondition ops
- `5a827f1` test(check-order): extend harness to roles, admin ops, announce, and createB20
- `03cefcd` style: forge fmt
- `d7e49ca` test(check-order): revokeRole pair test (unblocked by BOP-196 merge)