### PR TITLE
fix(factory): MissingRequiredField includes field name (BOP-155)

### DIFF
--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -182,7 +182,8 @@ interface IB20Factory {
     error UnsupportedVersion(uint8 version, B20Variant variant);
 
     /// @notice A required string argument was the empty string.
-    /// @param field Name of the missing field (e.g. `"isin"`, `"currency"`).
+    /// @param field Name of the missing field (e.g. `"isin"`). Empty
+    ///        `currency` is rejected separately via `InvalidCurrency("")`.
     error MissingRequiredField(string field);
 
     /// @notice The stablecoin `currency` contained a non-`A`–`Z` byte.

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -181,9 +181,9 @@ interface IB20Factory {
     ///         any known encoding for the requested variant.
     error UnsupportedVersion(uint8 version, B20Variant variant);
 
-    /// @notice A required string argument was the empty string (e.g.
-    ///         security `isin`).
-    error MissingRequiredField();
+    /// @notice A required string argument was the empty string.
+    /// @param field Name of the missing field (e.g. `"isin"`, `"currency"`).
+    error MissingRequiredField(string field);
 
     /// @notice The stablecoin `currency` contained a non-`A`–`Z` byte.
     error InvalidCurrency(string code);

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -134,7 +134,7 @@ contract MockB20Factory is IB20Factory {
             if (p.version != B20FactoryLib.B20_SECURITY_CREATE_PARAMS_VERSION) {
                 revert UnsupportedVersion(p.version, variant);
             }
-            if (bytes(p.isin).length == 0) revert MissingRequiredField();
+            if (bytes(p.isin).length == 0) revert MissingRequiredField("isin");
             name_ = p.name;
             symbol_ = p.symbol;
             admin = p.initialAdmin;

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -119,6 +119,8 @@ contract MockB20Factory is IB20Factory {
             if (p.version != B20FactoryLib.B20_STABLECOIN_CREATE_PARAMS_VERSION) {
                 revert UnsupportedVersion(p.version, variant);
             }
+            // Required: currency must be non-empty.
+            if (bytes(p.currency).length == 0) revert MissingRequiredField("currency");
             // Format check: every byte must be an uppercase ASCII letter (A-Z).
             bytes memory cb = bytes(p.currency);
             for (uint256 i = 0; i < cb.length; ++i) {

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -93,7 +93,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Any non-empty string containing a non-`A`–`Z` byte reverts with `InvalidCurrency(code)`.
     /// @dev Subsumes every point case (lowercase, digits, symbols, multi-byte UTF-8) via
     ///      `vm.assume(!_isValidFiatCode)`. Empty input is covered by
-    ///      `test_createB20_revert_missingCurrency` (rejected with MissingRequiredField).
+    ///      `test_createB20_revert_emptyCurrency` (rejected with `InvalidCurrency("")`).
     function test_createB20_revert_currency_rejectsInvalidFormat(string memory code, address caller, bytes32 salt)
         public
     {

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -127,12 +127,12 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     }
 
     /// @notice Verifies security createToken reverts when isin is the empty string
-    /// @dev Per-variant required-field check; checks MissingRequiredField() error
+    /// @dev Per-variant required-field check; checks MissingRequiredField(string) error
     function test_createB20_revert_missingIsin(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20SecurityCreateParams memory p = _securityParams("Security Test", "SEC", admin, "", 0);
         vm.prank(caller);
-        vm.expectRevert(IB20Factory.MissingRequiredField.selector);
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.MissingRequiredField.selector, "isin"));
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -126,6 +126,16 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 
+    /// @notice Verifies stablecoin createToken reverts when currency is the empty string
+    /// @dev Per-variant required-field check; checks MissingRequiredField(string) error
+    function test_createB20_revert_missingCurrency(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Stable Test", "STB", admin, "");
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.MissingRequiredField.selector, "currency"));
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
+    }
+
     /// @notice Verifies security createToken reverts when isin is the empty string
     /// @dev Per-variant required-field check; checks MissingRequiredField(string) error
     function test_createB20_revert_missingIsin(address caller, bytes32 salt) public {


### PR DESCRIPTION
[BOP-155](https://linear.app/coinbase/issue/BOP-155)

## Motivation

The Solidity `MissingRequiredField` interface and the `isin` test did not match the updated Rust precompile: the error had no `string field` parameter, and the existing `isin` test expected only the bare selector rather than the full ABI-encoded error with the field name.

Note: empty `currency` is rejected separately via `InvalidCurrency("")` (added on `main` by the audit-response PR #89), so `MissingRequiredField` only covers `isin` today.

## What changed

- `IB20Factory.sol`: `error MissingRequiredField(string field)`; natspec updated to use `"isin"` as the example
- `MockB20Factory.sol`: updates the security path to pass `"isin"` as the field name
- `createToken.t.sol`: updates `test_createB20_revert_missingIsin` to use `abi.encodeWithSelector` with the field name

## Note on merge

This branch was merged with `main` to resolve a conflict between the original empty-currency check and the audit-response PR #89 (which had already added an `InvalidCurrency("")` check for the same case). Per Amie's call, kept main's audit-canonical behavior; dropped the overlapping `MissingRequiredField("currency")` additions and the corresponding test. The remaining changes (interface signature + `isin` field name) are unaffected.
