### PR TITLE
test(PolicyRegistry): add revertOrder tests for all mutating functions

### DIFF
--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `createPolicyWithAccounts`.
+///
+/// @notice **Canonical order (Solidity reference entry-point, pre-`_create`):**
+///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
+///         2. BATCH-SIZE (`accounts.length > MAX_BATCH_SIZE`) → `BatchSizeTooLarge`
+///
+///         C(2, 2) = 1 pair.
+///
+///         The natspec on `createPolicyWithAccounts` explicitly annotates this ordering:
+///         "Reverts with `ZeroAddress` … Takes precedence over `BatchSizeTooLarge`."
+///         This test pins that annotation against the Solidity reference implementation.
+contract PolicyRegistryCreatePolicyWithAccountsRevertOrderTest is PolicyRegistryTest {
+    /// @notice ZERO-ADMIN beats BATCH-SIZE.
+    /// @dev admin is address(0) AND accounts.length exceeds MAX_BATCH_SIZE.
+    ///      The zero-admin guard is checked before the batch-size guard.
+    function test_createPolicyWithAccounts_revertOrder_zeroAddress_beats_batchSizeTooLarge(
+        address caller,
+        uint8 typeIdx,
+        uint8 overflow
+    ) public {
+        _assumeValidCaller(caller);
+        IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.ZeroAddress.selector);
+        policyRegistry.createPolicyWithAccounts(address(0), pt, accounts);
+    }
+}

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
@@ -5,33 +5,41 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `createPolicyWithAccounts`.
+/// @title Sequential revert-order test for `createPolicyWithAccounts`.
 ///
-/// @notice **Canonical order (Solidity reference entry-point, pre-`_create`):**
+/// @notice **Canonical order:**
 ///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
 ///         2. BATCH-SIZE (`accounts.length > MAX_BATCH_SIZE`) → `BatchSizeTooLarge`
 ///
-///         C(2, 2) = 1 pair.
-///
-///         The natspec on `createPolicyWithAccounts` explicitly annotates this ordering:
-///         "Reverts with `ZeroAddress` … Takes precedence over `BatchSizeTooLarge`."
-///         This test pins that annotation against the Solidity reference implementation.
+///         Walks from all conditions broken to success, fixing one per step.
 contract PolicyRegistryCreatePolicyWithAccountsRevertOrderTest is PolicyRegistryTest {
-    /// @notice ZERO-ADMIN beats BATCH-SIZE.
-    /// @dev admin is address(0) AND accounts.length exceeds MAX_BATCH_SIZE.
-    ///      The zero-admin guard is checked before the batch-size guard.
-    function test_createPolicyWithAccounts_revertOrder_zeroAddress_beats_batchSizeTooLarge(
-        address caller,
-        uint8 typeIdx,
-        uint8 overflow
-    ) public {
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_createPolicyWithAccounts_revertOrder(address caller, address admin_, uint8 typeIdx, uint8 overflow)
+        public
+    {
         _assumeValidCaller(caller);
+        vm.assume(admin_ != address(0));
         IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
         uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
+        address[] memory tooMany = _makeAccounts(n);
+        address[] memory valid = new address[](0);
 
+        // 1. ZERO-ADMIN: admin==address(0) AND batch oversized → ZeroAddress fires first.
         vm.prank(caller);
         vm.expectRevert(IPolicyRegistry.ZeroAddress.selector);
-        policyRegistry.createPolicyWithAccounts(address(0), pt, accounts);
+        policyRegistry.createPolicyWithAccounts(address(0), pt, tooMany);
+
+        // Fix: use a non-zero admin.
+
+        // 2. BATCH-SIZE: valid admin, but accounts.length > MAX_BATCH_SIZE → BatchSizeTooLarge.
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.BatchSizeTooLarge.selector, MAX_BATCH_SIZE));
+        policyRegistry.createPolicyWithAccounts(admin_, pt, tooMany);
+
+        // Fix: use an empty accounts array.
+
+        // Success
+        vm.prank(caller);
+        policyRegistry.createPolicyWithAccounts(admin_, pt, valid);
     }
 }

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `createPolicy`.
+///
+/// @notice **Canonical order (Solidity reference `_create`):**
+///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
+///
+///         C(1, 2) = 0 pairs. `createPolicy` has only a single revert
+///         condition so there is no pair-wise ordering to pin. This file
+///         exists for coverage bookkeeping only; the individual revert is
+///         tested in `createPolicy.t.sol`.
+// solhint-disable-next-line no-empty-blocks
+contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {}

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -1,16 +1,32 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `createPolicy`.
+/// @title Sequential revert-order test for `createPolicy`.
 ///
-/// @notice **Canonical order (Solidity reference `_create`):**
+/// @notice **Canonical order:**
 ///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
 ///
-///         C(1, 2) = 0 pairs. `createPolicy` has only a single revert
-///         condition so there is no pair-wise ordering to pin. This file
-///         exists for coverage bookkeeping only; the individual revert is
-///         tested in `createPolicy.t.sol`.
-// solhint-disable-next-line no-empty-blocks
-contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {}
+///         Single revert condition; walks from that condition to success.
+contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_createPolicy_revertOrder(address caller, address admin_, uint8 typeIdx) public {
+        _assumeValidCaller(caller);
+        vm.assume(admin_ != address(0));
+        IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
+
+        // 1. ZERO-ADMIN: admin == address(0) → ZeroAddress
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.ZeroAddress.selector);
+        policyRegistry.createPolicy(address(0), pt);
+
+        // Fix: use a non-zero admin.
+
+        // Success
+        vm.prank(caller);
+        policyRegistry.createPolicy(admin_, pt);
+    }
+}

--- a/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
@@ -5,69 +5,49 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `finalizeUpdateAdmin`.
+/// @title Sequential revert-order test for `finalizeUpdateAdmin`.
 ///
-/// @notice **Canonical order (Solidity reference):**
+/// @notice **Canonical order:**
 ///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
 ///         2. NO-PENDING-ADMIN (`pendingAdmins[policyId] == address(0)`) → `NoPendingAdmin`
 ///         3. UNAUTHORIZED (`pendingAdmins[policyId] != msg.sender`) → `Unauthorized`
 ///
