### PR TITLE
fix(roles): prevent admin-role resurrection on admin-less tokens

### DIFF
--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -111,7 +111,19 @@ contract MockB20 is IB20 {
     ///      / `setRoleAdmin`, where the gate is over the meta-role,
     ///      not the role itself.
     modifier onlyRoleAdmin(bytes32 role) {
-        if (!_isPrivileged()) _requireRoleAdmin(role);
+        if (!_isPrivileged()) {
+            // Admin-resurrection guard: once `adminCount == 0` the token is admin-less
+            // by design (post-`renounceLastAdmin`). No role-mgmt mutation is permitted
+            // even if the caller holds a custom-admin role that would otherwise
+            // authorize them, because allowing such mutations would let a custom-admin
+            // chain (e.g. setRoleAdmin(MINT_ROLE, BURN_ROLE) → grantRole(BURN_ROLE, X))
+            // re-establish admin power on a token that has explicitly relinquished it.
+            // Mirrors base/base PR #2961 (`ensure_role_admin_mutations_available`).
+            if (MockB20Storage.layout().adminCount == 0) {
+                revert AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE);
+            }
+            _requireRoleAdmin(role);
+        }
         _;
     }
 

--- a/test/unit/B20/roles/grantRole.t.sol
+++ b/test/unit/B20/roles/grantRole.t.sol
@@ -64,4 +64,52 @@ contract B20GrantRoleTest is B20Test {
         emit IB20.RoleGranted(role, account, admin);
         _grantRole(role, account);
     }
+
+    /// @notice Verifies grantRole reverts on an admin-less token even when the caller holds a
+    ///         custom-admin role that would otherwise authorize the grant.
+    /// @dev Admin-role-resurrection guard — mirrors base/base PR #2961
+    ///      (`ensure_role_admin_mutations_available`). Without this guard a custom-admin
+    ///      role chain set up while an admin existed (e.g. setRoleAdmin(MINT_ROLE, BURN_ROLE)
+    ///      + grantRole(BURN_ROLE, alice)) survives `renounceLastAdmin()` and lets BURN_ROLE
+    ///      holders keep mutating the role graph on a token that has no admin. The shared
+    ///      `onlyRoleAdmin` modifier short-circuits when adminCount == 0 with
+    ///      `AccessControlUnauthorizedAccount(caller, DEFAULT_ADMIN_ROLE)`, matching Rust.
+    ///
+    ///      Same guard fires on `revokeRole` and `setRoleAdmin` (also `onlyRoleAdmin`-gated);
+    ///      this test pins the property at the modifier level via the grantRole entry.
+    function test_grantRole_revert_adminResurrectionViaCustomChain(address customAdmin, address recipient) public {
+        _assumeValidActor(customAdmin);
+        _assumeValidActor(recipient);
+        vm.assume(customAdmin != admin);
+        vm.assume(recipient != admin);
+        vm.assume(customAdmin != recipient);
+
+        // 1. admin makes BURN_ROLE the admin-of MINT_ROLE.
+        vm.prank(admin);
+        token.setRoleAdmin(B20Constants.MINT_ROLE, B20Constants.BURN_ROLE);
+
+        // 2. admin grants BURN_ROLE to customAdmin so they become an admin-of-MINT_ROLE.
+        _grantRole(B20Constants.BURN_ROLE, customAdmin);
+
+        // 3. admin renounces the last admin — adminCount drops to 0.
+        vm.prank(admin);
+        token.renounceLastAdmin();
+        assertEq(
+            uint256(vm.load(address(token), MockB20Storage.adminCountSlot())),
+            0,
+            "precondition: token is admin-less"
+        );
+        assertTrue(token.hasRole(B20Constants.BURN_ROLE, customAdmin), "precondition: custom-chain admin still holds BURN_ROLE");
+
+        // 4. customAdmin attempts to mutate the role graph. The shared `onlyRoleAdmin`
+        //    modifier rejects with DEFAULT_ADMIN_ROLE as the needed-role payload — matching
+        //    Rust's `ensure_role_admin_mutations_available`.
+        vm.prank(customAdmin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20.AccessControlUnauthorizedAccount.selector, customAdmin, B20Constants.DEFAULT_ADMIN_ROLE
+            )
+        );
+        token.grantRole(B20Constants.MINT_ROLE, recipient);
+    }
 }

