### PR TITLE
feat(ci): interface coverage check using forge coverage and lcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,58 @@ jobs:
 
             Full report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}). To browse locally: `make coverage` (runs forge coverage + genhtml + opens the HTML report).
 
-  coverage:
+  interface-coverage:
     name: Interface Coverage
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check interface coverage
-        run: python3 scripts/check-coverage.py
+      - name: Run interface coverage check
+        id: check
+        run: |
+          set +e
+          output=$(python3 scripts/check-coverage.py 2>&1)
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          {
+            echo "output<<__EOF__"
+            echo "$output"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+          exit $exit_code
+        continue-on-error: true
+
+      - name: Find existing comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- interface-coverage -->
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- interface-coverage -->
+            ### Interface Coverage
+
+            ${{ steps.check.outputs.exit_code == '0' && '✅ All interface functions have test files.' || '❌ Gaps found — add the missing test files or update `GROUPED`/`HAPPY_PATH_RENAMES` in `scripts/check-coverage.py`.' }}
+
+            ```
+            ${{ steps.check.outputs.output }}
+            ```
+
+      - name: Fail if gaps found
+        if: steps.check.outputs.exit_code != '0'
+        run: exit 1
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
             <!-- interface-coverage -->
             ### Interface Coverage
 
-            ${{ steps.check.outputs.exit_code == '0' && '✅ All mock functions have test coverage.' || '❌ Mock functions with no test coverage found.' }}
+            ${{ steps.check.outputs.exit_code == '0' && '✅ All interface functions have test coverage.' || '❌ Interface functions with no test coverage found.' }}
 
             ```
             ${{ steps.check.outputs.output }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
     name: Interface Coverage
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
 
             Full report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}). To browse locally: `make coverage` (runs forge coverage + genhtml + opens the HTML report).
 
+  coverage:
+    name: Interface Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check interface coverage
+        run: python3 scripts/check-coverage.py
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.1
 
       - name: Run interface coverage check
         id: check
@@ -143,7 +149,7 @@ jobs:
             <!-- interface-coverage -->
             ### Interface Coverage
 
-            ${{ steps.check.outputs.exit_code == '0' && '✅ All interface functions have test files.' || '❌ Gaps found — add the missing test files or update `GROUPED`/`HAPPY_PATH_RENAMES` in `scripts/check-coverage.py`.' }}
+            ${{ steps.check.outputs.exit_code == '0' && '✅ All mock functions have test coverage.' || '❌ Mock functions with no test coverage found.' }}
 
             ```
             ${{ steps.check.outputs.output }}

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+check-coverage.py
+
+Validates that every external function declared in base-std interface files
+has a corresponding unit test file. Exits 1 if gaps are found.
+
+Usage:
+  python3 scripts/check-coverage.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Maps interface filename -> unit test subdirectory under test/unit/
+INTERFACE_MAP = {
+    "IB20.sol":               "B20",
+    "IB20Security.sol":       "B20Security",
+    "IB20Stablecoin.sol":     "B20Stablecoin",
+    "IB20Factory.sol":        "B20Factory",
+    "IPolicyRegistry.sol":    "PolicyRegistry",
+    "IActivationRegistry.sol": "ActivationRegistry",
+}
+
+# Functions covered by a shared grouped test file rather than one file each.
+# These are skipped by the per-function file check. Update this when a new
+# constant is added to an interface and it belongs to an existing grouped test.
+GROUPED: dict[str, set[str]] = {
+    "B20": {
+        # Role byte constants — covered by roles/roleConstants.t.sol
+        "DEFAULT_ADMIN_ROLE", "MINT_ROLE", "BURN_ROLE", "BURN_BLOCKED_ROLE",
+        "PAUSE_ROLE", "UNPAUSE_ROLE", "METADATA_ROLE",
+        # Policy-slot constants — covered by policy tests
+        "TRANSFER_SENDER_POLICY", "TRANSFER_RECEIVER_POLICY",
+        "TRANSFER_EXECUTOR_POLICY", "MINT_RECEIVER_POLICY",
+    },
+    "B20Security": {
+        # Role constant — covered by constants/roleConstants.t.sol
+        "SECURITY_OPERATOR_ROLE", "BURN_FROM_ROLE",
+        # Precision constant — covered by constants/precisionConstants.t.sol
+        "WAD_PRECISION",
+        # Policy constant — covered by constants/policyTypeConstants.t.sol
+        "REDEEM_SENDER_POLICY",
+    },
+}
+
+# Happy-path test file stem overrides for functions whose test file was named
+# differently from the function (historical naming). Only affects the happy-path
+# file; _revertOrder files always use the actual function name.
+HAPPY_PATH_RENAMES: dict[str, dict[str, str]] = {
+    "B20Factory": {
+        "createB20":     "createToken",
+        "getB20Address": "getTokenAddress",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUNC_RE = re.compile(
+    r"function\s+(\w+)\s*\([^)]*\)\s*external\s*(view|pure)?",
+    re.MULTILINE,
+)
+
+
+def extract_functions(sol_file: Path) -> list[dict]:
+    text = sol_file.read_text()
+    results = []
+    for m in _FUNC_RE.finditer(text):
+        results.append({
+            "name": m.group(1),
+            "view": m.group(2) in ("view", "pure"),
+        })
+    return results
+
+
+def exists_in(test_dir: Path, stem: str) -> bool:
+    return bool(list(test_dir.rglob(f"{stem}.t.sol")))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    interfaces_dir = ROOT / "src" / "interfaces"
+    test_unit_dir = ROOT / "test" / "unit"
+
+    gaps: list[str] = []
+
+    for iface_file, contract_dir_name in INTERFACE_MAP.items():
+        iface_path = interfaces_dir / iface_file
+        if not iface_path.exists():
+            print(f"WARNING: {iface_file} not found, skipping")
+            continue
+
+        test_dir = test_unit_dir / contract_dir_name
+        if not test_dir.exists():
+            gaps.append(
+                f"[{contract_dir_name}] MISSING test directory: test/unit/{contract_dir_name}/"
+            )
+            continue
+
+        grouped = GROUPED.get(contract_dir_name, set())
+        renames = HAPPY_PATH_RENAMES.get(contract_dir_name, {})
+        functions = extract_functions(iface_path)
+
+        for fn in functions:
+            name = fn["name"]
+            if name in grouped:
+                continue
+
+            happy_stem = renames.get(name, name)
+            if not exists_in(test_dir, happy_stem):
+                gaps.append(
+                    f"[{contract_dir_name}] MISSING happy-path  : {happy_stem}.t.sol"
+                )
+
+            # _revertOrder is required for every state-mutating function
+            if not fn["view"]:
+                if not exists_in(test_dir, f"{name}_revertOrder"):
+                    gaps.append(
+                        f"[{contract_dir_name}] MISSING revertOrder : {name}_revertOrder.t.sol"
+                    )
+
+    if gaps:
+        print("Interface coverage gaps found:\n")
+        for g in sorted(gaps):
+            print(f"  {g}")
+        print(f"\n{len(gaps)} gap(s). Add missing test files or update GROUPED/HAPPY_PATH_RENAMES in scripts/check-coverage.py.")
+        return 1
+
+    print("Coverage OK — all interface functions have test files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -2,144 +2,88 @@
 """
 check-coverage.py
 
-Validates that every external function declared in base-std interface files
-has a corresponding unit test file. Exits 1 if gaps are found.
+Runs forge coverage and checks that every function in the mock implementations
+under test/lib/mocks/ has at least one test calling it. Uses the lcov report
+as the source of truth rather than parsing Solidity files.
 
 Usage:
   python3 scripts/check-coverage.py
 """
 
-import re
+import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
-# Maps interface filename -> unit test subdirectory under test/unit/
-INTERFACE_MAP = {
-    "IB20.sol":               "B20",
-    "IB20Security.sol":       "B20Security",
-    "IB20Stablecoin.sol":     "B20Stablecoin",
-    "IB20Factory.sol":        "B20Factory",
-    "IPolicyRegistry.sol":    "PolicyRegistry",
-    "IActivationRegistry.sol": "ActivationRegistry",
-}
-
-# Functions covered by a shared grouped test file rather than one file each.
-# These are skipped by the per-function file check. Update this when a new
-# constant is added to an interface and it belongs to an existing grouped test.
-GROUPED: dict[str, set[str]] = {
-    "B20": {
-        # Role byte constants — covered by roles/roleConstants.t.sol
-        "DEFAULT_ADMIN_ROLE", "MINT_ROLE", "BURN_ROLE", "BURN_BLOCKED_ROLE",
-        "PAUSE_ROLE", "UNPAUSE_ROLE", "METADATA_ROLE",
-        # Policy-slot constants — covered by policy tests
-        "TRANSFER_SENDER_POLICY", "TRANSFER_RECEIVER_POLICY",
-        "TRANSFER_EXECUTOR_POLICY", "MINT_RECEIVER_POLICY",
-    },
-    "B20Security": {
-        # Role constant — covered by constants/roleConstants.t.sol
-        "SECURITY_OPERATOR_ROLE", "BURN_FROM_ROLE",
-        # Precision constant — covered by constants/precisionConstants.t.sol
-        "WAD_PRECISION",
-        # Policy constant — covered by constants/policyTypeConstants.t.sol
-        "REDEEM_SENDER_POLICY",
-    },
-}
-
-# Happy-path test file stem overrides for functions whose test file was named
-# differently from the function (historical naming). Only affects the happy-path
-# file; _revertOrder files always use the actual function name.
-HAPPY_PATH_RENAMES: dict[str, dict[str, str]] = {
-    "B20Factory": {
-        "createB20":     "createToken",
-        "getB20Address": "getTokenAddress",
-    },
-}
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_FUNC_RE = re.compile(
-    r"function\s+(\w+)\s*\([^)]*\)\s*external\s*(view|pure)?",
-    re.MULTILINE,
-)
+MOCK_DIR = "test/lib/mocks/"
+LCOV_PATH = ROOT / "lcov.info"
 
 
-def extract_functions(sol_file: Path) -> list[dict]:
-    text = sol_file.read_text()
-    results = []
-    for m in _FUNC_RE.finditer(text):
-        results.append({
-            "name": m.group(1),
-            "view": m.group(2) in ("view", "pure"),
-        })
-    return results
+def generate_lcov() -> None:
+    result = subprocess.run(
+        [
+            "forge",
+            "coverage",
+            "--no-match-coverage",
+            r"(\.t\.sol|Test\.sol)$",
+            "--report",
+            "lcov",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"forge coverage failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
 
 
-def exists_in(test_dir: Path, stem: str) -> bool:
-    return bool(list(test_dir.rglob(f"{stem}.t.sol")))
+def parse_lcov() -> dict[str, list[str]]:
+    """Return {source_file: [uncovered_fn, ...]} for mock files with 0-hit functions."""
+    uncovered: dict[str, list[str]] = {}
+    current_file: str | None = None
+    fn_hits: dict[str, int] = {}
 
+    for line in LCOV_PATH.read_text().splitlines():
+        if line.startswith("SF:"):
+            current_file = line[3:]
+            fn_hits = {}
+        elif line.startswith("FN:"):
+            _, name = line[3:].split(",", 1)
+            fn_hits.setdefault(name, 0)
+        elif line.startswith("FNDA:"):
+            count_str, name = line[5:].split(",", 1)
+            fn_hits[name] = fn_hits.get(name, 0) + int(count_str)
+        elif line == "end_of_record":
+            if current_file and MOCK_DIR in current_file:
+                zero = sorted(fn for fn, hits in fn_hits.items() if hits == 0)
+                if zero:
+                    uncovered[current_file] = zero
+            current_file = None
+            fn_hits = {}
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
+    return uncovered
 
 
 def main() -> int:
-    interfaces_dir = ROOT / "src" / "interfaces"
-    test_unit_dir = ROOT / "test" / "unit"
+    generate_lcov()
 
-    gaps: list[str] = []
-
-    for iface_file, contract_dir_name in INTERFACE_MAP.items():
-        iface_path = interfaces_dir / iface_file
-        if not iface_path.exists():
-            print(f"WARNING: {iface_file} not found, skipping")
-            continue
-
-        test_dir = test_unit_dir / contract_dir_name
-        if not test_dir.exists():
-            gaps.append(
-                f"[{contract_dir_name}] MISSING test directory: test/unit/{contract_dir_name}/"
-            )
-            continue
-
-        grouped = GROUPED.get(contract_dir_name, set())
-        renames = HAPPY_PATH_RENAMES.get(contract_dir_name, {})
-        functions = extract_functions(iface_path)
-
-        for fn in functions:
-            name = fn["name"]
-            if name in grouped:
-                continue
-
-            happy_stem = renames.get(name, name)
-            if not exists_in(test_dir, happy_stem):
-                gaps.append(
-                    f"[{contract_dir_name}] MISSING happy-path  : {happy_stem}.t.sol"
-                )
-
-            # _revertOrder is required for every state-mutating function
-            if not fn["view"]:
-                if not exists_in(test_dir, f"{name}_revertOrder"):
-                    gaps.append(
-                        f"[{contract_dir_name}] MISSING revertOrder : {name}_revertOrder.t.sol"
-                    )
-
-    if gaps:
-        print("Interface coverage gaps found:\n")
-        for g in sorted(gaps):
-            print(f"  {g}")
-        print(f"\n{len(gaps)} gap(s). Add missing test files or update GROUPED/HAPPY_PATH_RENAMES in scripts/check-coverage.py.")
+    if not LCOV_PATH.exists():
+        print("ERROR: lcov.info not found after forge coverage run", file=sys.stderr)
         return 1
 
-    print("Coverage OK — all interface functions have test files.")
+    uncovered = parse_lcov()
+
+    if uncovered:
+        total = sum(len(fns) for fns in uncovered.values())
+        print(f"Mock functions with no test coverage ({total}):\n")
+        for source_file, fns in sorted(uncovered.items()):
+            rel = source_file.replace(str(ROOT) + "/", "")
+            for fn in fns:
+                print(f"  {rel}: {fn}")
+        return 1
+
+    print("Coverage OK — all mock functions have test coverage.")
     return 0
 
 


### PR DESCRIPTION
[BOP-221](https://linear.app/coinbase/issue/BOP-221/featbase-std-automated-interface-coverage-check-in-ci)

## Motivation

base-std tests are the behavioral spec for the base/base Rust precompile implementations. If a function exists in an interface but has no test coverage in the mock implementations, the Rust implementation can diverge silently.

## What changed

Adds `scripts/check-coverage.py` and a new `Interface Coverage` CI job that runs on every PR.

The script runs `forge coverage`, parses the resulting `lcov.info` for mock functions with zero hits, and exits 1 if any are found. No Solidity file parsing.

The CI job posts or updates a sticky PR comment on every commit showing either a green checkmark or the list of uncovered functions.

The `Interface Coverage` job runs independently of the `Forge Coverage` job even though both run `forge coverage`. Intentional: `Interface Coverage` is a blocking gate and `Forge Coverage` is informational. Coupling the gate to the informational job would mean a `Forge Coverage` failure silently skips the coverage check, and sequential execution adds latency. The extra parallel forge run is the right tradeoff.

## What was tried / considered

Parsing interface `.sol` files directly to find missing test files (earlier version of this PR). Replaced after review feedback that it was fragile and reinvented a solved problem. The lcov-based approach uses forge's built-in coverage tooling as the source of truth.

Making `Interface Coverage` depend on the `Forge Coverage` artifact to avoid running `forge coverage` twice. Rejected because it couples a blocking check to an informational job, and adds artifact upload/download complexity with sequential latency.

type=routine
risk=low
impact=sev5