-///         C(3, 2) = 3 pairs.
+///         Walks from all conditions broken to success, fixing one per step.
 contract PolicyRegistryFinalizeUpdateAdminRevertOrderTest is PolicyRegistryTest {
-    // ---------------------------------------------------------------
-    // Pairs where POLICY-NOT-FOUND wins
-    // ---------------------------------------------------------------
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_finalizeUpdateAdmin_revertOrder() public {
+        // ghostId is a well-formed policyId that has never been created.
+        uint64 ghostId = _wellFormedUncreatedPolicyId(type(uint64).max);
 
-    /// @notice POLICY-NOT-FOUND beats NO-PENDING-ADMIN.
-    /// @dev policyId does not exist (packed == 0) AND no pending admin is staged.
-    ///      PolicyNotFound fires before the pending-admin slot is read.
-    function test_finalizeUpdateAdmin_revertOrder_policyNotFound_beats_noPendingAdmin(uint64 seed) public {
-        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created.
-        // - NoPendingAdmin: pendingAdmins[policyId] == address(0) (zero storage).
+        // 1. POLICY-NOT-FOUND: policyId has never been created AND no pending admin is
+        //    staged (NoPendingAdmin and Unauthorized would also apply once a policy exists).
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.finalizeUpdateAdmin(policyId);
-    }
+        policyRegistry.finalizeUpdateAdmin(ghostId);
 
-    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
-    /// @dev policyId does not exist AND caller is not address(0), so the pending-admin
-    ///      comparison (address(0) != caller) would trigger Unauthorized if reached.
-    ///      PolicyNotFound fires before the pending-admin slot or caller comparison runs.
-    function test_finalizeUpdateAdmin_revertOrder_policyNotFound_beats_unauthorized(address caller, uint64 seed)
-        public
-    {
-        _assumeValidCaller(caller);
-        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+        // Fix: create an allowlist policy with alice as admin.
+        uint64 policyId = policyRegistry.createPolicy(alice, IPolicyRegistry.PolicyType.ALLOWLIST);
 
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created (packed == 0).
-        // - Unauthorized: pendingAdmins[policyId] == address(0) != caller.
-        //   (NoPendingAdmin also applies; it would fire second if PolicyNotFound didn't.)
-        vm.prank(caller);
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.finalizeUpdateAdmin(policyId);
-    }
-
-    // ---------------------------------------------------------------
-    // Pairs where NO-PENDING-ADMIN wins
-    // ---------------------------------------------------------------
-
-    /// @notice NO-PENDING-ADMIN beats UNAUTHORIZED.
-    /// @dev Policy exists but has no pending admin staged. Caller is a non-zero address,
-    ///      so `pendingAdmins[policyId] (== address(0)) != caller` would trigger
-    ///      Unauthorized if the NoPendingAdmin guard were absent.
-    function test_finalizeUpdateAdmin_revertOrder_noPendingAdmin_beats_unauthorized(address caller) public {
-        _assumeValidCaller(caller);
-        // Create a policy; no stageUpdateAdmin call follows, so pending == address(0).
-        uint64 policyId = policyRegistry.createPolicy(admin, IPolicyRegistry.PolicyType.ALLOWLIST);
-
-        // Both conditions apply independently:
-        // - NoPendingAdmin: pendingAdmins[policyId] == address(0).
-        // - Unauthorized: address(0) != caller (caller is non-zero).
-        vm.prank(caller);
+        // 2. NO-PENDING-ADMIN: policy exists but no pending admin has been staged.
+        //    (Unauthorized would also fire if NoPendingAdmin were absent, since
+        //    pendingAdmins[policyId] == address(0) != attacker.)
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.NoPendingAdmin.selector);
+        policyRegistry.finalizeUpdateAdmin(policyId);
+
+        // Fix: stage bob as the pending admin.
+        vm.prank(alice);
+        policyRegistry.stageUpdateAdmin(policyId, bob);
+
+        // 3. UNAUTHORIZED: bob is the staged pending admin, but attacker is calling.
+        vm.prank(attacker);
+        vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
+        policyRegistry.finalizeUpdateAdmin(policyId);
+
+        // Fix: call as bob (the staged pending admin).
+
+        // Success
+        vm.prank(bob);
         policyRegistry.finalizeUpdateAdmin(policyId);
     }
 }

--- a/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `finalizeUpdateAdmin`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
+///         2. NO-PENDING-ADMIN (`pendingAdmins[policyId] == address(0)`) → `NoPendingAdmin`
+///         3. UNAUTHORIZED (`pendingAdmins[policyId] != msg.sender`) → `Unauthorized`
+///
+///         C(3, 2) = 3 pairs.
+contract PolicyRegistryFinalizeUpdateAdminRevertOrderTest is PolicyRegistryTest {
+    // ---------------------------------------------------------------
+    // Pairs where POLICY-NOT-FOUND wins
+    // ---------------------------------------------------------------
+
+    /// @notice POLICY-NOT-FOUND beats NO-PENDING-ADMIN.
+    /// @dev policyId does not exist (packed == 0) AND no pending admin is staged.
+    ///      PolicyNotFound fires before the pending-admin slot is read.
+    function test_finalizeUpdateAdmin_revertOrder_policyNotFound_beats_noPendingAdmin(uint64 seed) public {
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created.
+        // - NoPendingAdmin: pendingAdmins[policyId] == address(0) (zero storage).
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.finalizeUpdateAdmin(policyId);
+    }
+
+    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
+    /// @dev policyId does not exist AND caller is not address(0), so the pending-admin
+    ///      comparison (address(0) != caller) would trigger Unauthorized if reached.
+    ///      PolicyNotFound fires before the pending-admin slot or caller comparison runs.
+    function test_finalizeUpdateAdmin_revertOrder_policyNotFound_beats_unauthorized(address caller, uint64 seed)
+        public
+    {
+        _assumeValidCaller(caller);
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created (packed == 0).
+        // - Unauthorized: pendingAdmins[policyId] == address(0) != caller.
+        //   (NoPendingAdmin also applies; it would fire second if PolicyNotFound didn't.)
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.finalizeUpdateAdmin(policyId);
+    }
+
+    // ---------------------------------------------------------------
+    // Pairs where NO-PENDING-ADMIN wins
+    // ---------------------------------------------------------------
+
+    /// @notice NO-PENDING-ADMIN beats UNAUTHORIZED.
+    /// @dev Policy exists but has no pending admin staged. Caller is a non-zero address,
+    ///      so `pendingAdmins[policyId] (== address(0)) != caller` would trigger
+    ///      Unauthorized if the NoPendingAdmin guard were absent.
+    function test_finalizeUpdateAdmin_revertOrder_noPendingAdmin_beats_unauthorized(address caller) public {
+        _assumeValidCaller(caller);
+        // Create a policy; no stageUpdateAdmin call follows, so pending == address(0).
+        uint64 policyId = policyRegistry.createPolicy(admin, IPolicyRegistry.PolicyType.ALLOWLIST);
+
+        // Both conditions apply independently:
+        // - NoPendingAdmin: pendingAdmins[policyId] == address(0).
+        // - Unauthorized: address(0) != caller (caller is non-zero).
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.NoPendingAdmin.selector);
+        policyRegistry.finalizeUpdateAdmin(policyId);
+    }
+}