--- a/test/unit/B20/roles/grantRole.t.sol
+++ b/test/unit/B20/roles/grantRole.t.sol
@@ -95,11 +95,11 @@ contract B20GrantRoleTest is B20Test {
         vm.prank(admin);
         token.renounceLastAdmin();
         assertEq(
-            uint256(vm.load(address(token), MockB20Storage.adminCountSlot())),
-            0,
-            "precondition: token is admin-less"
+            uint256(vm.load(address(token), MockB20Storage.adminCountSlot())), 0, "precondition: token is admin-less"
         );
-        assertTrue(token.hasRole(B20Constants.BURN_ROLE, customAdmin), "precondition: custom-chain admin still holds BURN_ROLE");
+        assertTrue(
+            token.hasRole(B20Constants.BURN_ROLE, customAdmin), "precondition: custom-chain admin still holds BURN_ROLE"
+        );
 
         // 4. customAdmin attempts to mutate the role graph. The shared `onlyRoleAdmin`
         //    modifier rejects with DEFAULT_ADMIN_ROLE as the needed-role payload — matching


### PR DESCRIPTION
## Context

Tracking ticket: [BOP-204](https://linear.app/coinbase/issue/BOP-204)

Mirrors [base/base#2961](https://github.com/base/base/pull/2961) / [BOP-185](https://linear.app/coinbase/issue/BOP-185) (`ensure_role_admin_mutations_available`) on the Solidity reference. base-std currently diverges from the post-#2961 Rust precompile: a custom role-admin chain established **before** an admin renounces can be used to keep mutating the role graph **after** the token is admin-less.

## Repro (without this fix)

1. admin calls `setRoleAdmin(MINT_ROLE, BURN_ROLE)` — now BURN_ROLE holders are the admin-of MINT_ROLE
2. admin calls `grantRole(BURN_ROLE, alice)`
3. admin calls `renounceLastAdmin()` → `adminCount == 0`
4. alice calls `grantRole(MINT_ROLE, bob)` — **succeeds in Solidity, reverts in Rust**

The shared `onlyRoleAdmin` modifier is the only entry point for `grantRole` / `revokeRole` / `setRoleAdmin`, so a single check at the modifier covers all three role-graph mutations.

## Fix

In `MockB20.onlyRoleAdmin`, short-circuit with `AccessControlUnauthorizedAccount(msg.sender, DEFAULT_ADMIN_ROLE)` when `adminCount == 0`, before the normal `_requireRoleAdmin(role)` resolution. The error payload matches Rust's response (which always names DEFAULT_ADMIN_ROLE as the missing role in this scenario).

## Regression test

`test_grantRole_revert_adminResurrectionViaCustomChain` in `test/unit/B20/roles/grantRole.t.sol` walks the repro above and asserts the revert. Pins the property at the modifier level via the grantRole entry; `revokeRole` and `setRoleAdmin` are covered transitively because they share the modifier.

## Verification

- Mock suite: **507 / 0 / 0**
- Fork suite (current Rust pin `f9d9d2804`): regression test **passes** — confirms Rust already enforces this and Solidity now matches.
- `forge fmt --check` clean on touched files.

## Notes

- No new error type. Reuses the existing `AccessControlUnauthorizedAccount` selector with `DEFAULT_ADMIN_ROLE` as the needed-role payload, matching Rust.
- Not breaking: the rejected operations were only reachable via a code path that Rust already rejects.

## Related

- Tracking: BOP-204
- Rust counterpart: BOP-185 / base/base#2961
- Companion audit work: #89 (audit fixes), #90 (check-order parity tests)
