### PR TITLE
test(rollback): fork-mode regression tests for precompile-storage checkpoint integration (BOP-214)

### DIFF
--- a/test/unit/B20Security/batch/batchBurn_rollback.t.sol
+++ b/test/unit/B20Security/batch/batchBurn_rollback.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+/// @title B20SecurityBatchBurnRollbackTest
+/// @notice Verifies a revert mid-batchBurn leaves no orphan token state.
+///
+/// @dev    Sibling of `B20SecurityBatchBurnTest` (happy path) and
+///         `B20SecurityBatchBurnRevertOrderTest` (check-order). This file
+///         covers the precompile-storage checkpoint integration: when an
+///         element past index 0 reverts, the per-element debits from the
+///         earlier successful iterations must be rolled back.
+///
+///         Mock mode gets this for free from revm's journaled storage.
+///         The signal is in fork mode against the real Rust precompile,
+///         where any break in the `precompile-storage` journal hookup
+///         would leave the earlier debits persisted across the revert.
+///         Companion to BOP-176 (Rust-side unit tests).
+contract B20SecurityBatchBurnRollbackTest is B20SecurityTest {
+    /// @notice batchBurn that reverts on element 1 via InsufficientBalance leaves balances + supply unchanged
+    /// @dev    Element 0 burns exactly alice's balance to 0; element 1
+    ///         then attempts to burn more than bob holds and reverts.
+    ///         The journal must roll element 0's debit back, restoring
+    ///         alice to her pre-call balance and totalSupply to its
+    ///         pre-call value. Fuzzes alice's burn amount and bob's
+    ///         shortfall so the test exercises a range of pre-revert
+    ///         write sizes.
+    function test_batchBurn_rollback_revertMidBatch_insufficientBalance(uint64 a1Seed, uint64 bobBalSeed) public {
+        uint256 a1 = bound(uint256(a1Seed), 1, type(uint64).max);
+        // bob is mid-batch and underfunded relative to amounts[1].
+        uint256 bobBurnAmount = bound(uint256(bobBalSeed), 1, type(uint64).max);
+        uint256 bobBal = bound(uint256(bobBalSeed), 0, bobBurnAmount - 1);
+
+        _grantBurnFrom();
+        _mint(alice, a1); // alice has exactly the burn amount → element 0 zeroes her
+        _mint(bob, bobBal); // bob is short by at least 1 → element 1 reverts
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = a1;
+        amounts[1] = bobBurnAmount;
+
+        // Snapshot the state the revert must leave untouched.
+        uint256 aliceBefore = token.balanceOf(alice);
+        uint256 bobBefore = token.balanceOf(bob);
+        uint256 supplyBefore = token.totalSupply();
+
+        vm.prank(burnFromActor);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InsufficientBalance.selector, bob, bobBal, bobBurnAmount));
+        security().batchBurn(accounts, amounts);
+
+        // Element 0's debit must have been rolled back by the journal.
+        assertEq(token.balanceOf(alice), aliceBefore, "alice balance must be unchanged after rollback");
+        assertEq(token.balanceOf(bob), bobBefore, "bob balance must be unchanged after rollback");
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply must be unchanged after rollback");
+    }
+}