--- a/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `renounceAdmin`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
+///         2. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
+///
+///         C(2, 2) = 1 pair.
+contract PolicyRegistryRenounceAdminRevertOrderTest is PolicyRegistryTest {
+    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
+    /// @dev policyId does not exist (packed == 0) AND caller is not the policy admin.
+    ///      PolicyNotFound fires before the admin comparison runs.
+    function test_renounceAdmin_revertOrder_policyNotFound_beats_unauthorized(address caller, uint64 seed) public {
+        _assumeValidCaller(caller);
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created (policies[policyId] == 0).
+        // - Unauthorized: _decodeAdmin(0) == address(0) != caller (caller is non-zero).
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.renounceAdmin(policyId);
+    }
+}

--- a/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
@@ -5,26 +5,37 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `renounceAdmin`.
+/// @title Sequential revert-order test for `renounceAdmin`.
 ///
-/// @notice **Canonical order (Solidity reference):**
+/// @notice **Canonical order:**
 ///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
 ///         2. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
 ///
-///         C(2, 2) = 1 pair.
+///         Walks from all conditions broken to success, fixing one per step.
 contract PolicyRegistryRenounceAdminRevertOrderTest is PolicyRegistryTest {
-    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
-    /// @dev policyId does not exist (packed == 0) AND caller is not the policy admin.
-    ///      PolicyNotFound fires before the admin comparison runs.
-    function test_renounceAdmin_revertOrder_policyNotFound_beats_unauthorized(address caller, uint64 seed) public {
-        _assumeValidCaller(caller);
-        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_renounceAdmin_revertOrder() public {
+        // ghostId is a well-formed policyId that has never been created.
+        uint64 ghostId = _wellFormedUncreatedPolicyId(type(uint64).max);
 
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created (policies[policyId] == 0).
-        // - Unauthorized: _decodeAdmin(0) == address(0) != caller (caller is non-zero).
-        vm.prank(caller);
+        // 1. POLICY-NOT-FOUND: policyId has never been created AND attacker is not the
+        //    policy admin (Unauthorized would also apply if the policy existed).
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.renounceAdmin(ghostId);
+
+        // Fix: create an allowlist policy with alice as admin.
+        uint64 policyId = policyRegistry.createPolicy(alice, IPolicyRegistry.PolicyType.ALLOWLIST);
+
+        // 2. UNAUTHORIZED: attacker is not the policy admin (alice).
+        vm.prank(attacker);
+        vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
+        policyRegistry.renounceAdmin(policyId);
+
+        // Fix: call as alice (the policy admin).
+
+        // Success
+        vm.prank(alice);
         policyRegistry.renounceAdmin(policyId);
     }
 }

--- a/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
@@ -5,30 +5,37 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `stageUpdateAdmin`.
+/// @title Sequential revert-order test for `stageUpdateAdmin`.
 ///
-/// @notice **Canonical order (Solidity reference):**
-///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+/// @notice **Canonical order:**
+///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
 ///         2. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
 ///
-///         C(2, 2) = 1 pair.
+///         Walks from all conditions broken to success, fixing one per step.
 contract PolicyRegistryStageUpdateAdminRevertOrderTest is PolicyRegistryTest {
-    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
-    /// @dev policyId does not exist (packed == 0) AND caller is not the policy admin.
-    ///      `_requireCustom` reverts with `PolicyNotFound` before the admin check runs.
-    function test_stageUpdateAdmin_revertOrder_policyNotFound_beats_unauthorized(
-        address caller,
-        uint64 seed,
-        address newAdmin
-    ) public {
-        _assumeValidCaller(caller);
-        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_stageUpdateAdmin_revertOrder(address newAdmin) public {
+        // ghostId is a well-formed policyId that has never been created.
+        uint64 ghostId = _wellFormedUncreatedPolicyId(type(uint64).max);
 
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created (policies[policyId] == 0).
-        // - Unauthorized: _decodeAdmin(0) == address(0) != caller (caller is non-zero).
-        vm.prank(caller);
+        // 1. POLICY-NOT-FOUND: policyId has never been created AND attacker is not the
+        //    policy admin (Unauthorized would also apply if the policy existed).
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.stageUpdateAdmin(ghostId, newAdmin);
+
+        // Fix: create an allowlist policy with alice as admin.
+        uint64 policyId = policyRegistry.createPolicy(alice, IPolicyRegistry.PolicyType.ALLOWLIST);
+
+        // 2. UNAUTHORIZED: attacker is not the policy admin (alice).
+        vm.prank(attacker);
+        vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
+        policyRegistry.stageUpdateAdmin(policyId, newAdmin);
+
+        // Fix: call as alice (the policy admin).
+
+        // Success
+        vm.prank(alice);
         policyRegistry.stageUpdateAdmin(policyId, newAdmin);
     }
 }

--- a/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `stageUpdateAdmin`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+///         2. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
+///
+///         C(2, 2) = 1 pair.
+contract PolicyRegistryStageUpdateAdminRevertOrderTest is PolicyRegistryTest {
+    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
+    /// @dev policyId does not exist (packed == 0) AND caller is not the policy admin.
+    ///      `_requireCustom` reverts with `PolicyNotFound` before the admin check runs.
+    function test_stageUpdateAdmin_revertOrder_policyNotFound_beats_unauthorized(
+        address caller,
+        uint64 seed,
+        address newAdmin
+    ) public {
+        _assumeValidCaller(caller);
+        uint64 policyId = _wellFormedUncreatedPolicyId(seed);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created (policies[policyId] == 0).
+        // - Unauthorized: _decodeAdmin(0) == address(0) != caller (caller is non-zero).
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.stageUpdateAdmin(policyId, newAdmin);
+    }
+}

--- a/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `updateAllowlist`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+///         2. INCOMPATIBLE-TYPE (`_typeOf(policyId) != ALLOWLIST`) → `IncompatiblePolicyType`
+///         3. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
+///         4. BATCH-SIZE (inside `_batchSetMembers`) → `BatchSizeTooLarge`
+///
+///         C(4, 2) = 6 pairs.
+contract PolicyRegistryUpdateAllowlistRevertOrderTest is PolicyRegistryTest {
+    // ---------------------------------------------------------------
+    // Pairs where POLICY-NOT-FOUND wins
+    // ---------------------------------------------------------------
+
+    /// @notice POLICY-NOT-FOUND beats INCOMPATIBLE-TYPE.
+    /// @dev policyId encodes as BLOCKLIST (top byte 0, incompatible for updateAllowlist)
+    ///      AND the policy has never been created (packed == 0).
+    ///      PolicyNotFound fires before the type discriminator is examined.
+    function test_updateAllowlist_revertOrder_policyNotFound_beats_incompatiblePolicyType(uint56 counter) public {
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        // top byte 0 = BLOCKLIST; would trigger IncompatiblePolicyType if the policy existed.
+        uint64 policyId = uint64(counter);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created.
+        // - IncompatiblePolicyType: policyId encodes as BLOCKLIST, not ALLOWLIST.
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateAllowlist(policyId, true, empty);
+    }
+
+    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
+    /// @dev policyId encodes as ALLOWLIST (so IncompatiblePolicyType does not apply)
+    ///      AND has never been created (PolicyNotFound fires), AND caller is non-zero
+    ///      (Unauthorized would fire if policyId existed as ALLOWLIST).
+    function test_updateAllowlist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter)
+        public
+    {
+        _assumeValidCaller(caller);
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        // top byte 1 = ALLOWLIST; IncompatiblePolicyType would not apply if the policy existed.
+        uint64 policyId = (uint64(1) << 56) | uint64(counter);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created (packed == 0).
+        // - Unauthorized: _decodeAdmin(0) == address(0) != caller.
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateAllowlist(policyId, true, empty);
+    }
+
+    /// @notice POLICY-NOT-FOUND beats BATCH-SIZE.
+    /// @dev policyId has never been created (PolicyNotFound fires) AND accounts.length
+    ///      exceeds MAX_BATCH_SIZE (BatchSizeTooLarge would fire inside _batchSetMembers
+    ///      if the policy existed and all earlier checks passed).
+    function test_updateAllowlist_revertOrder_policyNotFound_beats_batchSizeTooLarge(uint56 counter, uint8 overflow)
+        public
+    {
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        uint64 policyId = (uint64(1) << 56) | uint64(counter); // ALLOWLIST type, not created
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created.
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateAllowlist(policyId, true, accounts);
+    }
+
+    // ---------------------------------------------------------------
+    // Pairs where INCOMPATIBLE-TYPE wins
+    // ---------------------------------------------------------------
+
+    /// @notice INCOMPATIBLE-TYPE beats UNAUTHORIZED.
+    /// @dev Policy exists as BLOCKLIST (incompatible for updateAllowlist) AND caller
+    ///      is not the policy admin (Unauthorized would fire if the type check were absent).
+    function test_updateAllowlist_revertOrder_incompatiblePolicyType_beats_unauthorized(address caller) public {
+        _assumeValidCaller(caller);
+        // Create a BLOCKLIST policy with `alice` as admin.
+        uint64 policyId = _createBlocklist(admin, alice);
+        vm.assume(caller != alice);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - IncompatiblePolicyType: policy is BLOCKLIST, updateAllowlist requires ALLOWLIST.
+        // - Unauthorized: caller is not alice (the policy admin).
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
+        policyRegistry.updateAllowlist(policyId, true, empty);
+    }
+
+    /// @notice INCOMPATIBLE-TYPE beats BATCH-SIZE.
+    /// @dev Policy exists as BLOCKLIST AND accounts.length exceeds MAX_BATCH_SIZE.
+    ///      Caller is the policy admin so Unauthorized does not apply; only type and
+    ///      batch-size conditions compete.
+    function test_updateAllowlist_revertOrder_incompatiblePolicyType_beats_batchSizeTooLarge(uint8 overflow) public {
+        // Create a BLOCKLIST policy with alice as admin; call as alice (no Unauthorized).
+        uint64 policyId = _createBlocklist(admin, alice);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - IncompatiblePolicyType: policy is BLOCKLIST, updateAllowlist requires ALLOWLIST.
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.prank(alice);
+        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
+        policyRegistry.updateAllowlist(policyId, true, accounts);
+    }
+
+    // ---------------------------------------------------------------
+    // Pairs where UNAUTHORIZED wins
+    // ---------------------------------------------------------------
+
+    /// @notice UNAUTHORIZED beats BATCH-SIZE.
+    /// @dev Policy exists as ALLOWLIST (IncompatiblePolicyType does not apply) AND
+    ///      caller is not the policy admin AND accounts.length exceeds MAX_BATCH_SIZE.
+    ///      Unauthorized fires before _batchSetMembers runs its batch-size guard.
+    function test_updateAllowlist_revertOrder_unauthorized_beats_batchSizeTooLarge(address caller, uint8 overflow)
+        public
+    {
+        _assumeValidCaller(caller);
+        // Create an ALLOWLIST policy with alice as admin; caller is not alice.
+        uint64 policyId = _createAllowlist(admin, alice);
+        vm.assume(caller != alice);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - Unauthorized: caller is not alice (the policy admin).
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
+        policyRegistry.updateAllowlist(policyId, true, accounts);
+    }
+}

--- a/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
@@ -40,9 +40,7 @@ contract PolicyRegistryUpdateAllowlistRevertOrderTest is PolicyRegistryTest {
     /// @dev policyId encodes as ALLOWLIST (so IncompatiblePolicyType does not apply)
     ///      AND has never been created (PolicyNotFound fires), AND caller is non-zero
     ///      (Unauthorized would fire if policyId existed as ALLOWLIST).
-    function test_updateAllowlist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter)
-        public
-    {
+    function test_updateAllowlist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter) public {
         _assumeValidCaller(caller);
         counter = uint56(bound(uint256(counter), 2, type(uint56).max));
         // top byte 1 = ALLOWLIST; IncompatiblePolicyType would not apply if the policy existed.

--- a/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
@@ -5,138 +5,59 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `updateAllowlist`.
+/// @title Sequential revert-order test for `updateAllowlist`.
 ///
-/// @notice **Canonical order (Solidity reference):**
-///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+/// @notice **Canonical order:**
+///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
 ///         2. INCOMPATIBLE-TYPE (`_typeOf(policyId) != ALLOWLIST`) → `IncompatiblePolicyType`
 ///         3. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
 ///         4. BATCH-SIZE (inside `_batchSetMembers`) → `BatchSizeTooLarge`
 ///
-///         C(4, 2) = 6 pairs.
+///         Walks from all conditions broken to success, fixing one per step.
 contract PolicyRegistryUpdateAllowlistRevertOrderTest is PolicyRegistryTest {
-    // ---------------------------------------------------------------
-    // Pairs where POLICY-NOT-FOUND wins
-    // ---------------------------------------------------------------
-
-    /// @notice POLICY-NOT-FOUND beats INCOMPATIBLE-TYPE.
-    /// @dev policyId encodes as BLOCKLIST (top byte 0, incompatible for updateAllowlist)
-    ///      AND the policy has never been created (packed == 0).
-    ///      PolicyNotFound fires before the type discriminator is examined.
-    function test_updateAllowlist_revertOrder_policyNotFound_beats_incompatiblePolicyType(uint56 counter) public {
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        // top byte 0 = BLOCKLIST; would trigger IncompatiblePolicyType if the policy existed.
-        uint64 policyId = uint64(counter);
-        address[] memory empty = new address[](0);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created.
-        // - IncompatiblePolicyType: policyId encodes as BLOCKLIST, not ALLOWLIST.
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateAllowlist(policyId, true, empty);
-    }
-
-    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
-    /// @dev policyId encodes as ALLOWLIST (so IncompatiblePolicyType does not apply)
-    ///      AND has never been created (PolicyNotFound fires), AND caller is non-zero
-    ///      (Unauthorized would fire if policyId existed as ALLOWLIST).
-    function test_updateAllowlist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter) public {
-        _assumeValidCaller(caller);
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        // top byte 1 = ALLOWLIST; IncompatiblePolicyType would not apply if the policy existed.
-        uint64 policyId = (uint64(1) << 56) | uint64(counter);
-        address[] memory empty = new address[](0);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created (packed == 0).
-        // - Unauthorized: _decodeAdmin(0) == address(0) != caller.
-        vm.prank(caller);
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateAllowlist(policyId, true, empty);
-    }
-
-    /// @notice POLICY-NOT-FOUND beats BATCH-SIZE.
-    /// @dev policyId has never been created (PolicyNotFound fires) AND accounts.length
-    ///      exceeds MAX_BATCH_SIZE (BatchSizeTooLarge would fire inside _batchSetMembers
-    ///      if the policy existed and all earlier checks passed).
-    function test_updateAllowlist_revertOrder_policyNotFound_beats_batchSizeTooLarge(uint56 counter, uint8 overflow)
-        public
-    {
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        uint64 policyId = (uint64(1) << 56) | uint64(counter); // ALLOWLIST type, not created
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_updateAllowlist_revertOrder(uint8 overflow) public {
         uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created.
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateAllowlist(policyId, true, accounts);
-    }
-
-    // ---------------------------------------------------------------
-    // Pairs where INCOMPATIBLE-TYPE wins
-    // ---------------------------------------------------------------
-
-    /// @notice INCOMPATIBLE-TYPE beats UNAUTHORIZED.
-    /// @dev Policy exists as BLOCKLIST (incompatible for updateAllowlist) AND caller
-    ///      is not the policy admin (Unauthorized would fire if the type check were absent).
-    function test_updateAllowlist_revertOrder_incompatiblePolicyType_beats_unauthorized(address caller) public {
-        _assumeValidCaller(caller);
-        // Create a BLOCKLIST policy with `alice` as admin.
-        uint64 policyId = _createBlocklist(admin, alice);
-        vm.assume(caller != alice);
+        address[] memory tooMany = _makeAccounts(n);
         address[] memory empty = new address[](0);
+        // ghostId is a well-formed policyId that has never been created.
+        uint64 ghostId = _wellFormedUncreatedPolicyId(type(uint64).max);
 
-        // Both conditions apply independently:
-        // - IncompatiblePolicyType: policy is BLOCKLIST, updateAllowlist requires ALLOWLIST.
-        // - Unauthorized: caller is not alice (the policy admin).
-        vm.prank(caller);
+        // 1. POLICY-NOT-FOUND: policyId has never been created AND all later conditions
+        //    would also apply (wrong type, unauthorized caller, oversized batch).
+        vm.prank(attacker);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateAllowlist(ghostId, true, tooMany);
+
+        // Fix: create a BLOCKLIST policy with alice as admin (exists, but wrong type for updateAllowlist).
+        uint64 blocklistId = _createBlocklist(admin, alice);
+
+        // 2. INCOMPATIBLE-TYPE: policy exists as BLOCKLIST; updateAllowlist requires ALLOWLIST.
+        //    (Unauthorized and BatchSizeTooLarge would also apply.)
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
-        policyRegistry.updateAllowlist(policyId, true, empty);
-    }
+        policyRegistry.updateAllowlist(blocklistId, true, tooMany);
 
-    /// @notice INCOMPATIBLE-TYPE beats BATCH-SIZE.
-    /// @dev Policy exists as BLOCKLIST AND accounts.length exceeds MAX_BATCH_SIZE.
-    ///      Caller is the policy admin so Unauthorized does not apply; only type and
-    ///      batch-size conditions compete.
-    function test_updateAllowlist_revertOrder_incompatiblePolicyType_beats_batchSizeTooLarge(uint8 overflow) public {
-        // Create a BLOCKLIST policy with alice as admin; call as alice (no Unauthorized).
-        uint64 policyId = _createBlocklist(admin, alice);
-        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
-
-        // Both conditions apply independently:
-        // - IncompatiblePolicyType: policy is BLOCKLIST, updateAllowlist requires ALLOWLIST.
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.prank(alice);
-        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
-        policyRegistry.updateAllowlist(policyId, true, accounts);
-    }
-
-    // ---------------------------------------------------------------
-    // Pairs where UNAUTHORIZED wins
-    // ---------------------------------------------------------------
-
-    /// @notice UNAUTHORIZED beats BATCH-SIZE.
-    /// @dev Policy exists as ALLOWLIST (IncompatiblePolicyType does not apply) AND
-    ///      caller is not the policy admin AND accounts.length exceeds MAX_BATCH_SIZE.
-    ///      Unauthorized fires before _batchSetMembers runs its batch-size guard.
-    function test_updateAllowlist_revertOrder_unauthorized_beats_batchSizeTooLarge(address caller, uint8 overflow)
-        public
-    {
-        _assumeValidCaller(caller);
-        // Create an ALLOWLIST policy with alice as admin; caller is not alice.
+        // Fix: create an ALLOWLIST policy with alice as admin.
         uint64 policyId = _createAllowlist(admin, alice);
-        vm.assume(caller != alice);
-        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
 
-        // Both conditions apply independently:
-        // - Unauthorized: caller is not alice (the policy admin).
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.prank(caller);
+        // 3. UNAUTHORIZED: policy is ALLOWLIST but attacker is not the policy admin (alice).
+        //    (BatchSizeTooLarge would also apply.)
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
-        policyRegistry.updateAllowlist(policyId, true, accounts);
+        policyRegistry.updateAllowlist(policyId, true, tooMany);
+
+        // Fix: call as alice (the policy admin).
+
+        // 4. BATCH-SIZE: alice is the admin, but accounts.length > MAX_BATCH_SIZE.
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.BatchSizeTooLarge.selector, MAX_BATCH_SIZE));
+        policyRegistry.updateAllowlist(policyId, true, tooMany);
+
+        // Fix: use an empty accounts array.
+
+        // Success
+        vm.prank(alice);
+        policyRegistry.updateAllowlist(policyId, true, empty);
     }
 }

