### PR TITLE
feat(ci): forge coverage job with per-file breakdown and PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Run tests
         run: forge test -v
 
-  coverage:
+  forge-coverage:
     name: Forge Coverage
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,8 +53,18 @@ jobs:
         with:
           version: stable
 
-      - name: Generate coverage report
+      - name: Generate lcov report
         run: forge coverage --no-match-coverage "^test/" --report lcov
+
+      - name: Capture coverage summary
+        id: summary
+        run: |
+          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null | grep -E "^(\||File|Total)" || echo "No coverage data")
+          {
+            echo "output<<__EOF__"
+            echo "$output"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload lcov report
         uses: actions/upload-artifact@v4
@@ -60,9 +72,31 @@ jobs:
           name: lcov
           path: lcov.info
 
-      - name: Print coverage summary
-        run: |
-          forge coverage --no-match-coverage "^test/" 2>/dev/null | grep -E "^(File|Total)" || true
+      - name: Find existing comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- forge-coverage -->
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- forge-coverage -->
+            ### Forge Coverage (`src/lib/`)
+
+            ```
+            ${{ steps.summary.outputs.output }}
+            ```
+
+            Full lcov report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) → run `genhtml lcov.info --branch-coverage -o coverage && open coverage/index.html`
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Capture coverage summary
         id: summary
         run: |
-          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null | grep -E "^(\||File|Total)" || echo "No coverage data")
+          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null || echo "No coverage data")
           {
             echo "output<<__EOF__"
             echo "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
           version: stable
 
       - name: Generate lcov report
-        run: forge coverage --no-match-coverage "^test/" --report lcov
+        run: forge coverage --no-match-coverage "(\.t\.sol|Test\.sol)$" --report lcov
 
       - name: Capture coverage summary
         id: summary
         run: |
-          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null | grep "^|" || echo "| (no coverage data) |")
+          output=$(forge coverage --no-match-coverage "(\.t\.sol|Test\.sol)$" 2>/dev/null | grep "^|" || echo "| (no coverage data) |")
           {
             echo "output<<__EOF__"
             echo "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             ${{ steps.summary.outputs.output }}
             ```
 
-            Full lcov report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}). To view locally: `genhtml lcov.info --branch-coverage -o coverage && open coverage/index.html`
+            Full report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}). To browse locally: `make coverage` (runs forge coverage + genhtml + opens the HTML report).
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     name: Forge Coverage
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Capture coverage summary
         id: summary
         run: |
-          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null || echo "No coverage data")
+          output=$(forge coverage --no-match-coverage "^test/" 2>/dev/null | grep "^|" || echo "| (no coverage data) |")
           {
             echo "output<<__EOF__"
             echo "$output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Build
         run: forge build
@@ -34,7 +34,7 @@ jobs:
 
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Run tests
         run: forge test -v
@@ -52,7 +52,7 @@ jobs:
 
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Generate lcov report
         run: forge coverage --no-match-coverage "(\.t\.sol|Test\.sol)$" --report lcov
@@ -97,7 +97,7 @@ jobs:
             ${{ steps.summary.outputs.output }}
             ```
 
-            Full lcov report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) → run `genhtml lcov.info --branch-coverage -o coverage && open coverage/index.html`
+            Full lcov report: [download artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}). To view locally: `genhtml lcov.info --branch-coverage -o coverage && open coverage/index.html`
 
   fmt:
     name: Format
@@ -109,7 +109,7 @@ jobs:
 
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Check formatting
         run: forge fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,31 @@ jobs:
       - name: Run tests
         run: forge test -v
 
+  coverage:
+    name: Forge Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Generate coverage report
+        run: forge coverage --no-match-coverage "^test/" --report lcov
+
+      - name: Upload lcov report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov
+          path: lcov.info
+
+      - name: Print coverage summary
+        run: |
+          forge coverage --no-match-coverage "^test/" 2>/dev/null | grep -E "^(File|Total)" || true
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: coverage
+
+# Generate an lcov coverage report and open it in the browser.
+# Scoped to src/ and test/lib/mocks/ (excludes test runner files).
+coverage:
+	forge coverage --no-match-coverage "(\.t\.sol|Test\.sol)$$" --report lcov
+	genhtml lcov.info --branch-coverage -o coverage --dark-mode --ignore-errors inconsistent,corrupt
+	open coverage/index.html


### PR DESCRIPTION
[BOP-221](https://linear.app/coinbase/issue/BOP-221/featbase-std-automated-interface-coverage-check-in-ci)

## Motivation

base-std has one real Solidity library (`B20FactoryLib`) and a set of mock implementations that serve as the Rust precompile reference. Neither was measured for branch/line coverage. This adds a CI job that runs on every PR commit, posts a per-file coverage table as a sticky PR comment, and uploads an lcov artifact for local HTML browsing.

## What changed

Adds a `Forge Coverage` job to `.github/workflows/ci.yml`:
- Runs `forge coverage --no-match-coverage "(\.t\.sol|Test\.sol)\$"` to include mocks but exclude test runner files
- Generates `lcov.info` and uploads it as a CI artifact
- Posts/updates a per-file markdown table as a PR comment on every commit (using peter-evans/find-comment + create-or-update-comment so the comment updates in place)
- Informational only: does not block merging. A follow-on can add threshold enforcement once a stable baseline is visible.

Also pins `foundry-toolchain` to `v1.7.1` (matching `.foundry-version`) across all CI jobs to avoid GitHub API rate limit errors that occur when using `version: stable`.

## What was tried / considered

Running `forge coverage` against only `src/` (excluding all of `test/`). Rejected because the mocks in `test/lib/mocks/` are the Solidity reference implementations used to validate the Rust precompile, so their branch coverage is exactly what we want to measure. The filter `(\.t\.sol|Test\.sol)\$` excludes test runner files while keeping mocks.

type=routine
risk=low
impact=sev5