### PR TITLE
fix(test): skip vm.store poison test when running against live precompiles

### DIFF
--- a/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
+++ b/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
@@ -75,7 +75,12 @@ contract PolicyRegistryPendingPolicyAdminTest is PolicyRegistryTest {
     ///         function MUST return `address(0)` for built-in IDs regardless of storage
     ///         state, matching the Rust precompile's gated read at
     ///         `crates/common/precompiles/src/policy/storage.rs` (`pending_policy_admin`).
+    ///
+    ///         Mock-only: `vm.store` cannot write to native precompile addresses, so this
+    ///         test is skipped when running against live precompiles.
     function test_pendingPolicyAdmin_success_zeroForBuiltinsEvenWithStoragePoison() public {
+        // Skip when running against live precompiles — vm.store cannot target native precompiles.
+        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
         address poison = address(0xDEAD);
         vm.store(
             address(policyRegistry),


### PR DESCRIPTION
## Summary

Skip `test_pendingPolicyAdmin_success_zeroForBuiltinsEvenWithStoragePoison` when running in fork mode (`LIVE_PRECOMPILES=true`).

## Problem

The test fails with:
```
vm.store: cannot use precompile 0x8453000000000000000000000000000000000002 as an argument
```

This happens because `vm.store` cannot write to native EVM precompile addresses. The test is designed to verify the mock's short-circuit behavior by poisoning storage slots, which only works against etched Solidity bytecode.

## What This Test Validates

This is a **defense-in-depth test** that verifies `pending_policy_admin` correctly short-circuits reads for built-in policy IDs (`ALWAYS_ALLOW_ID` and `ALWAYS_BLOCK_ID`).

The test:
1. **Poisons storage**: Uses `vm.store` to write a non-zero address (`0xDEAD`) directly into the `pendingAdmins` storage slot for built-in IDs
2. **Asserts short-circuit**: Calls `pendingPolicyAdmin()` and expects it to return `address(0)` despite the poisoned storage

## Rust Precompile Verification

Verified that the Rust precompile in `base/crates/common/precompiles/src/policy/storage.rs` has the correct short-circuit (lines 438-446):

```rust
pub fn pending_policy_admin(&self, policy_id: u64) -> Result<Address> {
    // 1. Check malformed first
    if Self::policy_id_type(policy_id) > PolicyType::ALLOWLIST as u8 {
        return Ok(Address::ZERO);
    }
    // 2. Check built-ins BEFORE reading storage - KEY SHORT-CIRCUIT
    if policy_id == Self::ALWAYS_ALLOW_ID || policy_id == Self::ALWAYS_BLOCK_ID {
        return Ok(Address::ZERO);
    }
    // 3. Only read storage for custom policies
    self.pending_admins.at(&policy_id).read()
}
```

**The Rust implementation is correct** - it checks for built-in IDs BEFORE any storage read, so even if the storage slot were somehow corrupted, the function would still return `address(0)` for built-ins.

The Rust codebase also has its own unit test for this behavior: `pending_policy_admin_builtin_ids_short_circuit_staged_slot` (lines 1333-1353).

## Solution

Add `vm.skip(vm.envOr("LIVE_PRECOMPILES", false))` to skip the test when running against live precompiles. The defense-in-depth check remains active for mock-mode runs where storage poisoning is possible.

## Testing

```bash
# Mock mode (default) - test runs and passes
forge test --match-test test_pendingPolicyAdmin_success_zeroForBuiltinsEvenWithStoragePoison -v

# Fork mode - test is skipped
LIVE_PRECOMPILES=true forge test --match-test test_pendingPolicyAdmin_success_zeroForBuiltinsEvenWithStoragePoison -v
```