--- a/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
@@ -5,139 +5,60 @@ import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
 
-/// @title Differential check-order tests for `updateBlocklist`.
+/// @title Sequential revert-order test for `updateBlocklist`.
 ///
-/// @notice **Canonical order (Solidity reference):**
-///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+/// @notice **Canonical order:**
+///         1. POLICY-NOT-FOUND (`policies[policyId] == 0`) → `PolicyNotFound`
 ///         2. INCOMPATIBLE-TYPE (`_typeOf(policyId) != BLOCKLIST`) → `IncompatiblePolicyType`
 ///         3. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
 ///         4. BATCH-SIZE (inside `_batchSetMembers`) → `BatchSizeTooLarge`
 ///
-///         C(4, 2) = 6 pairs. Mirror of `updateAllowlist_revertOrder.t.sol` with
-///         ALLOWLIST and BLOCKLIST roles swapped.
+///         Walks from all conditions broken to success, fixing one per step.
+///         Mirror of `updateAllowlist_revertOrder.t.sol` with ALLOWLIST and BLOCKLIST roles swapped.
 contract PolicyRegistryUpdateBlocklistRevertOrderTest is PolicyRegistryTest {
-    // ---------------------------------------------------------------
-    // Pairs where POLICY-NOT-FOUND wins
-    // ---------------------------------------------------------------
-
-    /// @notice POLICY-NOT-FOUND beats INCOMPATIBLE-TYPE.
-    /// @dev policyId encodes as ALLOWLIST (top byte 1, incompatible for updateBlocklist)
-    ///      AND the policy has never been created (packed == 0).
-    ///      PolicyNotFound fires before the type discriminator is examined.
-    function test_updateBlocklist_revertOrder_policyNotFound_beats_incompatiblePolicyType(uint56 counter) public {
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        // top byte 1 = ALLOWLIST; would trigger IncompatiblePolicyType if the policy existed.
-        uint64 policyId = (uint64(1) << 56) | uint64(counter);
-        address[] memory empty = new address[](0);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created.
-        // - IncompatiblePolicyType: policyId encodes as ALLOWLIST, not BLOCKLIST.
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateBlocklist(policyId, true, empty);
-    }
-
-    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
-    /// @dev policyId encodes as BLOCKLIST (so IncompatiblePolicyType does not apply)
-    ///      AND has never been created (PolicyNotFound fires), AND caller is non-zero
-    ///      (Unauthorized would fire if policyId existed as BLOCKLIST).
-    function test_updateBlocklist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter) public {
-        _assumeValidCaller(caller);
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        // top byte 0 = BLOCKLIST; IncompatiblePolicyType would not apply if the policy existed.
-        uint64 policyId = uint64(counter);
-        address[] memory empty = new address[](0);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created (packed == 0).
-        // - Unauthorized: _decodeAdmin(0) == address(0) != caller.
-        vm.prank(caller);
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateBlocklist(policyId, true, empty);
-    }
-
-    /// @notice POLICY-NOT-FOUND beats BATCH-SIZE.
-    /// @dev policyId has never been created (PolicyNotFound fires) AND accounts.length
-    ///      exceeds MAX_BATCH_SIZE (BatchSizeTooLarge would fire inside _batchSetMembers
-    ///      if the policy existed and all earlier checks passed).
-    function test_updateBlocklist_revertOrder_policyNotFound_beats_batchSizeTooLarge(uint56 counter, uint8 overflow)
-        public
-    {
-        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
-        uint64 policyId = uint64(counter); // BLOCKLIST type, not created
+    /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
+    function test_updateBlocklist_revertOrder(uint8 overflow) public {
         uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
-
-        // Both conditions apply independently:
-        // - PolicyNotFound: policyId has never been created.
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
-        policyRegistry.updateBlocklist(policyId, true, accounts);
-    }
-
-    // ---------------------------------------------------------------
-    // Pairs where INCOMPATIBLE-TYPE wins
-    // ---------------------------------------------------------------
-
-    /// @notice INCOMPATIBLE-TYPE beats UNAUTHORIZED.
-    /// @dev Policy exists as ALLOWLIST (incompatible for updateBlocklist) AND caller
-    ///      is not the policy admin (Unauthorized would fire if the type check were absent).
-    function test_updateBlocklist_revertOrder_incompatiblePolicyType_beats_unauthorized(address caller) public {
-        _assumeValidCaller(caller);
-        // Create an ALLOWLIST policy with `alice` as admin.
-        uint64 policyId = _createAllowlist(admin, alice);
-        vm.assume(caller != alice);
+        address[] memory tooMany = _makeAccounts(n);
         address[] memory empty = new address[](0);
+        // ghostId is a well-formed policyId that has never been created.
+        uint64 ghostId = _wellFormedUncreatedPolicyId(type(uint64).max);
 
-        // Both conditions apply independently:
-        // - IncompatiblePolicyType: policy is ALLOWLIST, updateBlocklist requires BLOCKLIST.
-        // - Unauthorized: caller is not alice (the policy admin).
-        vm.prank(caller);
+        // 1. POLICY-NOT-FOUND: policyId has never been created AND all later conditions
+        //    would also apply (wrong type, unauthorized caller, oversized batch).
+        vm.prank(attacker);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateBlocklist(ghostId, true, tooMany);
+
+        // Fix: create an ALLOWLIST policy with alice as admin (exists, but wrong type for updateBlocklist).
+        uint64 allowlistId = _createAllowlist(admin, alice);
+
+        // 2. INCOMPATIBLE-TYPE: policy exists as ALLOWLIST; updateBlocklist requires BLOCKLIST.
+        //    (Unauthorized and BatchSizeTooLarge would also apply.)
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
-        policyRegistry.updateBlocklist(policyId, true, empty);
-    }
+        policyRegistry.updateBlocklist(allowlistId, true, tooMany);
 
-    /// @notice INCOMPATIBLE-TYPE beats BATCH-SIZE.
-    /// @dev Policy exists as ALLOWLIST AND accounts.length exceeds MAX_BATCH_SIZE.
-    ///      Caller is the policy admin so Unauthorized does not apply; only type and
-    ///      batch-size conditions compete.
-    function test_updateBlocklist_revertOrder_incompatiblePolicyType_beats_batchSizeTooLarge(uint8 overflow) public {
-        // Create an ALLOWLIST policy with alice as admin; call as alice (no Unauthorized).
-        uint64 policyId = _createAllowlist(admin, alice);
-        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
-
-        // Both conditions apply independently:
-        // - IncompatiblePolicyType: policy is ALLOWLIST, updateBlocklist requires BLOCKLIST.
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.prank(alice);
-        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
-        policyRegistry.updateBlocklist(policyId, true, accounts);
-    }
-
-    // ---------------------------------------------------------------
-    // Pairs where UNAUTHORIZED wins
-    // ---------------------------------------------------------------
-
-    /// @notice UNAUTHORIZED beats BATCH-SIZE.
-    /// @dev Policy exists as BLOCKLIST (IncompatiblePolicyType does not apply) AND
-    ///      caller is not the policy admin AND accounts.length exceeds MAX_BATCH_SIZE.
-    ///      Unauthorized fires before _batchSetMembers runs its batch-size guard.
-    function test_updateBlocklist_revertOrder_unauthorized_beats_batchSizeTooLarge(address caller, uint8 overflow)
-        public
-    {
-        _assumeValidCaller(caller);
-        // Create a BLOCKLIST policy with alice as admin; caller is not alice.
+        // Fix: create a BLOCKLIST policy with alice as admin.
         uint64 policyId = _createBlocklist(admin, alice);
-        vm.assume(caller != alice);
-        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
-        address[] memory accounts = _makeAccounts(n);
 
-        // Both conditions apply independently:
-        // - Unauthorized: caller is not alice (the policy admin).
-        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
-        vm.prank(caller);
+        // 3. UNAUTHORIZED: policy is BLOCKLIST but attacker is not the policy admin (alice).
+        //    (BatchSizeTooLarge would also apply.)
+        vm.prank(attacker);
         vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
-        policyRegistry.updateBlocklist(policyId, true, accounts);
+        policyRegistry.updateBlocklist(policyId, true, tooMany);
+
+        // Fix: call as alice (the policy admin).
+
+        // 4. BATCH-SIZE: alice is the admin, but accounts.length > MAX_BATCH_SIZE.
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IPolicyRegistry.BatchSizeTooLarge.selector, MAX_BATCH_SIZE));
+        policyRegistry.updateBlocklist(policyId, true, tooMany);
+
+        // Fix: use an empty accounts array.
+
+        // Success
+        vm.prank(alice);
+        policyRegistry.updateBlocklist(policyId, true, empty);
     }
 }

