### PR TITLE
fix(base-std): remove isin as required field for security token creation

### DIFF
--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -138,7 +138,6 @@ contract MockB20Factory is IB20Factory {
             if (p.version != B20FactoryLib.B20_SECURITY_CREATE_PARAMS_VERSION) {
                 revert UnsupportedVersion(p.version, variant);
             }
-            if (bytes(p.isin).length == 0) revert MissingRequiredField("isin");
             name_ = p.name;
             symbol_ = p.symbol;
             admin = p.initialAdmin;

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -145,16 +145,6 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
     }
 
-    /// @notice Verifies security createToken reverts when isin is the empty string
-    /// @dev Per-variant required-field check; checks MissingRequiredField(string) error
-    function test_createB20_revert_missingIsin(address caller, bytes32 salt) public {
-        _assumeValidCaller(caller);
-        IB20Factory.B20SecurityCreateParams memory p = _securityParams("Security Test", "SEC", admin, "", 0);
-        vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20Factory.MissingRequiredField.selector, "isin"));
-        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(p), new bytes[](0));
-    }
-
     /// @notice Verifies stablecoin createToken reverts when currency is the empty string
     /// @dev The format-check loop on `currency` is vacuously safe on empty input (no bytes
     ///      to inspect), so an explicit length check is required to reject empty up front.


### PR DESCRIPTION
[BOP-220](https://linear.app/coinbase/issue/BOP-220/fixbase-std-remove-isin-as-a-required-field-for-security)

## Motivation

`isin` is an optional identifier. Security tokens that don't have an ISIN assigned at creation should be creatable; the identifier can be set later via `updateSecurityIdentifier`.