### PR TITLE
test(ActivationRegistry): add activate and deactivate revertOrder tests

### DIFF
--- a/test/unit/ActivationRegistry/activate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/activate_revertOrder.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+
+contract ActivationRegistryActivateRevertOrderTest is ActivationRegistryTest {
+    /// @notice Verifies Unauthorized fires before AlreadyActivated when caller is not admin
+    ///         and the feature is already activated
+    /// @dev Revert order: access-control check precedes state validation; a non-admin caller
+    ///      never reaches the AlreadyActivated guard regardless of feature state.
+    ///      Fuzz: any caller that is not the activationAdmin, any feature id.
+    function test_activate_revertOrder_unauthorized_beats_alreadyActivated(address caller, bytes32 feature) public {
+        // unimplemented
+    }
+}

--- a/test/unit/ActivationRegistry/activate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/activate_revertOrder.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+
 import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryActivateRevertOrderTest is ActivationRegistryTest {
@@ -10,6 +12,18 @@ contract ActivationRegistryActivateRevertOrderTest is ActivationRegistryTest {
     ///      never reaches the AlreadyActivated guard regardless of feature state.
     ///      Fuzz: any caller that is not the activationAdmin, any feature id.
     function test_activate_revertOrder_unauthorized_beats_alreadyActivated(address caller, bytes32 feature) public {
-        // unimplemented
+        _assumeValidCaller(caller);
+        vm.assume(caller != activationAdmin);
+
+        // Activate the feature as admin so it is already activated, establishing
+        // the precondition that AlreadyActivated *could* fire for an admin caller.
+        vm.prank(activationAdmin);
+        activationRegistry.activate(feature);
+
+        // A non-admin caller must see Unauthorized, not AlreadyActivated,
+        // because the access-control check in activate fires first.
+        vm.expectRevert(abi.encodeWithSelector(IActivationRegistry.Unauthorized.selector, caller));
+        vm.prank(caller);
+        activationRegistry.activate(feature);
     }
 }

--- a/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+
 import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryDeactivateRevertOrderTest is ActivationRegistryTest {
@@ -10,7 +12,18 @@ contract ActivationRegistryDeactivateRevertOrderTest is ActivationRegistryTest {
     ///      never reaches the FeatureNotActivated guard regardless of feature state.
     ///      Fuzz: any caller that is not the activationAdmin, any feature id.
     function test_deactivate_revertOrder_unauthorized_beats_featureNotActivated(address caller, bytes32 feature)
-        public {
-        // unimplemented
+        public
+    {
+        _assumeValidCaller(caller);
+        vm.assume(caller != activationAdmin);
+
+        // The feature is not activated (default state), establishing the precondition
+        // that FeatureNotActivated *could* fire for an admin caller.
+
+        // A non-admin caller must see Unauthorized, not FeatureNotActivated,
+        // because the access-control check in deactivate fires first.
+        vm.expectRevert(abi.encodeWithSelector(IActivationRegistry.Unauthorized.selector, caller));
+        vm.prank(caller);
+        activationRegistry.deactivate(feature);
     }
 }

--- a/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+
+contract ActivationRegistryDeactivateRevertOrderTest is ActivationRegistryTest {
+    /// @notice Verifies Unauthorized fires before FeatureNotActivated when caller is not admin
+    ///         and the feature is not currently activated
+    /// @dev Revert order: access-control check precedes state validation; a non-admin caller
+    ///      never reaches the FeatureNotActivated guard regardless of feature state.
+    ///      Fuzz: any caller that is not the activationAdmin, any feature id.
+    function test_deactivate_revertOrder_unauthorized_beats_featureNotActivated(address caller, bytes32 feature)
+        public {
+        // unimplemented
+    }
+}


### PR DESCRIPTION
[BOP-221](https://linear.app/coinbase/issue/BOP-221/featbase-std-automated-interface-coverage-check-in-ci)

## Motivation

`check-coverage.py` flagged two missing test files for `ActivationRegistry`:

- `test/unit/ActivationRegistry/activate_revertOrder.t.sol`
- `test/unit/ActivationRegistry/deactivate_revertOrder.t.sol`

RevertOrder files document and enforce the priority ordering of reverts when multiple error conditions hold simultaneously. For `activate`, the only multi-revert scenario is an unauthorized caller attempting to activate an already-activated feature; access control must fire before the state check. The deactivate file is a forward stub matching the same pattern for when a deactivate function is added.

## What changed

- Added `activate_revertOrder.t.sol` with `test_activate_revertOrder_unauthorized_beats_alreadyActivated` stub documenting that `Unauthorized` fires before `AlreadyActivated`.
- Added `deactivate_revertOrder.t.sol` with `test_deactivate_revertOrder_unauthorized_beats_featureNotActivated` stub matching the same access-control-first ordering convention.
- Both files inherit from `ActivationRegistryTest`, follow the `// unimplemented` stub convention used across this test suite, and pass `forge fmt`.

type=routine
risk=low
impact=sev5