### PR TITLE
fix(activation): add B20_STABLECOIN to feature id constants + pin all 5 to preimage (BOP-159)

### DIFF
--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -14,4 +14,7 @@ library ActivationRegistryFeatureList {
 
     /// @dev keccak256("base.policy_registry")
     bytes32 internal constant POLICY_REGISTRY = 0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f;
+
+    /// @dev keccak256("base.b20_stablecoin")
+    bytes32 internal constant B20_STABLECOIN = 0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601;
 }

--- a/test/unit/ActivationRegistry/featureList.t.sol
+++ b/test/unit/ActivationRegistry/featureList.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+
+/// @notice Pins each feature id constant in `ActivationRegistryFeatureList` to
+///         its canonical `keccak256("base.<feature>")` preimage.
+///
+/// @dev    These constants are the cross-language contract between the
+///         Solidity mock surface and the Rust precompile's `ActivationFeature`
+///         enum (`crates/common/precompiles/src/activation/storage.rs` in
+///         base/base): both sides must hash the same string and arrive at the
+///         same id. The pinning tests below catch silent drift in either
+///         direction — a typo in the hex literal or in the string preimage
+///         surfaces here before it can desync against the Rust source of
+///         truth.
+contract ActivationRegistryFeatureListTest is Test {
+    /// @notice `B20_SECURITY` equals `keccak256("base.b20_security")`.
+    function test_B20_SECURITY_pinnedToKeccak() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.B20_SECURITY,
+            keccak256("base.b20_security"),
+            "B20_SECURITY must equal keccak256(\"base.b20_security\")"
+        );
+    }
+
+    /// @notice `B20_TOKEN` equals `keccak256("base.b20_token")`.
+    function test_B20_TOKEN_pinnedToKeccak() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.B20_TOKEN,
+            keccak256("base.b20_token"),
+            "B20_TOKEN must equal keccak256(\"base.b20_token\")"
+        );
+    }
+
+    /// @notice `B20_FACTORY` equals `keccak256("base.b20_factory")`.
+    function test_B20_FACTORY_pinnedToKeccak() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.B20_FACTORY,
+            keccak256("base.b20_factory"),
+            "B20_FACTORY must equal keccak256(\"base.b20_factory\")"
+        );
+    }
+
+    /// @notice `POLICY_REGISTRY` equals `keccak256("base.policy_registry")`.
+    function test_POLICY_REGISTRY_pinnedToKeccak() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.POLICY_REGISTRY,
+            keccak256("base.policy_registry"),
+            "POLICY_REGISTRY must equal keccak256(\"base.policy_registry\")"
+        );
+    }
+
+    /// @notice `B20_STABLECOIN` equals `keccak256("base.b20_stablecoin")`.
+    function test_B20_STABLECOIN_pinnedToKeccak() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.B20_STABLECOIN,
+            keccak256("base.b20_stablecoin"),
+            "B20_STABLECOIN must equal keccak256(\"base.b20_stablecoin\")"
+        );
+    }
+}


### PR DESCRIPTION
## Context

Tracking ticket: [BOP-159](https://linear.app/coinbase/issue/BOP-159)

The original audit finding said *"`B20Stablecoin` is missing from the activation registry feature list in `base-std`"* and the ticket triage suggested this was likely invalid Rust-side. After comparing both sources, the auditor was right — the gap is Solidity-side. The Rust `ActivationFeature` enum in [base/base `crates/common/precompiles/src/activation/storage.rs`](https://github.com/base/base/blob/main/crates/common/precompiles/src/activation/storage.rs) has 5 variants; the Solidity constants library had 4.

## The gap

| Feature id string | Rust `ActivationFeature` | Solidity `ActivationRegistryFeatureList` |
|---|---|---|
| `base.b20_token` | `B20Token` | `B20_TOKEN` |
| `base.b20_factory` | `B20Factory` | `B20_FACTORY` |
| `base.policy_registry` | `PolicyRegistry` | `POLICY_REGISTRY` |
| `base.b20_security` | `B20Security` | `B20_SECURITY` |
| **`base.b20_stablecoin`** | **`B20Stablecoin`** | **— missing —** |

The constant has no current consumers in base-std (the library is a canonical reference, not load-bearing in any code path), so this is not a runtime bug. It is a documentation/parity gap: an audit asking *"show me the Solidity-side activation feature list"* should find a complete one matching the Rust enum.

## Fix

One-line addition to `test/lib/mocks/ActivationRegistryFeatureList.sol`:

```solidity
/// @dev keccak256("base.b20_stablecoin")
bytes32 internal constant B20_STABLECOIN = 0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601;
```

The hash matches the literal in the Rust enum (`Self::B20Stablecoin => b256!("0xecfa0def…0b8601")`).

## Tests added

`test/unit/ActivationRegistry/featureList.t.sol` — `ActivationRegistryFeatureListTest` pins each of the 5 constants to its `keccak256("base.<feature>")` preimage. Defense-in-depth: a typo in the hex literal *or* in the string surfaces here before it can desync against the Rust source of truth. Mirrors the same pattern used by `MockActivationRegistryStorageLocationTest` for the ERC-7201 storage location constant.

## Verification

- `forge fmt --check` clean on touched files
- `forge build` clean (only pre-existing warnings on unrelated files)
- All 5 pinning tests pass:
  ```
  [PASS] test_B20_FACTORY_pinnedToKeccak() (gas: 343)
  [PASS] test_B20_SECURITY_pinnedToKeccak() (gas: 353)
  [PASS] test_B20_STABLECOIN_pinnedToKeccak() (gas: 299)
  [PASS] test_B20_TOKEN_pinnedToKeccak() (gas: 343)
  [PASS] test_POLICY_REGISTRY_pinnedToKeccak() (gas: 344)
  ```

## Related

- Tracking: BOP-159
- Rust source of truth: `ActivationFeature` enum in `base/base`