--- a/test/unit/B20Security/batch/batchMint_rollback.t.sol
+++ b/test/unit/B20Security/batch/batchMint_rollback.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {B20SecurityTest} from "test/lib/B20SecurityTest.sol";
+
+import {IB20} from "src/interfaces/IB20.sol";
+
+import {B20Constants} from "src/lib/B20Constants.sol";
+
+/// @title B20SecurityBatchMintRollbackTest
+/// @notice Verifies a revert mid-batchMint leaves no orphan token state.
+///
+/// @dev    Sibling of `B20SecurityBatchMintTest` (happy path) and
+///         `B20SecurityBatchMintRevertOrderTest` (check-order). This file
+///         covers the precompile-storage checkpoint integration: when an
+///         element past index 0 reverts, the per-element writes from the
+///         earlier successful iterations must be rolled back.
+///
+///         Mock mode gets this for free from revm's journaled storage —
+///         a passing test there just confirms revm works. The
+///         signal is in fork mode against the real Rust precompile,
+///         where any break in the `precompile-storage` journal hookup
+///         would leave the earlier writes persisted across the revert.
+///         Companion to BOP-176 (Rust-side unit tests).
+contract B20SecurityBatchMintRollbackTest is B20SecurityTest {
+    /// @notice batchMint that reverts on element 1 via supply-cap leaves balances + supply unchanged
+    /// @dev    Element 0 mints under the cap (writes alice's balance and
+    ///         totalSupply); element 1 would push totalSupply past the
+    ///         cap and reverts. The journal must roll element 0's
+    ///         writes back. Fuzzes both amounts so the test exercises a
+    ///         range of "how much element 0 wrote before element 1
+    ///         failed".
+    function test_batchMint_rollback_revertMidBatch_supplyCapExceeded(uint64 a1Seed, uint64 a2Seed) public {
+        // Fixed cap keeps the bounds simple; the property under test
+        // doesn't depend on the cap value, only that element 0 fits and
+        // (element 0 + element 1) does not.
+        uint256 cap = 1_000_000;
+        uint256 a1 = bound(uint256(a1Seed), 1, cap - 1);
+        uint256 a2 = bound(uint256(a2Seed), cap - a1 + 1, cap * 2);
+
+        vm.prank(admin);
+        token.updateSupplyCap(cap);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = alice;
+        recipients[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = a1;
+        amounts[1] = a2;
+
+        // Snapshot the state the revert must leave untouched.
+        uint256 aliceBefore = token.balanceOf(alice);
+        uint256 bobBefore = token.balanceOf(bob);
+        uint256 supplyBefore = token.totalSupply();
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.SupplyCapExceeded.selector, cap, a1 + a2));
+        security().batchMint(recipients, amounts);
+
+        // Element 0's mint must have been rolled back by the journal.
+        assertEq(token.balanceOf(alice), aliceBefore, "alice balance must be unchanged after rollback");
+        assertEq(token.balanceOf(bob), bobBefore, "bob balance must be unchanged after rollback");
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply must be unchanged after rollback");
+    }
+}

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+
+/// @title PolicyRegistryCreatePolicyWithAccountsRollbackTest
+/// @notice Verifies a revert from createPolicyWithAccounts leaves no orphan
+///         registry state.
+///
+/// @dev    Sibling of `PolicyRegistryCreatePolicyWithAccountsTest` (happy
+///         path + revert reasons). Distinct from BOP-176 (Rust-side unit
+///         tests of `precompile-storage`): this exercises the precompile
+///         in a real EVM execution context to verify the JournaledState
+///         integration rolls back any partial writes — or, in the case
+///         of an impl that validates before creating, that no writes
+///         occur at all.
+///
+///         Currently the two impls reach the same end state via
+///         different paths:
+///         - The Solidity mock advances `nextCounter` and writes the
+///           policy slot before checking the batch size, then relies on
+///           revm's journal to roll back on revert (BOP-207 tracks the
+///           reorder).
+///         - The Rust precompile validates batch size first and never
+///           writes.
+///         End state is identical in both: counter unchanged, predicted
+///         policy slot still zero, `policyExists(predicted)` false.
+contract PolicyRegistryCreatePolicyWithAccountsRollbackTest is PolicyRegistryTest {
+    /// @notice An oversized batch reverts and leaves nextCounter + the predicted policy slot byte-identical
+    /// @dev    Reads the relevant slots with `vm.load` before and after
+    ///         the reverting call — the test's signal is the byte-level
+    ///         equality, which is the strictest possible "state
+    ///         unchanged" assertion across both mock and fork modes.
+    function test_createPolicyWithAccounts_rollback_batchSizeTooLarge(
+        address caller,
+        address admin_,
+        uint8 typeIdx,
+        uint8 overflow
+    ) public {
+        _assumeValidCaller(caller);
+        vm.assume(admin_ != address(0));
+        IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Snapshot the registry state the revert must leave untouched.
+        uint64 predictedId = _predictNextPolicyId(pt);
+        bytes32 counterBefore = vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot());
+        bytes32 policySlotBefore = vm.load(address(policyRegistry), MockPolicyRegistryStorage.policySlot(predictedId));
+
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.BatchSizeTooLarge.selector, MAX_BATCH_SIZE));
+        vm.prank(caller);
+        policyRegistry.createPolicyWithAccounts(admin_, pt, accounts);
+
+        // Slots must be byte-identical to pre-revert.
+        bytes32 counterAfter = vm.load(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot());
+        bytes32 policySlotAfter = vm.load(address(policyRegistry), MockPolicyRegistryStorage.policySlot(predictedId));
+        assertEq(counterAfter, counterBefore, "nextCounter slot must be unchanged after rollback");
+        assertEq(policySlotAfter, policySlotBefore, "predicted policy slot must be unchanged after rollback");
+        // And the predicted ID must not be reachable as an existing policy.
+        assertFalse(policyRegistry.policyExists(predictedId), "predicted policy must not exist after rollback");
+    }
+}


### PR DESCRIPTION
## What

Adds three fork-mode regression tests verifying that mid-execution reverts in multi-write batch operations leave no orphan state.

| File | Operation | Mid-batch revert trigger |
|---|---|---|
| `test/unit/B20Security/batch/batchMint_rollback.t.sol` | `batchMint` | Element 1 pushes totalSupply past `supplyCap` |
| `test/unit/B20Security/batch/batchBurn_rollback.t.sol` | `batchBurn` | Element 1's account has insufficient balance |
| `test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol` | `createPolicyWithAccounts` | Batch length > `MAX_BATCH_SIZE` |

Each test snapshots the relevant state (balances + totalSupply, or slot-level `nextCounter` + policy slot), triggers the revert, and asserts the post-revert state is byte-identical to pre-revert.

## Why

Closes [BOP-214](https://linear.app/coinbase/issue/BOP-214). Companion to [BOP-176](https://linear.app/coinbase/issue/BOP-176) (Rust-side unit tests of the `precompile-storage` checkpoint mechanism in isolation).

Mock mode (revm-journaled storage) gives rollback for free — passing tests there mostly just confirms setup is correct and revm works. **The signal is in fork mode**, where the same tests exercise the real Rust precompile and verify that `precompile-storage`'s `JournaledState` integration correctly rolls back partial writes on revert. A broken integration (writes that aren't journaled, checkpoints released early, future refactor that drops the hookup) would leave earlier writes persisted across the revert — this suite would catch it.

The `createPolicyWithAccounts` test is robust to either impl order:
- Solidity mock advances `nextCounter` + writes the policy slot before the batch check (BOP-207 tracks the reorder), relying on revm's journal to roll back.
- Rust precompile validates batch size first; no writes attempted.

Both reach the same end state (counter unchanged, predicted slot still zero); the test passes in both modes for different reasons today.

## Verification

Mock mode:
```
forge test --match-contract 'Rollback' -vv
# 3 passed, 0 failed (256 fuzz runs each)
```

Fork mode (against live Rust precompile via patched anvil):
```
./script/run-fork-tests.sh --match-contract 'Rollback' -vv
# 3 passed, 0 failed (10 fuzz runs each)
```

## Out of scope

Exhaustive coverage of every multi-write entrypoint — only enough to catch precompile-storage integration regressions. Comprehensive unit-level rollback coverage stays in BOP-176.
