### PR TITLE
fix(ci): fix fork test infrastructure and make job advisory

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -18,6 +18,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   fork-tests:
@@ -159,6 +160,37 @@ jobs:
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment fork test results on PR
+        if: github.event_name == 'pull_request' && always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          output="$RUNNER_TEMP/fork-test-output.txt"
+          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
+          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
+
+          if [ "$failed" -eq 0 ]; then
+            body="### ✅ Fork tests: all ${passed} passed
+          base/base is fully in sync with the base-std spec."
+          else
+            failing=$(grep '\[FAIL' "$output" | sed 's/\x1B\[[0-9;]*m//g' | sed 's/\[FAIL[^]]*\] /- /' | cut -d'(' -f1 | sort -u || true)
+            body="### ⚠️ Fork tests: ${failed} failed, ${passed} passed
+
+          These failures indicate divergences where **base/base needs to catch up** to the base-std spec. This check is advisory and does not block merging.
+
+          <details>
+          <summary>Failing tests</summary>
+
+          ${failing}
+
+          </details>"
+          fi
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "$body"
 
       - name: Upload anvil log
         if: always()

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -11,8 +11,9 @@ concurrency:
 
 env:
   BASE_REF: main
-  # Pinned to a specific commit so CI is reproducible and the branch can't disappear under us.
-  BASE_ANVIL_REF: 14a43909528eb7ff4bafab0e5fee9b3b651bcd50
+  # Branch to clone; SHA below is pinned for reproducibility and verified after clone.
+  BASE_ANVIL_BRANCH: base-anvil-fork
+  BASE_ANVIL_SHA: 14a43909528eb7ff4bafab0e5fee9b3b651bcd50
   CARGO_TERM_COLOR: always
 
 permissions:
@@ -70,13 +71,6 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "base-std-fork-tests"
-          cache-targets: "false"
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
         with:
@@ -93,8 +87,14 @@ jobs:
 
           git clone --depth 1 --single-branch --branch "$BASE_REF" \
             https://github.com/base/base.git "$workdir/base"
-          git clone --depth 1 --single-branch --branch "$BASE_ANVIL_REF" \
+
+          git clone --depth 1 --single-branch --branch "$BASE_ANVIL_BRANCH" \
             https://github.com/base/base-anvil.git "$workdir/base-anvil"
+
+          actual_sha=$(git -C "$workdir/base-anvil" rev-parse HEAD)
+          if [ "$actual_sha" != "$BASE_ANVIL_SHA" ]; then
+            echo "::warning::base-anvil HEAD ($actual_sha) differs from pinned SHA ($BASE_ANVIL_SHA) — update BASE_ANVIL_SHA in the workflow"
+          fi
 
           echo "BASE_DIR=$workdir/base" >> "$GITHUB_ENV"
           echo "BASE_ANVIL_DIR=$workdir/base-anvil" >> "$GITHUB_ENV"

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -170,13 +170,20 @@ jobs:
           output="$RUNNER_TEMP/fork-test-output.txt"
           passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
           failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
+          marker="<!-- fork-test-results -->"
 
           if [ "$failed" -eq 0 ]; then
-            body="### ✅ Fork tests: all ${passed} passed
+            body="${marker}
+          ### ✅ Fork tests: all ${passed} passed
           base/base is fully in sync with the base-std spec."
           else
-            failing=$(grep '\[FAIL' "$output" | sed 's/\x1B\[[0-9;]*m//g' | sed 's/\[FAIL[^]]*\] /- /' | cut -d'(' -f1 | sort -u || true)
-            body="### ⚠️ Fork tests: ${failed} failed, ${passed} passed
+            # Extract test name and full error for each failure, deduplicated
+            failing=$(grep '\[FAIL' "$output" \
+              | sed 's/\x1B\[[0-9;]*m//g' \
+              | sed 's/^\[FAIL: \(.*\)\] \(.*\) (runs.*$/- **\2**: `\1`/' \
+              | sort -u || true)
+            body="${marker}
+          ### ⚠️ Fork tests: ${failed} failed, ${passed} passed
 
           These failures indicate divergences where **base/base needs to catch up** to the base-std spec. This check is advisory and does not block merging.
 