--- a/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+
+import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+
+/// @title Differential check-order tests for `updateBlocklist`.
+///
+/// @notice **Canonical order (Solidity reference):**
+///         1. POLICY-NOT-FOUND (`_requireCustom`: packed == 0) → `PolicyNotFound`
+///         2. INCOMPATIBLE-TYPE (`_typeOf(policyId) != BLOCKLIST`) → `IncompatiblePolicyType`
+///         3. UNAUTHORIZED (`_decodeAdmin(packed) != msg.sender`) → `Unauthorized`
+///         4. BATCH-SIZE (inside `_batchSetMembers`) → `BatchSizeTooLarge`
+///
+///         C(4, 2) = 6 pairs. Mirror of `updateAllowlist_revertOrder.t.sol` with
+///         ALLOWLIST and BLOCKLIST roles swapped.
+contract PolicyRegistryUpdateBlocklistRevertOrderTest is PolicyRegistryTest {
+    // ---------------------------------------------------------------
+    // Pairs where POLICY-NOT-FOUND wins
+    // ---------------------------------------------------------------
+
+    /// @notice POLICY-NOT-FOUND beats INCOMPATIBLE-TYPE.
+    /// @dev policyId encodes as ALLOWLIST (top byte 1, incompatible for updateBlocklist)
+    ///      AND the policy has never been created (packed == 0).
+    ///      PolicyNotFound fires before the type discriminator is examined.
+    function test_updateBlocklist_revertOrder_policyNotFound_beats_incompatiblePolicyType(uint56 counter) public {
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        // top byte 1 = ALLOWLIST; would trigger IncompatiblePolicyType if the policy existed.
+        uint64 policyId = (uint64(1) << 56) | uint64(counter);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created.
+        // - IncompatiblePolicyType: policyId encodes as ALLOWLIST, not BLOCKLIST.
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateBlocklist(policyId, true, empty);
+    }
+
+    /// @notice POLICY-NOT-FOUND beats UNAUTHORIZED.
+    /// @dev policyId encodes as BLOCKLIST (so IncompatiblePolicyType does not apply)
+    ///      AND has never been created (PolicyNotFound fires), AND caller is non-zero
+    ///      (Unauthorized would fire if policyId existed as BLOCKLIST).
+    function test_updateBlocklist_revertOrder_policyNotFound_beats_unauthorized(address caller, uint56 counter) public {
+        _assumeValidCaller(caller);
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        // top byte 0 = BLOCKLIST; IncompatiblePolicyType would not apply if the policy existed.
+        uint64 policyId = uint64(counter);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created (packed == 0).
+        // - Unauthorized: _decodeAdmin(0) == address(0) != caller.
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateBlocklist(policyId, true, empty);
+    }
+
+    /// @notice POLICY-NOT-FOUND beats BATCH-SIZE.
+    /// @dev policyId has never been created (PolicyNotFound fires) AND accounts.length
+    ///      exceeds MAX_BATCH_SIZE (BatchSizeTooLarge would fire inside _batchSetMembers
+    ///      if the policy existed and all earlier checks passed).
+    function test_updateBlocklist_revertOrder_policyNotFound_beats_batchSizeTooLarge(uint56 counter, uint8 overflow)
+        public
+    {
+        counter = uint56(bound(uint256(counter), 2, type(uint56).max));
+        uint64 policyId = uint64(counter); // BLOCKLIST type, not created
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - PolicyNotFound: policyId has never been created.
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.expectRevert(IPolicyRegistry.PolicyNotFound.selector);
+        policyRegistry.updateBlocklist(policyId, true, accounts);
+    }
+
+    // ---------------------------------------------------------------
+    // Pairs where INCOMPATIBLE-TYPE wins
+    // ---------------------------------------------------------------
+
+    /// @notice INCOMPATIBLE-TYPE beats UNAUTHORIZED.
+    /// @dev Policy exists as ALLOWLIST (incompatible for updateBlocklist) AND caller
+    ///      is not the policy admin (Unauthorized would fire if the type check were absent).
+    function test_updateBlocklist_revertOrder_incompatiblePolicyType_beats_unauthorized(address caller) public {
+        _assumeValidCaller(caller);
+        // Create an ALLOWLIST policy with `alice` as admin.
+        uint64 policyId = _createAllowlist(admin, alice);
+        vm.assume(caller != alice);
+        address[] memory empty = new address[](0);
+
+        // Both conditions apply independently:
+        // - IncompatiblePolicyType: policy is ALLOWLIST, updateBlocklist requires BLOCKLIST.
+        // - Unauthorized: caller is not alice (the policy admin).
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
+        policyRegistry.updateBlocklist(policyId, true, empty);
+    }
+
+    /// @notice INCOMPATIBLE-TYPE beats BATCH-SIZE.
+    /// @dev Policy exists as ALLOWLIST AND accounts.length exceeds MAX_BATCH_SIZE.
+    ///      Caller is the policy admin so Unauthorized does not apply; only type and
+    ///      batch-size conditions compete.
+    function test_updateBlocklist_revertOrder_incompatiblePolicyType_beats_batchSizeTooLarge(uint8 overflow) public {
+        // Create an ALLOWLIST policy with alice as admin; call as alice (no Unauthorized).
+        uint64 policyId = _createAllowlist(admin, alice);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - IncompatiblePolicyType: policy is ALLOWLIST, updateBlocklist requires BLOCKLIST.
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.prank(alice);
+        vm.expectRevert(IPolicyRegistry.IncompatiblePolicyType.selector);
+        policyRegistry.updateBlocklist(policyId, true, accounts);
+    }
+
+    // ---------------------------------------------------------------
+    // Pairs where UNAUTHORIZED wins
+    // ---------------------------------------------------------------
+
+    /// @notice UNAUTHORIZED beats BATCH-SIZE.
+    /// @dev Policy exists as BLOCKLIST (IncompatiblePolicyType does not apply) AND
+    ///      caller is not the policy admin AND accounts.length exceeds MAX_BATCH_SIZE.
+    ///      Unauthorized fires before _batchSetMembers runs its batch-size guard.
+    function test_updateBlocklist_revertOrder_unauthorized_beats_batchSizeTooLarge(address caller, uint8 overflow)
+        public
+    {
+        _assumeValidCaller(caller);
+        // Create a BLOCKLIST policy with alice as admin; caller is not alice.
+        uint64 policyId = _createBlocklist(admin, alice);
+        vm.assume(caller != alice);
+        uint256 n = MAX_BATCH_SIZE + 1 + (uint256(overflow) % 16);
+        address[] memory accounts = _makeAccounts(n);
+
+        // Both conditions apply independently:
+        // - Unauthorized: caller is not alice (the policy admin).
+        // - BatchSizeTooLarge: accounts.length > MAX_BATCH_SIZE.
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.Unauthorized.selector);
+        policyRegistry.updateBlocklist(policyId, true, accounts);
+    }
+}


