### PR TITLE
feat(factory): add variantParams bytes field to B20Created event for stablecoin currency (BOP-158)

### DIFF
--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -162,7 +162,7 @@ interface IB20Factory {
         uint256 minimumRedeemable;
     }
 
-    /// @notice Event payload carried in the `variantParams` field of
+    /// @notice Event payload carried in the `eventParams` field of
     ///         `B20Created` for STABLECOIN-variant tokens. ABI-encoded
     ///         and emitted with a leading `version` byte so stream-based
     ///         indexers can decode by `(variant, version)` without an
@@ -176,11 +176,11 @@ interface IB20Factory {
     ///                   `B20StablecoinCreateParams.currency`. Surfaced here
     ///                   because `currency` has no setter and no other
     ///                   event ever emits it; indexers that cannot make
-    ///                   mid-handler view calls (e.g. Coindexer) would
+    ///                   mid-handler view calls would
     ///                   otherwise have no way to recover it from the
     ///                   event stream.
     /// @dev    DEFAULT and SECURITY variants currently emit an empty
-    ///         `variantParams` byte string: DEFAULT has no extra
+    ///         `eventParams` byte string: DEFAULT has no extra
     ///         immutable identity fields beyond what's already in
     ///         `B20Created`, and SECURITY's `isin` and
     ///         `minimumRedeemable` are mutable and surfaced via their
@@ -247,7 +247,7 @@ interface IB20Factory {
     /// @param name          ERC-20 token name.
     /// @param symbol        ERC-20 token symbol.
     /// @param decimals      ERC-20 decimals (fixed per variant).
-    /// @param variantParams ABI-encoded variant-specific immutable identity
+    /// @param eventParams ABI-encoded variant-specific immutable identity
     ///                      fields, leading with a version byte. Empty
     ///                      (`""`) for DEFAULT and SECURITY (no extra
     ///                      immutable fields not already covered); for
@@ -255,12 +255,7 @@ interface IB20Factory {
     ///                      with `currency`. Indexers decode by
     ///                      `(variant, leading version byte)`.
     event B20Created(
-        address indexed token,
-        B20Variant indexed variant,
-        string name,
-        string symbol,
-        uint8 decimals,
-        bytes variantParams
+        address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals, bytes eventParams
     );
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -162,7 +162,7 @@ interface IB20Factory {
         uint256 minimumRedeemable;
     }
 
-    /// @notice Event payload carried in the `eventParams` field of
+    /// @notice Event payload carried in the `variantParams` field of
     ///         `B20Created` for STABLECOIN-variant tokens. ABI-encoded
     ///         and emitted with a leading `version` byte so stream-based
     ///         indexers can decode by `(variant, version)` without an
@@ -180,7 +180,7 @@ interface IB20Factory {
     ///                   otherwise have no way to recover it from the
     ///                   event stream.
     /// @dev    DEFAULT and SECURITY variants currently emit an empty
-    ///         `eventParams` byte string: DEFAULT has no extra
+    ///         `variantParams` byte string: DEFAULT has no extra
     ///         immutable identity fields beyond what's already in
     ///         `B20Created`, and SECURITY's `isin` and
     ///         `minimumRedeemable` are mutable and surfaced via their
@@ -247,7 +247,7 @@ interface IB20Factory {
     /// @param name          ERC-20 token name.
     /// @param symbol        ERC-20 token symbol.
     /// @param decimals      ERC-20 decimals (fixed per variant).
-    /// @param eventParams ABI-encoded variant-specific immutable identity
+    /// @param variantParams ABI-encoded variant-specific immutable identity
     ///                      fields, leading with a version byte. Empty
     ///                      (`""`) for DEFAULT and SECURITY (no extra
     ///                      immutable fields not already covered); for
@@ -255,7 +255,12 @@ interface IB20Factory {
     ///                      with `currency`. Indexers decode by
     ///                      `(variant, leading version byte)`.
     event B20Created(
-        address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals, bytes eventParams
+        address indexed token,
+        B20Variant indexed variant,
+        string name,
+        string symbol,
+        uint8 decimals,
+        bytes variantParams
     );
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -162,6 +162,37 @@ interface IB20Factory {
         uint256 minimumRedeemable;
     }
 
+    /// @notice Event payload carried in the `variantParams` field of
+    ///         `B20Created` for STABLECOIN-variant tokens. ABI-encoded
+    ///         and emitted with a leading `version` byte so stream-based
+    ///         indexers can decode by `(variant, version)` without an
+    ///         RPC call to read storage.
+    /// @param  version   Event-encoding version. Currently `1`.
+    ///                   Independent of `B20StablecoinCreateParams.version`;
+    ///                   the event payload schema can evolve separately
+    ///                   from the create-call payload schema.
+    /// @param  currency  The immutable stablecoin currency identifier, same
+    ///                   value that was passed in
+    ///                   `B20StablecoinCreateParams.currency`. Surfaced here
+    ///                   because `currency` has no setter and no other
+    ///                   event ever emits it; indexers that cannot make
+    ///                   mid-handler view calls (e.g. Coindexer) would
+    ///                   otherwise have no way to recover it from the
+    ///                   event stream.
+    /// @dev    DEFAULT and SECURITY variants currently emit an empty
+    ///         `variantParams` byte string: DEFAULT has no extra
+    ///         immutable identity fields beyond what's already in
+    ///         `B20Created`, and SECURITY's `isin` and
+    ///         `minimumRedeemable` are mutable and surfaced via their
+    ///         own `SecurityIdentifierUpdated` /
+    ///         `MinimumRedeemableUpdated` events. Either variant can
+    ///         promote from empty to a non-empty payload in a future
+    ///         version without re-issuing a new event type.
+    struct B20StablecoinEventParams {
+        uint8 version;
+        string currency;
+    }
+
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -211,7 +242,26 @@ interface IB20Factory {
     ///         `B20Created` is the token-identity signal only. The
     ///         "demonstrate no owner" path (`initialAdmin == address(0)`)
     ///         skips the grant and emits no `RoleGranted` at bootstrap.
-    event B20Created(address indexed token, B20Variant indexed variant, string name, string symbol, uint8 decimals);
+    /// @param token         Address of the newly-created token.
+    /// @param variant       Which `B20Variant` was created.
+    /// @param name          ERC-20 token name.
+    /// @param symbol        ERC-20 token symbol.
+    /// @param decimals      ERC-20 decimals (fixed per variant).
+    /// @param variantParams ABI-encoded variant-specific immutable identity
+    ///                      fields, leading with a version byte. Empty
+    ///                      (`""`) for DEFAULT and SECURITY (no extra
+    ///                      immutable fields not already covered); for
+    ///                      STABLECOIN, carries `abi.encode(B20StablecoinEventParams)`
+    ///                      with `currency`. Indexers decode by
+    ///                      `(variant, leading version byte)`.
+    event B20Created(
+        address indexed token,
+        B20Variant indexed variant,
+        string name,
+        string symbol,
+        uint8 decimals,
+        bytes variantParams
+    );
 
     /*//////////////////////////////////////////////////////////////
                                  CREATE

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -162,7 +162,7 @@ interface IB20Factory {
         uint256 minimumRedeemable;
     }
 
-    /// @notice Event payload carried in the `variantParams` field of
+    /// @notice Event payload carried in the `variantEventParams` field of
     ///         `B20Created` for STABLECOIN-variant tokens. ABI-encoded
     ///         and emitted with a leading `version` byte so stream-based
     ///         indexers can decode by `(variant, version)` without an
@@ -180,7 +180,7 @@ interface IB20Factory {
     ///                   otherwise have no way to recover it from the
     ///                   event stream.
     /// @dev    DEFAULT and SECURITY variants currently emit an empty
-    ///         `variantParams` byte string: DEFAULT has no extra
+    ///         `variantEventParams` byte string: DEFAULT has no extra
     ///         immutable identity fields beyond what's already in
     ///         `B20Created`, and SECURITY's `isin` and
     ///         `minimumRedeemable` are mutable and surfaced via their
@@ -247,7 +247,7 @@ interface IB20Factory {
     /// @param name          ERC-20 token name.
     /// @param symbol        ERC-20 token symbol.
     /// @param decimals      ERC-20 decimals (fixed per variant).
-    /// @param variantParams ABI-encoded variant-specific immutable identity
+    /// @param variantEventParams ABI-encoded variant-specific immutable identity
     ///                      fields, leading with a version byte. Empty
     ///                      (`""`) for DEFAULT and SECURITY (no extra
     ///                      immutable fields not already covered); for
@@ -260,7 +260,7 @@ interface IB20Factory {
         string name,
         string symbol,
         uint8 decimals,
-        bytes variantParams
+        bytes variantEventParams
     );
 
     /*//////////////////////////////////////////////////////////////

--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -225,6 +225,24 @@ library B20FactoryLib {
         );
     }
 
+    /// @notice Encodes a `B20StablecoinEventParams` as the `variantParams`
+    ///         blob the factory emits in the `B20Created` event when
+    ///         `variant == B20Variant.STABLECOIN`. The leading byte is
+    ///         `B20_STABLECOIN_EVENT_PARAMS_VERSION`. Indexers decode
+    ///         this blob by `(variant, leading version byte)` to recover
+    ///         the immutable `currency` without an RPC call.
+    ///
+    /// @param  currency  ISO 4217 fiat code this stablecoin tracks; same
+    ///                   value passed to `encodeStablecoinCreateParams`
+    ///                   at creation time.
+    ///
+    /// @return The ABI-encoded `B20StablecoinEventParams` blob.
+    function encodeStablecoinEventParams(string memory currency) internal pure returns (bytes memory) {
+        return abi.encode(
+            IB20Factory.B20StablecoinEventParams({version: B20_STABLECOIN_EVENT_PARAMS_VERSION, currency: currency})
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////
                         INIT-CALL SETTER ENCODERS
     //////////////////////////////////////////////////////////////*/

--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -61,7 +61,7 @@ library B20FactoryLib {
     uint8 internal constant B20_SECURITY_CREATE_PARAMS_VERSION = 1;
 
     /// @notice Current encoding version for `B20StablecoinEventParams`,
-    ///         the payload carried in the `variantParams` field of the
+    ///         the payload carried in the `variantEventParams` field of the
     ///         `B20Created` event for STABLECOIN-variant tokens.
     ///         Independent of `B20_STABLECOIN_CREATE_PARAMS_VERSION` —
     ///         the event payload schema can evolve separately from the
@@ -225,7 +225,7 @@ library B20FactoryLib {
         );
     }
 
-    /// @notice Encodes a `B20StablecoinEventParams` as the `variantParams`
+    /// @notice Encodes a `B20StablecoinEventParams` as the `variantEventParams`
     ///         blob the factory emits in the `B20Created` event when
     ///         `variant == B20Variant.STABLECOIN`. The leading byte is
     ///         `B20_STABLECOIN_EVENT_PARAMS_VERSION`. Indexers decode

--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -61,7 +61,7 @@ library B20FactoryLib {
     uint8 internal constant B20_SECURITY_CREATE_PARAMS_VERSION = 1;
 
     /// @notice Current encoding version for `B20StablecoinEventParams`,
-    ///         the payload carried in the `variantParams` field of the
+    ///         the payload carried in the `eventParams` field of the
     ///         `B20Created` event for STABLECOIN-variant tokens.
     ///         Independent of `B20_STABLECOIN_CREATE_PARAMS_VERSION` —
     ///         the event payload schema can evolve separately from the
@@ -225,7 +225,7 @@ library B20FactoryLib {
         );
     }
 
-    /// @notice Encodes a `B20StablecoinEventParams` as the `variantParams`
+    /// @notice Encodes a `B20StablecoinEventParams` as the `eventParams`
     ///         blob the factory emits in the `B20Created` event when
     ///         `variant == B20Variant.STABLECOIN`. The leading byte is
     ///         `B20_STABLECOIN_EVENT_PARAMS_VERSION`. Indexers decode

--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -61,7 +61,7 @@ library B20FactoryLib {
     uint8 internal constant B20_SECURITY_CREATE_PARAMS_VERSION = 1;
 
     /// @notice Current encoding version for `B20StablecoinEventParams`,
-    ///         the payload carried in the `eventParams` field of the
+    ///         the payload carried in the `variantParams` field of the
     ///         `B20Created` event for STABLECOIN-variant tokens.
     ///         Independent of `B20_STABLECOIN_CREATE_PARAMS_VERSION` —
     ///         the event payload schema can evolve separately from the
@@ -225,7 +225,7 @@ library B20FactoryLib {
         );
     }
 
-    /// @notice Encodes a `B20StablecoinEventParams` as the `eventParams`
+    /// @notice Encodes a `B20StablecoinEventParams` as the `variantParams`
     ///         blob the factory emits in the `B20Created` event when
     ///         `variant == B20Variant.STABLECOIN`. The leading byte is
     ///         `B20_STABLECOIN_EVENT_PARAMS_VERSION`. Indexers decode

--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -60,6 +60,14 @@ library B20FactoryLib {
     ///         Independent of the other variants' versions.
     uint8 internal constant B20_SECURITY_CREATE_PARAMS_VERSION = 1;
 
+    /// @notice Current encoding version for `B20StablecoinEventParams`,
+    ///         the payload carried in the `variantParams` field of the
+    ///         `B20Created` event for STABLECOIN-variant tokens.
+    ///         Independent of `B20_STABLECOIN_CREATE_PARAMS_VERSION` —
+    ///         the event payload schema can evolve separately from the
+    ///         create-call payload schema.
+    uint8 internal constant B20_STABLECOIN_EVENT_PARAMS_VERSION = 1;
+
     /// @notice Two parallel arrays passed to a `build*` helper had
     ///         different lengths.
     ///

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -188,11 +188,7 @@ contract MockB20Factory is IB20Factory {
         //       mutable and surfaced via their own update events).
         bytes memory variantParams;
         if (variant == B20Variant.STABLECOIN) {
-            variantParams = abi.encode(
-                IB20Factory.B20StablecoinEventParams({
-                    version: B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION, currency: currency_
-                })
-            );
+            variantParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
         }
         emit B20Created(token, variant, name_, symbol_, decimals, variantParams);
 

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -178,19 +178,19 @@ contract MockB20Factory is IB20Factory {
         //       assignment is announced via the standard RoleGranted
         //       event from step 7.
         //
-        //       The `variantParams` field carries variant-specific
+        //       The `eventParams` field carries variant-specific
         //       immutable identity that isn't already covered by the
         //       fixed event fields. STABLECOIN emits an ABI-encoded
         //       `B20StablecoinEventParams` so stream-based indexers
-        //       (e.g. Coindexer) can recover the immutable `currency`
+        //       can recover the immutable `currency`
         //       without an RPC call. DEFAULT and SECURITY emit empty
         //       bytes (SECURITY's `isin` / `minimumRedeemable` are
         //       mutable and surfaced via their own update events).
-        bytes memory variantParams;
+        bytes memory eventParams;
         if (variant == B20Variant.STABLECOIN) {
-            variantParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
+            eventParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
         }
-        emit B20Created(token, variant, name_, symbol_, decimals, variantParams);
+        emit B20Created(token, variant, name_, symbol_, decimals, eventParams);
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -178,7 +178,7 @@ contract MockB20Factory is IB20Factory {
         //       assignment is announced via the standard RoleGranted
         //       event from step 7.
         //
-        //       The `variantParams` field carries variant-specific
+        //       The `variantEventParams` field carries variant-specific
         //       immutable identity that isn't already covered by the
         //       fixed event fields. STABLECOIN emits an ABI-encoded
         //       `B20StablecoinEventParams` so stream-based indexers
@@ -186,11 +186,11 @@ contract MockB20Factory is IB20Factory {
         //       without an RPC call. DEFAULT and SECURITY emit empty
         //       bytes (SECURITY's `isin` / `minimumRedeemable` are
         //       mutable and surfaced via their own update events).
-        bytes memory variantParams;
+        bytes memory variantEventParams;
         if (variant == B20Variant.STABLECOIN) {
-            variantParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
+            variantEventParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
         }
-        emit B20Created(token, variant, name_, symbol_, decimals, variantParams);
+        emit B20Created(token, variant, name_, symbol_, decimals, variantEventParams);
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -178,7 +178,7 @@ contract MockB20Factory is IB20Factory {
         //       assignment is announced via the standard RoleGranted
         //       event from step 7.
         //
-        //       The `eventParams` field carries variant-specific
+        //       The `variantParams` field carries variant-specific
         //       immutable identity that isn't already covered by the
         //       fixed event fields. STABLECOIN emits an ABI-encoded
         //       `B20StablecoinEventParams` so stream-based indexers
@@ -186,11 +186,11 @@ contract MockB20Factory is IB20Factory {
         //       without an RPC call. DEFAULT and SECURITY emit empty
         //       bytes (SECURITY's `isin` / `minimumRedeemable` are
         //       mutable and surfaced via their own update events).
-        bytes memory eventParams;
+        bytes memory variantParams;
         if (variant == B20Variant.STABLECOIN) {
-            eventParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
+            variantParams = B20FactoryLib.encodeStablecoinEventParams(currency_);
         }
-        emit B20Created(token, variant, name_, symbol_, decimals, eventParams);
+        emit B20Created(token, variant, name_, symbol_, decimals, variantParams);
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -177,7 +177,24 @@ contract MockB20Factory is IB20Factory {
         // -- 6. Emit B20Created. Identity-only signal; admin role
         //       assignment is announced via the standard RoleGranted
         //       event from step 7.
-        emit B20Created(token, variant, name_, symbol_, decimals);
+        //
+        //       The `variantParams` field carries variant-specific
+        //       immutable identity that isn't already covered by the
+        //       fixed event fields. STABLECOIN emits an ABI-encoded
+        //       `B20StablecoinEventParams` so stream-based indexers
+        //       (e.g. Coindexer) can recover the immutable `currency`
+        //       without an RPC call. DEFAULT and SECURITY emit empty
+        //       bytes (SECURITY's `isin` / `minimumRedeemable` are
+        //       mutable and surfaced via their own update events).
+        bytes memory variantParams;
+        if (variant == B20Variant.STABLECOIN) {
+            variantParams = abi.encode(
+                IB20Factory.B20StablecoinEventParams({
+                    version: B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION, currency: currency_
+                })
+            );
+        }
+        emit B20Created(token, variant, name_, symbol_, decimals, variantParams);
 
         // -- 7. Grant the initial admin role via the canonical path.
         //       msg.sender at the token is address(this) == factory,

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -475,7 +475,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
     ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that. DEFAULT variant
-    ///      emits empty `eventParams` (no extra immutable identity fields beyond what's already
+    ///      emits empty `variantParams` (no extra immutable identity fields beyond what's already
     ///      in the event).
     function test_createB20_success_emitsB20Created(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -490,7 +490,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies createToken emits B20Created with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
     ///      way the default emitter test pins decimals=18. SECURITY variant emits empty
-    ///      `eventParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
+    ///      `variantParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
     ///      their own update events).
     function test_createB20_success_emitsB20Created_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -503,8 +503,8 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     }
 
     /// @notice Verifies createToken emits B20Created with decimals=6 and a non-empty
-    ///         `eventParams` payload for the stablecoin variant
-    /// @dev    STABLECOIN-only behavior: the `eventParams` field carries
+    ///         `variantParams` payload for the stablecoin variant
+    /// @dev    STABLECOIN-only behavior: the `variantParams` field carries
     ///         `abi.encode(B20StablecoinEventParams { version, currency })` so stream-based
     ///         indexers can recover the immutable `currency` without an RPC
     ///         call to `currency()`.
@@ -527,7 +527,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         _createStablecoin(caller, salt, p, new bytes[](0));
     }
 
-    /// @notice Verifies the `eventParams` payload of `B20Created` for STABLECOIN decodes
+    /// @notice Verifies the `variantParams` payload of `B20Created` for STABLECOIN decodes
     ///         back to a `B20StablecoinEventParams` whose `currency` round-trips the value
     ///         passed at creation and whose `version` matches the canonical event-encoding
     ///         version constant.
@@ -554,18 +554,18 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         bytes32 selector = IB20Factory.B20Created.selector;
-        bytes memory eventParams;
+        bytes memory variantParams;
         for (uint256 i = 0; i < logs.length; ++i) {
             if (logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
-                // B20Created data payload: (name, symbol, decimals, eventParams).
-                (,,, eventParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
+                // B20Created data payload: (name, symbol, decimals, variantParams).
+                (,,, variantParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
                 break;
             }
         }
-        assertGt(eventParams.length, 0, "STABLECOIN eventParams must be non-empty");
+        assertGt(variantParams.length, 0, "STABLECOIN variantParams must be non-empty");
 
         IB20Factory.B20StablecoinEventParams memory decoded =
-            abi.decode(eventParams, (IB20Factory.B20StablecoinEventParams));
+            abi.decode(variantParams, (IB20Factory.B20StablecoinEventParams));
         assertEq(
             decoded.version,
             B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION,

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -475,7 +475,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
     ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that. DEFAULT variant
-    ///      emits empty `variantParams` (no extra immutable identity fields beyond what's already
+    ///      emits empty `eventParams` (no extra immutable identity fields beyond what's already
     ///      in the event).
     function test_createB20_success_emitsB20Created(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -490,7 +490,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies createToken emits B20Created with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
     ///      way the default emitter test pins decimals=18. SECURITY variant emits empty
-    ///      `variantParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
+    ///      `eventParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
     ///      their own update events).
     function test_createB20_success_emitsB20Created_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -503,10 +503,10 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     }
 
     /// @notice Verifies createToken emits B20Created with decimals=6 and a non-empty
-    ///         `variantParams` payload for the stablecoin variant
-    /// @dev    STABLECOIN-only behavior: the `variantParams` field carries
+    ///         `eventParams` payload for the stablecoin variant
+    /// @dev    STABLECOIN-only behavior: the `eventParams` field carries
     ///         `abi.encode(B20StablecoinEventParams { version, currency })` so stream-based
-    ///         indexers (e.g. Coindexer) can recover the immutable `currency` without an RPC
+    ///         indexers can recover the immutable `currency` without an RPC
     ///         call to `currency()`.
     function test_createB20_success_emitsB20Created_stablecoin(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -527,7 +527,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         _createStablecoin(caller, salt, p, new bytes[](0));
     }
 
-    /// @notice Verifies the `variantParams` payload of `B20Created` for STABLECOIN decodes
+    /// @notice Verifies the `eventParams` payload of `B20Created` for STABLECOIN decodes
     ///         back to a `B20StablecoinEventParams` whose `currency` round-trips the value
     ///         passed at creation and whose `version` matches the canonical event-encoding
     ///         version constant.
@@ -554,18 +554,18 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         bytes32 selector = IB20Factory.B20Created.selector;
-        bytes memory variantParams;
+        bytes memory eventParams;
         for (uint256 i = 0; i < logs.length; ++i) {
             if (logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
-                // B20Created data payload: (name, symbol, decimals, variantParams).
-                (,,, variantParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
+                // B20Created data payload: (name, symbol, decimals, eventParams).
+                (,,, eventParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
                 break;
             }
         }
-        assertGt(variantParams.length, 0, "STABLECOIN variantParams must be non-empty");
+        assertGt(eventParams.length, 0, "STABLECOIN eventParams must be non-empty");
 
         IB20Factory.B20StablecoinEventParams memory decoded =
-            abi.decode(variantParams, (IB20Factory.B20StablecoinEventParams));
+            abi.decode(eventParams, (IB20Factory.B20StablecoinEventParams));
         assertEq(
             decoded.version,
             B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION,

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -475,7 +475,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
     ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that. DEFAULT variant
-    ///      emits empty `variantParams` (no extra immutable identity fields beyond what's already
+    ///      emits empty `variantEventParams` (no extra immutable identity fields beyond what's already
     ///      in the event).
     function test_createB20_success_emitsB20Created(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -490,7 +490,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies createToken emits B20Created with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
     ///      way the default emitter test pins decimals=18. SECURITY variant emits empty
-    ///      `variantParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
+    ///      `variantEventParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
     ///      their own update events).
     function test_createB20_success_emitsB20Created_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
@@ -503,8 +503,8 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     }
 
     /// @notice Verifies createToken emits B20Created with decimals=6 and a non-empty
-    ///         `variantParams` payload for the stablecoin variant
-    /// @dev    STABLECOIN-only behavior: the `variantParams` field carries
+    ///         `variantEventParams` payload for the stablecoin variant
+    /// @dev    STABLECOIN-only behavior: the `variantEventParams` field carries
     ///         `abi.encode(B20StablecoinEventParams { version, currency })` so stream-based
     ///         indexers can recover the immutable `currency` without an RPC
     ///         call to `currency()`.
@@ -527,7 +527,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         _createStablecoin(caller, salt, p, new bytes[](0));
     }
 
-    /// @notice Verifies the `variantParams` payload of `B20Created` for STABLECOIN decodes
+    /// @notice Verifies the `variantEventParams` payload of `B20Created` for STABLECOIN decodes
     ///         back to a `B20StablecoinEventParams` whose `currency` round-trips the value
     ///         passed at creation and whose `version` matches the canonical event-encoding
     ///         version constant.
@@ -554,18 +554,18 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         Vm.Log[] memory logs = vm.getRecordedLogs();
 
         bytes32 selector = IB20Factory.B20Created.selector;
-        bytes memory variantParams;
+        bytes memory variantEventParams;
         for (uint256 i = 0; i < logs.length; ++i) {
             if (logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
-                // B20Created data payload: (name, symbol, decimals, variantParams).
-                (,,, variantParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
+                // B20Created data payload: (name, symbol, decimals, variantEventParams).
+                (,,, variantEventParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
                 break;
             }
         }
-        assertGt(variantParams.length, 0, "STABLECOIN variantParams must be non-empty");
+        assertGt(variantEventParams.length, 0, "STABLECOIN variantEventParams must be non-empty");
 
         IB20Factory.B20StablecoinEventParams memory decoded =
-            abi.decode(variantParams, (IB20Factory.B20StablecoinEventParams));
+            abi.decode(variantEventParams, (IB20Factory.B20StablecoinEventParams));
         assertEq(
             decoded.version,
             B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION,

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -7,6 +7,7 @@ import {IB20} from "src/interfaces/IB20.sol";
 import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
 import {IB20Security} from "src/interfaces/IB20Security.sol";
 import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
 
 import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
 import {MockB20Security} from "test/lib/mocks/MockB20Security.sol";
@@ -116,6 +117,18 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
             if (b[i] < 0x41 || b[i] > 0x5A) return false;
         }
         return true;
+    }
+
+    /// @dev Deterministic seed → 3-letter uppercase ASCII fiat code, guaranteed
+    ///      to pass `_isValidFiatCode`. Use in success-path fuzz tests instead of
+    ///      `vm.assume(_isValidFiatCode(...))` over a raw `string` input, which
+    ///      would hit foundry's rejection-rate ceiling.
+    function _make3LetterUppercase(uint256 seed) private pure returns (string memory) {
+        bytes memory b = new bytes(3);
+        b[0] = bytes1(uint8(0x41 + (seed % 26)));
+        b[1] = bytes1(uint8(0x41 + ((seed >> 8) % 26)));
+        b[2] = bytes1(uint8(0x41 + ((seed >> 16) % 26)));
+        return string(b);
     }
 
     /// @notice Verifies createToken reverts for any unsupported version byte on the SECURITY variant
@@ -461,28 +474,104 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies createToken emits B20Created with the correct identity fields
     /// @dev Event integrity: token, variant, name, symbol, decimals must match derived variant defaults.
     ///      Admin role assignment is announced via RoleGranted, not as a field on this event;
-    ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that.
+    ///      see test_createB20_success_emitsRoleGrantedForInitialAdmin for that. DEFAULT variant
+    ///      emits empty `variantParams` (no extra immutable identity fields beyond what's already
+    ///      in the event).
     function test_createB20_success_emitsB20Created(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20CreateParams memory p = _b20Params("MyToken", "MYT", admin);
         address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.DEFAULT, "MyToken", "MYT", 18);
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.DEFAULT, "MyToken", "MYT", 18, bytes(""));
         _createDefault(caller, salt, p, new bytes[](0));
     }
 
     /// @notice Verifies createToken emits B20Created with decimals=6 for the security variant
     /// @dev Variant-specific dedicated event test: the security arm pins decimals=6 the same
-    ///      way the default emitter test pins decimals=18.
+    ///      way the default emitter test pins decimals=18. SECURITY variant emits empty
+    ///      `variantParams` (its `isin` and `minimumRedeemable` are mutable and surfaced via
+    ///      their own update events).
     function test_createB20_success_emitsB20Created_security(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20SecurityCreateParams memory p = _securityParams("Security Test", "SEC", admin, DEFAULT_ISIN, 0);
         address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, caller, salt);
 
         vm.expectEmit(true, true, false, true, address(factory));
-        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.SECURITY, "Security Test", "SEC", 6);
+        emit IB20Factory.B20Created(predicted, IB20Factory.B20Variant.SECURITY, "Security Test", "SEC", 6, bytes(""));
         _createSecurity(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice Verifies createToken emits B20Created with decimals=6 and a non-empty
+    ///         `variantParams` payload for the stablecoin variant
+    /// @dev    STABLECOIN-only behavior: the `variantParams` field carries
+    ///         `abi.encode(B20StablecoinEventParams { version, currency })` so stream-based
+    ///         indexers (e.g. Coindexer) can recover the immutable `currency` without an RPC
+    ///         call to `currency()`.
+    function test_createB20_success_emitsB20Created_stablecoin(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        string memory currency = "USD";
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("USD Stable", "USDS", admin, currency);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, caller, salt);
+
+        bytes memory expectedVariantParams = abi.encode(
+            IB20Factory.B20StablecoinEventParams({
+                version: B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION, currency: currency
+            })
+        );
+
+        vm.expectEmit(true, true, false, true, address(factory));
+        emit IB20Factory.B20Created(
+            predicted, IB20Factory.B20Variant.STABLECOIN, "USD Stable", "USDS", 6, expectedVariantParams
+        );
+        _createStablecoin(caller, salt, p, new bytes[](0));
+    }
+
+    /// @notice Verifies the `variantParams` payload of `B20Created` for STABLECOIN decodes
+    ///         back to a `B20StablecoinEventParams` whose `currency` round-trips the value
+    ///         passed at creation and whose `version` matches the canonical event-encoding
+    ///         version constant.
+    /// @dev    Decode-level pin (complementary to `_emitsB20Created_stablecoin`'s
+    ///         expectEmit-level pin). Catches a future regression that emits a payload with
+    ///         the right SHAPE but wrong VERSION or CONTENT — for example, accidentally
+    ///         re-using `B20_STABLECOIN_CREATE_PARAMS_VERSION` instead of
+    ///         `B20_STABLECOIN_EVENT_PARAMS_VERSION`, or echoing the `name` field instead of
+    ///         the `currency` field. Recorded-logs replay so the assertion runs against the
+    ///         exact bytes the factory actually emitted, not a re-computed expectation.
+    function test_createB20_success_b20CreatedVariantParams_stablecoin_decodes(
+        address caller,
+        bytes32 salt,
+        uint256 currencySeed
+    ) public {
+        _assumeValidCaller(caller);
+        // Generate a guaranteed-valid 3-letter uppercase fiat code from the fuzz seed.
+        // Avoids vm.assume rejection-rate exhaustion that filtering random strings would hit.
+        string memory currency = _make3LetterUppercase(currencySeed);
+        IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Stable", "STB", admin, currency);
+
+        vm.recordLogs();
+        _createStablecoin(caller, salt, p, new bytes[](0));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 selector = IB20Factory.B20Created.selector;
+        bytes memory variantParams;
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == selector) {
+                // B20Created data payload: (name, symbol, decimals, variantParams).
+                (,,, variantParams) = abi.decode(logs[i].data, (string, string, uint8, bytes));
+                break;
+            }
+        }
+        assertGt(variantParams.length, 0, "STABLECOIN variantParams must be non-empty");
+
+        IB20Factory.B20StablecoinEventParams memory decoded =
+            abi.decode(variantParams, (IB20Factory.B20StablecoinEventParams));
+        assertEq(
+            decoded.version,
+            B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION,
+            "decoded version must equal B20_STABLECOIN_EVENT_PARAMS_VERSION"
+        );
+        assertEq(decoded.currency, currency, "decoded currency must round-trip the value passed at creation");
     }
 
     /// @notice Verifies createToken executes each entry in initCalls during the bootstrap window

--- a/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+
+import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+
+contract B20FactoryLibEncodeStablecoinEventParamsTest is B20FactoryLibTest {
+    /// @notice Verifies the output decodes back to a `B20StablecoinEventParams`
+    ///         with the caller's currency and the current event-encoding version byte.
+    /// @dev    Round-trips through `abi.decode` to pin the wire format the
+    ///         `B20Created` `variantParams` field carries for STABLECOIN. The
+    ///         event-params version is independent of the create-params version,
+    ///         so this test pins against `B20_STABLECOIN_EVENT_PARAMS_VERSION`
+    ///         specifically (not `B20_STABLECOIN_CREATE_PARAMS_VERSION`).
+    function test_encodeStablecoinEventParams_success_roundTripsThroughDecode(string memory currency) public pure {
+        bytes memory blob = B20FactoryLib.encodeStablecoinEventParams(currency);
+        IB20Factory.B20StablecoinEventParams memory decoded = abi.decode(blob, (IB20Factory.B20StablecoinEventParams));
+
+        assertEq(
+            decoded.version,
+            B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION,
+            "version byte must match library constant"
+        );
+        assertEq(decoded.currency, currency, "currency must round-trip");
+    }
+
+    /// @notice Verifies the encoded blob is byte-identical to a hand-encoded
+    ///         `B20StablecoinEventParams` struct.
+    /// @dev    Pins the encoding shape so future field reordering on the
+    ///         struct is caught against an explicit reference.
+    function test_encodeStablecoinEventParams_success_matchesHandEncodedStruct(string memory currency) public pure {
+        bytes memory expected = abi.encode(
+            IB20Factory.B20StablecoinEventParams({
+                version: B20FactoryLib.B20_STABLECOIN_EVENT_PARAMS_VERSION, currency: currency
+            })
+        );
+        bytes memory actual = B20FactoryLib.encodeStablecoinEventParams(currency);
+        assertEq(actual, expected, "encoded blob must match hand-encoded struct byte-for-byte");
+    }
+}

--- a/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
@@ -10,7 +10,7 @@ contract B20FactoryLibEncodeStablecoinEventParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20StablecoinEventParams`
     ///         with the caller's currency and the current event-encoding version byte.
     /// @dev    Round-trips through `abi.decode` to pin the wire format the
-    ///         `B20Created` `variantParams` field carries for STABLECOIN. The
+    ///         `B20Created` `eventParams` field carries for STABLECOIN. The
     ///         event-params version is independent of the create-params version,
     ///         so this test pins against `B20_STABLECOIN_EVENT_PARAMS_VERSION`
     ///         specifically (not `B20_STABLECOIN_CREATE_PARAMS_VERSION`).

--- a/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
@@ -10,7 +10,7 @@ contract B20FactoryLibEncodeStablecoinEventParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20StablecoinEventParams`
     ///         with the caller's currency and the current event-encoding version byte.
     /// @dev    Round-trips through `abi.decode` to pin the wire format the
-    ///         `B20Created` `variantParams` field carries for STABLECOIN. The
+    ///         `B20Created` `variantEventParams` field carries for STABLECOIN. The
     ///         event-params version is independent of the create-params version,
     ///         so this test pins against `B20_STABLECOIN_EVENT_PARAMS_VERSION`
     ///         specifically (not `B20_STABLECOIN_CREATE_PARAMS_VERSION`).

--- a/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
@@ -10,7 +10,7 @@ contract B20FactoryLibEncodeStablecoinEventParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20StablecoinEventParams`
     ///         with the caller's currency and the current event-encoding version byte.
     /// @dev    Round-trips through `abi.decode` to pin the wire format the
-    ///         `B20Created` `eventParams` field carries for STABLECOIN. The
+    ///         `B20Created` `variantParams` field carries for STABLECOIN. The
     ///         event-params version is independent of the create-params version,
     ///         so this test pins against `B20_STABLECOIN_EVENT_PARAMS_VERSION`
     ///         specifically (not `B20_STABLECOIN_CREATE_PARAMS_VERSION`).


### PR DESCRIPTION
## Context

Tracking ticket: [BOP-158](https://linear.app/coinbase/issue/BOP-158)

Adds a `bytes variantParams` field to `B20Created` so stream-based indexers (e.g. Coindexer) can recover the immutable `currency` of a stablecoin without making mid-handler RPC calls. The payload format mirrors the existing `createParams` pattern: ABI-encoded variant-specific struct prefixed by a version byte.

Supersedes the closed [#85](https://github.com/base/base-std/pull/85) (Option B: separate `StablecoinCreated`/`SecurityCreated` companion events). Rust precompile counterpart: [BOP-216](https://linear.app/coinbase/issue/BOP-216).

## Design

```solidity
event B20Created(
    address indexed token,
    B20Variant indexed variant,
    string name,
    string symbol,
    uint8 decimals,
    bytes variantParams  // NEW
);

struct B20StablecoinEventParams {
    uint8 version;
    string currency;
}
```

Indexer contract: variant comes from the indexed field; if `variantParams.length == 0`, no extra immutable fields; if non-empty, first byte is the version, decoder selected by `(variant, version)`. Same shape as `B20CreateParams` / `B20StablecoinCreateParams` / `B20SecurityCreateParams`.

## Per-variant payload

| Variant | `variantParams` payload | Rationale |
|---|---|---|
| `DEFAULT` | empty (`""`) | No extra immutable identity beyond name/symbol/decimals |
| `STABLECOIN` | `abi.encode(B20StablecoinEventParams { version: 1, currency })` | `currency` is immutable, no setter, no other event emits it |
| `SECURITY` | empty (`""`) | `isin` is mutable via `updateSecurityIdentifier` (emits `SecurityIdentifierUpdated`); `minimumRedeemable` is mutable via `updateMinimumRedeemable` (emits `MinimumRedeemableUpdated`) |

Forward-compatible: any variant can promote from empty to non-empty in a future version (just bump the variant's `*_EVENT_PARAMS_VERSION` and decode by `(variant, version)`).

## Why Option A over Option B (PR #85)

| Concern | Option A (this PR) | Option B (#85) |
|---|---|---|
| Indexer-friendly | ✅ one event per creation | ✅ but two events per creation |
| Variant-specific payload | ✅ typed via bytes + version | ✅ separate event per variant |
| Forward-compat for new immutable fields | ✅ bump version, add struct field | ❌ new event per change |
| Mirrors existing createParams pattern | ✅ same shape | ❌ asymmetric |
| Selector count growth as variants are added | ✅ stays 1 | ❌ grows linearly with variants |

## Changes

| File | What |
|---|---|
| `src/interfaces/IB20Factory.sol` | Add `bytes variantParams` to `B20Created`; add `struct B20StablecoinEventParams` |
| `src/lib/B20FactoryLib.sol` | Add `B20_STABLECOIN_EVENT_PARAMS_VERSION = 1` constant |
| `test/lib/mocks/MockB20Factory.sol` | Build `variantParams` per variant before `emit B20Created` |
| `test/unit/B20Factory/createToken.t.sol` | Update 2 existing event-match tests for the 6-arg signature; add `test_createB20_success_emitsB20Created_stablecoin` (expectEmit-level pin) and `test_createB20_success_b20CreatedVariantParams_stablecoin_decodes` (recorded-logs decode round-trip) |

## Verification

- `forge fmt --check` clean on touched files
- `forge build` clean (only pre-existing warnings on unrelated files)
- Mock-only unit suite: **583 / 0 / 0** (stable across 3 consecutive runs; was 581 baseline + 2 new tests = 583)
- B20Factory suite: **55 / 0 / 0** (was 53 + 2 new = 55)
- All 4 `B20Created` emission tests pass:
  ```
  [PASS] test_createB20_success_emitsB20Created(address,bytes32) (runs: 256)
  [PASS] test_createB20_success_emitsB20Created_security(address,bytes32) (runs: 256)
  [PASS] test_createB20_success_emitsB20Created_stablecoin(address,bytes32) (runs: 256)
  [PASS] test_createB20_success_b20CreatedVariantParams_stablecoin_decodes(address,bytes32,uint256) (runs: 256)
  ```

## Diff stats

4 files changed, 170 insertions, 6 deletions.

## Notes for review

- Adds a `bytes memory variantParams` local at the bottom of `createB20`. Stayed under Solc's stack-too-deep limit; no inlining gymnastics needed (the local is allocated after `_writeBaseStorage` so several other locals are no longer live by the time it's introduced).
- The decode-level test (`test_createB20_success_b20CreatedVariantParams_stablecoin_decodes`) uses a deterministic seed → 3-letter uppercase generator (`_make3LetterUppercase`) rather than `vm.assume(_isValidFiatCode(...))` over a raw string. Avoids foundry's fuzz rejection-rate ceiling that the assume-filter approach hit on the first run.
- `_computeAddress` and `_writeBaseStorage` signatures are unchanged.

## Related

- Tracking: [BOP-158](https://linear.app/coinbase/issue/BOP-158)
- Rust counterpart: [BOP-216](https://linear.app/coinbase/issue/BOP-216)
- Parent decision: [CHAIN-4510](https://linear.app/coinbase/issue/CHAIN-4510)
- Superseded approach (Option B, companion events): [#85](https://github.com/base/base-std/pull/85) (closed)