@@ -188,9 +195,21 @@ jobs:
           </details>"
           fi
 
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body "$body"
+          pr="${{ github.event.pull_request.number }}"
+          repo="${{ github.repository }}"
+
+          # Find existing comment with our marker and update it, or post a new one
+          existing_id=$(gh api "repos/${repo}/issues/${pr}/comments" \
+            --jq ".[] | select(.body | startswith(\"${marker}\")) | .id" \
+            | head -1)
+
+          if [ -n "$existing_id" ]; then
+            gh api "repos/${repo}/issues/comments/${existing_id}" \
+              -X PATCH --field body="$body" > /dev/null
+          else
+            gh api "repos/${repo}/issues/${pr}/comments" \
+              --field body="$body" > /dev/null
+          fi
 
       - name: Upload anvil log
         if: always()

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -172,7 +172,11 @@ jobs:
           failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
           marker="<!-- fork-test-results -->"
 
-          if [ "$failed" -eq 0 ]; then
+          if [ ! -s "$output" ] || [ "$((passed + failed))" -eq 0 ]; then
+            body="${marker}
+          ### ❌ Fork tests did not run
+          The build or setup step failed before any tests could execute. Check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          elif [ "$failed" -eq 0 ]; then
             body="${marker}
           ### ✅ Fork tests: all ${passed} passed
           base/base is fully in sync with the base-std spec."

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -11,10 +11,9 @@ concurrency:
 
 env:
   BASE_REF: main
-  BASE_ANVIL_REF: base-anvil-fork
+  # Pinned to a specific commit so CI is reproducible and the branch can't disappear under us.
+  BASE_ANVIL_REF: 14a43909528eb7ff4bafab0e5fee9b3b651bcd50
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_ENABLED: "true"
 
 permissions:
   contents: read
@@ -104,6 +103,8 @@ jobs:
         shell: bash
         env:
           CARGO_PROFILE_RELEASE_LTO: "false"
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -24,6 +24,9 @@ jobs:
     name: Base Std Fork Tests
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # Advisory: base-std is the spec forerunner. Divergences mean base/base needs to catch up,
+    # not that base-std is wrong. This job surfaces failures without blocking PR merges.
+    continue-on-error: true
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -119,6 +122,7 @@ jobs:
           "$BASE_ANVIL_DIR/target/release/forge" --version
 
       - name: Run base-std fork tests
+        id: fork_tests
         shell: bash
         run: |
           set -euo pipefail
@@ -126,7 +130,35 @@ jobs:
           ANVIL_BIN="$BASE_ANVIL_DIR/target/release/anvil" \
             FORGE_BIN="$BASE_ANVIL_DIR/target/release/forge" \
             ANVIL_LOG="$RUNNER_TEMP/base-std-anvil.log" \
-            ./script/run-fork-tests.sh
+            ./script/run-fork-tests.sh 2>&1 | tee "$RUNNER_TEMP/fork-test-output.txt"
+          echo "fork_tests_exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Summarize fork test results
+        if: always()
+        shell: bash
+        run: |
+          output="$RUNNER_TEMP/fork-test-output.txt"
+          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
+          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
+
+          {
+            echo "## Fork Test Results"
+            echo ""
+            if [ "$failed" -eq 0 ]; then
+              echo "✅ All **${passed}** tests passed — base/base is fully in sync with base-std."
+            else
+              echo "⚠️ **${failed}** test(s) failed, **${passed}** passed."
+              echo ""
+              echo "These failures indicate divergences where **base/base needs to catch up** to the base-std spec."
+              echo "base-std PRs are not blocked by this check."
+              echo ""
+              echo "### Failing tests"
+              echo '```'
+              grep '\[FAIL' "$output" | sed 's/\x1B\[[0-9;]*m//g' || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload anvil log
         if: always()


### PR DESCRIPTION
[BOP-165](https://linear.app/coinbase/issue/BOP-165)

## Motivation

The fork test CI had two infrastructure bugs that prevented it from running at all, and the job was blocking PR merges even though base-std is the spec forerunner. Divergences between base-std and base/base mean Rust needs to catch up, not that base-std PRs are wrong.

## What changed

- **Removed `rust-cache`** and scoped `RUSTC_WRAPPER`/`SCCACHE_GHA_ENABLED` to the "Build patched base-anvil binaries" step only. Both `rust-cache` and `sccache-action` were running `cargo metadata` in the base-std checkout directory (a pure Solidity repo with no `Cargo.toml`), causing every run to fail before building anything.
- **Fixed `BASE_ANVIL_REF` pinning**: `git clone --branch` does not accept a commit SHA, so cloning was failing with "Remote branch not found". Now clones the named branch and verifies the HEAD SHA matches the pinned value, emitting a warning if the branch has moved.
- **Made the job advisory** (`continue-on-error: true`): base-std is the spec forerunner. Test failures mean base/base needs to catch up, not that base-std PRs should be blocked.
- **Added a PR comment** that finds and updates in place on each run, showing pass/fail counts and the full error for each failing test. Reports "did not run" if the build fails before tests execute.