### PR DESCRIPTION
[BOP-221](https://linear.app/coinbase/issue/BOP-221/featbase-std-automated-interface-coverage-check-in-ci)

## Motivation

`IPolicyRegistry` has seven mutating functions. Each has two to four revert conditions, but no tests pinning which condition fires first when multiple are simultaneously satisfied. Without these ordering tests, a refactor that reorders checks can silently change observable revert behavior without breaking any existing test.

## What changed

Added seven new `*_revertOrder.t.sol` files under `test/unit/PolicyRegistry/`:

| File | Pairs |
|---|---|
| `createPolicy_revertOrder.t.sol` | 0 (single revert condition; file documents why) |
| `createPolicyWithAccounts_revertOrder.t.sol` | 1 (ZeroAddress beats BatchSizeTooLarge) |
| `stageUpdateAdmin_revertOrder.t.sol` | 1 (PolicyNotFound beats Unauthorized) |
| `finalizeUpdateAdmin_revertOrder.t.sol` | 3 (PolicyNotFound beats NoPendingAdmin, PolicyNotFound beats Unauthorized, NoPendingAdmin beats Unauthorized) |
| `renounceAdmin_revertOrder.t.sol` | 1 (PolicyNotFound beats Unauthorized) |
| `updateAllowlist_revertOrder.t.sol` | 6 (all C(4,2) pairs across PolicyNotFound, IncompatiblePolicyType, Unauthorized, BatchSizeTooLarge) |
| `updateBlocklist_revertOrder.t.sol` | 6 (mirror of updateAllowlist with ALLOWLIST/BLOCKLIST swapped) |

18 fuzz tests total, all passing against the MockPolicyRegistry reference implementation.

type=routine
risk=low
impact=sev5