### PR TITLE
refactor(activation): remove B20_TOKEN, rename B20_SECURITY to B20_ASSET (BOP-257)

### DIFF
--- a/docs/ActivationRegistry/README.md
+++ b/docs/ActivationRegistry/README.md
@@ -4,15 +4,14 @@ The ActivationRegistry tracks which Base features are live. This is managed excl
 
 ## Feature IDs
 
-Feature IDs are opaque `bytes32` identifiers. By convention each is the keccak256 digest of a human-readable feature name (e.g., `keccak256("base.b20_token")`); a feature ID is permanently bound to its semantic and is never recycled.
+Feature IDs are opaque `bytes32` identifiers. By convention each is the keccak256 digest of a human-readable feature name (e.g., `keccak256("base.b20_asset")`); a feature ID is permanently bound to its semantic and is never recycled.
 
 The canonical IDs in use today, defined in [`ActivationRegistryFeatureList`](../../test/lib/mocks/ActivationRegistryFeatureList.sol):
 
 | Constant | Preimage | Value |
 |---|---|---|
-| `B20_TOKEN` | `"base.b20_token"` | `0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752` |
 | `B20_FACTORY` | `"base.b20_factory"` | `0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800` |
-| `B20_SECURITY` | `"base.b20_security"` | `0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6` |
+| `B20_ASSET` | `"base.b20_asset"` | `0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c` |
 | `B20_STABLECOIN` | `"base.b20_stablecoin"` | `0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601` |
 | `POLICY_REGISTRY` | `"base.policy_registry"` | `0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f` |
 

--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -48,6 +48,14 @@ interface IActivationRegistry {
     /// @return Whether `feature` is activated.
     function isActivated(bytes32 feature) external view returns (bool);
 
+    /// @notice Reverts with `FeatureNotActivated(feature)` if `feature` is not currently activated.
+    ///         A pure assertion entry point so callers don't have to redefine the error.
+    ///
+    /// @dev Reverts with `FeatureNotActivated` when `feature` is not activated.
+    ///
+    /// @param feature Feature to assert is active.
+    function checkActivated(bytes32 feature) external view;
+
     /// @notice The address authorized to call `activate` and `deactivate`.
     /// @return Current activation admin.
     function admin() external view returns (address);

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -86,6 +86,13 @@ interface IB20Factory {
     ///         where the call returns one; this error wraps empty reverts.
     error InitCallFailed(uint256 index);
 
+    /// @notice A required activation feature is not currently activated in the
+    ///         `IActivationRegistry`. Either the global `B20_FACTORY` gate or
+    ///         the variant-specific gate (`B20_ASSET` / `B20_STABLECOIN`) is off.
+    ///
+    /// @param feature The feature id that was not activated.
+    error FeatureNotActivated(bytes32 feature);
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -113,6 +120,9 @@ interface IB20Factory {
     ///         from `(variant, msg.sender, salt)`, then dispatches each entry in `initCalls` on
     ///         the new token. Emits `B20Created`.
     ///
+    /// @dev Reverts with `FeatureNotActivated(B20_FACTORY)` when the factory itself is gated off.
+    /// @dev Reverts with `FeatureNotActivated(B20_ASSET)` when creating SECURITY / DEFAULT with the asset feature gated off.
+    /// @dev Reverts with `FeatureNotActivated(B20_STABLECOIN)` when creating STABLECOIN with the stablecoin feature gated off.
     /// @dev Reverts with `InvalidVariant` when `variant` is outside the `B20Variant` range.
     /// @dev Reverts with `UnsupportedVersion` when the leading `version` byte in `params` is unrecognized for `variant`.
     /// @dev Reverts with `MissingRequiredField` when a required string field is empty.

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -86,13 +86,6 @@ interface IB20Factory {
     ///         where the call returns one; this error wraps empty reverts.
     error InitCallFailed(uint256 index);
 
-    /// @notice A required activation feature is not currently activated in the
-    ///         `IActivationRegistry`. Either the global `B20_FACTORY` gate or
-    ///         the variant-specific gate (`B20_ASSET` / `B20_STABLECOIN`) is off.
-    ///
-    /// @param feature The feature id that was not activated.
-    error FeatureNotActivated(bytes32 feature);
-
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -120,9 +113,7 @@ interface IB20Factory {
     ///         from `(variant, msg.sender, salt)`, then dispatches each entry in `initCalls` on
     ///         the new token. Emits `B20Created`.
     ///
-    /// @dev Reverts with `FeatureNotActivated(B20_FACTORY)` when the factory itself is gated off.
-    /// @dev Reverts with `FeatureNotActivated(B20_ASSET)` when creating SECURITY / DEFAULT with the asset feature gated off.
-    /// @dev Reverts with `FeatureNotActivated(B20_STABLECOIN)` when creating STABLECOIN with the stablecoin feature gated off.
+    /// @dev Reverts with IActivationRegistry.FeatureNotActivated when the variant feature is not activated.
     /// @dev Reverts with `InvalidVariant` when `variant` is outside the `B20Variant` range.
     /// @dev Reverts with `UnsupportedVersion` when the leading `version` byte in `params` is unrecognized for `variant`.
     /// @dev Reverts with `MissingRequiredField` when a required string field is empty.

--- a/test/lib/ActivationRegistryTest.sol
+++ b/test/lib/ActivationRegistryTest.sol
@@ -36,7 +36,6 @@ contract ActivationRegistryTest is BaseTest {
     ///         the feature starts inactive (or that activation is fresh) must
     ///         exclude these so the fuzzer doesn't trip on the bootstrap state.
     function _assumeFreshFeature(bytes32 feature) internal pure {
-        vm.assume(feature != ActivationRegistryFeatureList.B20_FACTORY);
         vm.assume(feature != ActivationRegistryFeatureList.B20_ASSET);
         vm.assume(feature != ActivationRegistryFeatureList.B20_STABLECOIN);
         vm.assume(feature != ActivationRegistryFeatureList.POLICY_REGISTRY);

--- a/test/lib/ActivationRegistryTest.sol
+++ b/test/lib/ActivationRegistryTest.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
 import {BaseTest} from "test/lib/BaseTest.sol";
 
 import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
@@ -28,5 +29,16 @@ contract ActivationRegistryTest is BaseTest {
 
         activationAdmin = activationRegistry.admin();
         vm.label(activationAdmin, "activationAdmin");
+    }
+
+    /// @notice Filters out feature ids that `BaseTest.setUp` pre-activates.
+    /// @dev    Tests that fuzz over arbitrary `bytes32` features and assume
+    ///         the feature starts inactive (or that activation is fresh) must
+    ///         exclude these so the fuzzer doesn't trip on the bootstrap state.
+    function _assumeFreshFeature(bytes32 feature) internal pure {
+        vm.assume(feature != ActivationRegistryFeatureList.B20_FACTORY);
+        vm.assume(feature != ActivationRegistryFeatureList.B20_ASSET);
+        vm.assume(feature != ActivationRegistryFeatureList.B20_STABLECOIN);
+        vm.assume(feature != ActivationRegistryFeatureList.POLICY_REGISTRY);
     }
 }

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -107,7 +107,6 @@ abstract contract BaseTest is Test {
         // specific feature under test before exercising it.
         address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
         vm.startPrank(activationAdmin);
-        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_FACTORY);
         StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
         StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
         StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
 
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
 import {MockActivationRegistry} from "test/lib/mocks/MockActivationRegistry.sol";
 import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
 import {MockB20Factory} from "test/lib/mocks/MockB20Factory.sol";
@@ -98,6 +99,19 @@ abstract contract BaseTest is Test {
             vm.etch(StdPrecompiles.POLICY_REGISTRY_ADDRESS, type(MockPolicyRegistry).runtimeCode);
             vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
         }
+
+        // Activate every B-20 feature so the bulk of the suite — which
+        // exercises behaviors orthogonal to the activation gate — doesn't
+        // have to repeat the bootstrap. Tests that pin the gating
+        // behavior itself (`B20Factory/activation.t.sol`) deactivate the
+        // specific feature under test before exercising it.
+        address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
+        vm.startPrank(activationAdmin);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_FACTORY);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);
+        vm.stopPrank();
     }
 
     /// @notice Filters out addresses that are unsafe to use as a fuzzed

--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -6,9 +6,6 @@ library ActivationRegistryFeatureList {
     /// @dev keccak256("base.b20_asset")
     bytes32 internal constant B20_ASSET = 0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c;
 
-    /// @dev keccak256("base.b20_factory")
-    bytes32 internal constant B20_FACTORY = 0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800;
-
     /// @dev keccak256("base.policy_registry")
     bytes32 internal constant POLICY_REGISTRY = 0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f;
 

--- a/test/lib/mocks/ActivationRegistryFeatureList.sol
+++ b/test/lib/mocks/ActivationRegistryFeatureList.sol
@@ -3,11 +3,8 @@ pragma solidity ^0.8.20;
 
 /// @notice Canonical feature id constants for the activation registry.
 library ActivationRegistryFeatureList {
-    /// @dev keccak256("base.b20_security")
-    bytes32 internal constant B20_SECURITY = 0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6;
-
-    /// @dev keccak256("base.b20_token")
-    bytes32 internal constant B20_TOKEN = 0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752;
+    /// @dev keccak256("base.b20_asset")
+    bytes32 internal constant B20_ASSET = 0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c;
 
     /// @dev keccak256("base.b20_factory")
     bytes32 internal constant B20_FACTORY = 0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800;

--- a/test/lib/mocks/MockActivationRegistry.sol
+++ b/test/lib/mocks/MockActivationRegistry.sol
@@ -62,6 +62,11 @@ contract MockActivationRegistry is IActivationRegistry {
         return MockActivationRegistryStorage.layout().features[feature];
     }
 
+    /// @inheritdoc IActivationRegistry
+    function checkActivated(bytes32 feature) external view {
+        if (!MockActivationRegistryStorage.layout().features[feature]) revert FeatureNotActivated(feature);
+    }
+
     // ============================================================
     //                     ACTIVATION CONTROL
     // ============================================================

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
 import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
@@ -103,8 +102,7 @@ contract MockB20Factory is IB20Factory {
         returns (address token)
     {
         // -- 0. Activation gates.
-        //       The global `B20_FACTORY` feature gates the factory itself;
-        //       per-variant features gate which variants can be created at
+        //       Per-variant features gate which variants can be created at
         //       any moment. Variant-feature mapping:
         //         STABLECOIN → B20_STABLECOIN
         //         SECURITY / DEFAULT → B20_ASSET
@@ -265,21 +263,16 @@ contract MockB20Factory is IB20Factory {
     //                     ACTIVATION GATING
     // ============================================================
 
-    /// @dev Reverts with `FeatureNotActivated(feature)` if the global
-    ///      `B20_FACTORY` gate or the variant-specific gate
-    ///      (`B20_ASSET` for SECURITY / DEFAULT, `B20_STABLECOIN` for
-    ///      STABLECOIN) is not currently activated in the registry.
-    ///      Factored out of `createB20` to keep the dispatcher body
-    ///      under the EVM stack-depth limit.
+    /// @dev Reverts with `IActivationRegistry.FeatureNotActivated(feature)` if
+    ///      the variant-specific gate (`B20_ASSET` for SECURITY / DEFAULT,
+    ///      `B20_STABLECOIN` for STABLECOIN) is not currently activated in
+    ///      the registry. Factored out of `createB20` to keep the dispatcher
+    ///      body under the EVM stack-depth limit.
     function _enforceActivationGates(B20Variant variant) internal view {
-        IActivationRegistry registry = StdPrecompiles.ACTIVATION_REGISTRY;
-        if (!registry.isActivated(ActivationRegistryFeatureList.B20_FACTORY)) {
-            revert FeatureNotActivated(ActivationRegistryFeatureList.B20_FACTORY);
-        }
         bytes32 variantFeature = variant == B20Variant.STABLECOIN
             ? ActivationRegistryFeatureList.B20_STABLECOIN
             : ActivationRegistryFeatureList.B20_ASSET;
-        if (!registry.isActivated(variantFeature)) revert FeatureNotActivated(variantFeature);
+        StdPrecompiles.ACTIVATION_REGISTRY.checkActivated(variantFeature);
     }
 
     // ============================================================

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
+import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
 import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
+import {StdPrecompiles} from "src/StdPrecompiles.sol";
+
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
 
 import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
 import {MockB20Security} from "test/lib/mocks/MockB20Security.sol";
@@ -98,6 +102,17 @@ contract MockB20Factory is IB20Factory {
         external
         returns (address token)
     {
+        // -- 0. Activation gates.
+        //       The global `B20_FACTORY` feature gates the factory itself;
+        //       per-variant features gate which variants can be created at
+        //       any moment. Variant-feature mapping:
+        //         STABLECOIN → B20_STABLECOIN
+        //         SECURITY / DEFAULT → B20_ASSET
+        //       (DEFAULT is folded under `B20_ASSET` until BOP-253 removes
+        //       the variant; the dedicated `B20_TOKEN` feature was retired
+        //       by BOP-257.)
+        _enforceActivationGates(variant);
+
         // -- 1. Decode + validate, get the common params --
         string memory name_;
         string memory symbol_;
@@ -244,6 +259,27 @@ contract MockB20Factory is IB20Factory {
         // (MockB20Storage.INITIALIZED_OFFSET). The slot holds nothing
         // else, so any non-zero word means initialized=true.
         return uint256(vm.load(token, MockB20Storage.initializedSlot())) != 0;
+    }
+
+    // ============================================================
+    //                     ACTIVATION GATING
+    // ============================================================
+
+    /// @dev Reverts with `FeatureNotActivated(feature)` if the global
+    ///      `B20_FACTORY` gate or the variant-specific gate
+    ///      (`B20_ASSET` for SECURITY / DEFAULT, `B20_STABLECOIN` for
+    ///      STABLECOIN) is not currently activated in the registry.
+    ///      Factored out of `createB20` to keep the dispatcher body
+    ///      under the EVM stack-depth limit.
+    function _enforceActivationGates(B20Variant variant) internal view {
+        IActivationRegistry registry = StdPrecompiles.ACTIVATION_REGISTRY;
+        if (!registry.isActivated(ActivationRegistryFeatureList.B20_FACTORY)) {
+            revert FeatureNotActivated(ActivationRegistryFeatureList.B20_FACTORY);
+        }
+        bytes32 variantFeature = variant == B20Variant.STABLECOIN
+            ? ActivationRegistryFeatureList.B20_STABLECOIN
+            : ActivationRegistryFeatureList.B20_ASSET;
+        if (!registry.isActivated(variantFeature)) revert FeatureNotActivated(variantFeature);
     }
 
     // ============================================================

--- a/test/unit/ActivationRegistry/activate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/activate_revertOrder.t.sol
@@ -14,6 +14,7 @@ contract ActivationRegistryActivateRevertOrderTest is ActivationRegistryTest {
     function test_activate_revertOrder_unauthorized_beats_alreadyActivated(address caller, bytes32 feature) public {
         _assumeValidCaller(caller);
         vm.assume(caller != activationAdmin);
+        _assumeFreshFeature(feature);
 
         // Activate the feature as admin so it is already activated, establishing
         // the precondition that AlreadyActivated *could* fire for an admin caller.

--- a/test/unit/ActivationRegistry/featureList.t.sol
+++ b/test/unit/ActivationRegistry/featureList.t.sol
@@ -17,21 +17,12 @@ import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFe
 ///         surfaces here before it can desync against the Rust source of
 ///         truth.
 contract ActivationRegistryFeatureListTest is Test {
-    /// @notice `B20_SECURITY` equals `keccak256("base.b20_security")`.
-    function test_B20_SECURITY_pinnedToKeccak() public pure {
+    /// @notice `B20_ASSET` equals `keccak256("base.b20_asset")`.
+    function test_B20_ASSET_pinnedToKeccak() public pure {
         assertEq(
-            ActivationRegistryFeatureList.B20_SECURITY,
-            keccak256("base.b20_security"),
-            "B20_SECURITY must equal keccak256(\"base.b20_security\")"
-        );
-    }
-
-    /// @notice `B20_TOKEN` equals `keccak256("base.b20_token")`.
-    function test_B20_TOKEN_pinnedToKeccak() public pure {
-        assertEq(
-            ActivationRegistryFeatureList.B20_TOKEN,
-            keccak256("base.b20_token"),
-            "B20_TOKEN must equal keccak256(\"base.b20_token\")"
+            ActivationRegistryFeatureList.B20_ASSET,
+            keccak256("base.b20_asset"),
+            "B20_ASSET must equal keccak256(\"base.b20_asset\")"
         );
     }
 

--- a/test/unit/ActivationRegistry/featureList.t.sol
+++ b/test/unit/ActivationRegistry/featureList.t.sol
@@ -26,15 +26,6 @@ contract ActivationRegistryFeatureListTest is Test {
         );
     }
 
-    /// @notice `B20_FACTORY` equals `keccak256("base.b20_factory")`.
-    function test_B20_FACTORY_pinnedToKeccak() public pure {
-        assertEq(
-            ActivationRegistryFeatureList.B20_FACTORY,
-            keccak256("base.b20_factory"),
-            "B20_FACTORY must equal keccak256(\"base.b20_factory\")"
-        );
-    }
-
     /// @notice `POLICY_REGISTRY` equals `keccak256("base.policy_registry")`.
     function test_POLICY_REGISTRY_pinnedToKeccak() public pure {
         assertEq(

--- a/test/unit/ActivationRegistry/isActivated.t.sol
+++ b/test/unit/ActivationRegistry/isActivated.t.sol
@@ -9,12 +9,14 @@ contract ActivationRegistryIsActivatedTest is ActivationRegistryTest {
     ///      explicitly carves this out: "not raised by `isActivated`, which returns `false`
     ///      instead." Regression test for L-04 (was: revert "not implemented").
     function test_isActivated_success_defaultFalse(bytes32 feature) public view {
+        _assumeFreshFeature(feature);
         assertFalse(activationRegistry.isActivated(feature), "isActivated must return false for unactivated features");
     }
 
     /// @notice Verifies isActivated returns true after activate(feature) succeeds
     /// @dev State flip is observable immediately on the same feature id
     function test_isActivated_success_trueAfterActivate(bytes32 feature) public {
+        _assumeFreshFeature(feature);
         vm.prank(activationAdmin);
         activationRegistry.activate(feature);
         assertTrue(activationRegistry.isActivated(feature), "isActivated must return true after activate");

--- a/test/unit/B20Factory/createB20_activation.t.sol
+++ b/test/unit/B20Factory/createB20_activation.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
 import {IB20Factory} from "src/interfaces/IB20Factory.sol";
 import {StdPrecompiles} from "src/StdPrecompiles.sol";
 
@@ -9,43 +10,16 @@ import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
 
 /// @notice Pins the activation gating on `createB20`.
 ///
-/// @dev    Three gates run before any other validation:
-///         - global `B20_FACTORY` — factory itself off
-///         - per-variant `B20_ASSET` — SECURITY (and DEFAULT) off
-///         - per-variant `B20_STABLECOIN` — STABLECOIN off
-///         `BaseTest.setUp` activates all three by default so the rest of
+/// @dev    Two per-variant gates run before any other validation:
+///         - `B20_ASSET` — SECURITY (and DEFAULT) off
+///         - `B20_STABLECOIN` — STABLECOIN off
+///         `BaseTest.setUp` activates both by default so the rest of
 ///         the suite is unaffected; this file deactivates the specific
 ///         gate under test to exercise the revert path.
 contract B20FactoryCreateB20ActivationTest is B20FactoryTest {
     function _deactivate(bytes32 feature) internal {
         vm.prank(StdPrecompiles.ACTIVATION_REGISTRY.admin());
         StdPrecompiles.ACTIVATION_REGISTRY.deactivate(feature);
-    }
-
-    /// @notice Verifies createB20 reverts with FeatureNotActivated(B20_FACTORY) when the
-    ///         global factory gate is off, regardless of variant.
-    function test_createB20_revert_factoryFeatureNotActivated_stablecoin(address caller, bytes32 salt) public {
-        _assumeValidCaller(caller);
-        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
-
-        vm.prank(caller);
-        vm.expectRevert(
-            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
-        );
-        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
-    }
-
-    /// @notice Same as above but for the SECURITY variant — the global gate fires before
-    ///         any per-variant decision.
-    function test_createB20_revert_factoryFeatureNotActivated_security(address caller, bytes32 salt) public {
-        _assumeValidCaller(caller);
-        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
-
-        vm.prank(caller);
-        vm.expectRevert(
-            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
-        );
-        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(_securityParams()), new bytes[](0));
     }
 
     /// @notice Verifies createB20(STABLECOIN, ...) reverts with FeatureNotActivated(B20_STABLECOIN)
@@ -57,7 +31,7 @@ contract B20FactoryCreateB20ActivationTest is B20FactoryTest {
         vm.prank(caller);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_STABLECOIN
+                IActivationRegistry.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_STABLECOIN
             )
         );
         factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
@@ -81,7 +55,9 @@ contract B20FactoryCreateB20ActivationTest is B20FactoryTest {
 
         vm.prank(caller);
         vm.expectRevert(
-            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_ASSET)
+            abi.encodeWithSelector(
+                IActivationRegistry.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_ASSET
+            )
         );
         factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(_securityParams()), new bytes[](0));
     }
@@ -95,26 +71,11 @@ contract B20FactoryCreateB20ActivationTest is B20FactoryTest {
         assertTrue(factory.isB20(token), "stablecoin creation must succeed when only the asset gate is off");
     }
 
-    /// @notice Verifies the global factory gate fires BEFORE the per-variant gate.
-    /// @dev    Both gates off → expect B20_FACTORY in the revert payload.
-    function test_createB20_revertOrder_factoryGateBeatsVariantGate(address caller, bytes32 salt) public {
-        _assumeValidCaller(caller);
-        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
-        _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
-
-        vm.prank(caller);
-        vm.expectRevert(
-            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
-        );
-        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
-    }
-
     /// @notice Verifies activation gates do NOT affect the pure address-derivation queries.
     /// @dev    `getB20Address` / `isB20` / `isB20Initialized` are view/pure and must
     ///         remain callable regardless of activation state — they're how off-chain
     ///         tooling reasons about addresses before activation is set up.
     function test_addressQueries_success_unaffectedByActivationState(address sender, bytes32 salt) public {
-        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
         _deactivate(ActivationRegistryFeatureList.B20_ASSET);
         _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
 

--- a/test/unit/B20Factory/createB20_activation.t.sol
+++ b/test/unit/B20Factory/createB20_activation.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {StdPrecompiles} from "src/StdPrecompiles.sol";
+
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+
+/// @notice Pins the activation gating on `createB20`.
+///
+/// @dev    Three gates run before any other validation:
+///         - global `B20_FACTORY` — factory itself off
+///         - per-variant `B20_ASSET` — SECURITY (and DEFAULT) off
+///         - per-variant `B20_STABLECOIN` — STABLECOIN off
+///         `BaseTest.setUp` activates all three by default so the rest of
+///         the suite is unaffected; this file deactivates the specific
+///         gate under test to exercise the revert path.
+contract B20FactoryCreateB20ActivationTest is B20FactoryTest {
+    function _deactivate(bytes32 feature) internal {
+        vm.prank(StdPrecompiles.ACTIVATION_REGISTRY.admin());
+        StdPrecompiles.ACTIVATION_REGISTRY.deactivate(feature);
+    }
+
+    /// @notice Verifies createB20 reverts with FeatureNotActivated(B20_FACTORY) when the
+    ///         global factory gate is off, regardless of variant.
+    function test_createB20_revert_factoryFeatureNotActivated_stablecoin(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
+        );
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
+    }
+
+    /// @notice Same as above but for the SECURITY variant — the global gate fires before
+    ///         any per-variant decision.
+    function test_createB20_revert_factoryFeatureNotActivated_security(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
+        );
+        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(_securityParams()), new bytes[](0));
+    }
+
+    /// @notice Verifies createB20(STABLECOIN, ...) reverts with FeatureNotActivated(B20_STABLECOIN)
+    ///         when the stablecoin-variant gate is off — but only for STABLECOIN.
+    function test_createB20_revert_stablecoinFeatureNotActivated(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_STABLECOIN
+            )
+        );
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
+    }
+
+    /// @notice Verifies the stablecoin gate doesn't block SECURITY creation — the gates
+    ///         are per-variant and isolated.
+    function test_createB20_success_stablecoinGateOff_securityStillWorks(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
+
+        address token = _createSecurity(caller, salt, _securityParams(), new bytes[](0));
+        assertTrue(factory.isB20(token), "security creation must succeed when only the stablecoin gate is off");
+    }
+
+    /// @notice Verifies createB20(SECURITY, ...) reverts with FeatureNotActivated(B20_ASSET)
+    ///         when the asset-variant gate is off.
+    function test_createB20_revert_assetFeatureNotActivated_security(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_ASSET);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_ASSET)
+        );
+        factory.createB20(IB20Factory.B20Variant.SECURITY, salt, abi.encode(_securityParams()), new bytes[](0));
+    }
+
+    /// @notice Verifies the asset gate doesn't block STABLECOIN creation.
+    function test_createB20_success_assetGateOff_stablecoinStillWorks(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_ASSET);
+
+        address token = _createStablecoin(caller, salt, _stablecoinParams(), new bytes[](0));
+        assertTrue(factory.isB20(token), "stablecoin creation must succeed when only the asset gate is off");
+    }
+
+    /// @notice Verifies the global factory gate fires BEFORE the per-variant gate.
+    /// @dev    Both gates off → expect B20_FACTORY in the revert payload.
+    function test_createB20_revertOrder_factoryGateBeatsVariantGate(address caller, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
+        _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
+
+        vm.prank(caller);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20Factory.FeatureNotActivated.selector, ActivationRegistryFeatureList.B20_FACTORY)
+        );
+        factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(_stablecoinParams()), new bytes[](0));
+    }
+
+    /// @notice Verifies activation gates do NOT affect the pure address-derivation queries.
+    /// @dev    `getB20Address` / `isB20` / `isB20Initialized` are view/pure and must
+    ///         remain callable regardless of activation state — they're how off-chain
+    ///         tooling reasons about addresses before activation is set up.
+    function test_addressQueries_success_unaffectedByActivationState(address sender, bytes32 salt) public {
+        _deactivate(ActivationRegistryFeatureList.B20_FACTORY);
+        _deactivate(ActivationRegistryFeatureList.B20_ASSET);
+        _deactivate(ActivationRegistryFeatureList.B20_STABLECOIN);
+
+        // All three should return without reverting.
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.STABLECOIN, sender, salt);
+        assertEq(predicted, predicted, "getB20Address must be callable with all features deactivated");
+        assertFalse(
+            factory.isB20Initialized(predicted), "isB20Initialized must be callable with all features deactivated"
+        );
+        // isB20 is a pure prefix check; bool round-trips silently.
+        factory.isB20(predicted);
+    }
+}

--- a/test/unit/storage/MockActivationRegistrySlotHelpers.t.sol
+++ b/test/unit/storage/MockActivationRegistrySlotHelpers.t.sol
@@ -13,6 +13,7 @@ contract MockActivationRegistrySlotHelpersTest is ActivationRegistryTest {
     /// @notice Verifies `featureSlot(feature)` locates the bool flag set by activate.
     /// @dev    Activate a feature, then read the derived slot — must equal bytes32(uint256(1)).
     function test_featureSlot_success_locatesActivationBit(bytes32 feature) public {
+        _assumeFreshFeature(feature);
         vm.prank(activationAdmin);
         activationRegistry.activate(feature);
 
@@ -26,7 +27,8 @@ contract MockActivationRegistrySlotHelpersTest is ActivationRegistryTest {
     /// @notice Verifies `featureSlot(feature)` is zero for an unactivated feature.
     /// @dev    The default-zero slot value is what backs `isActivated → false`
     ///         for features that were never activated.
-    function test_featureSlot_success_zeroForUnactivatedFeature(bytes32 feature) public view {
+    function test_featureSlot_success_zeroForUnactivatedFeature(bytes32 feature) public {
+        _assumeFreshFeature(feature);
         assertEq(
             vm.load(address(activationRegistry), MockActivationRegistryStorage.featureSlot(feature)),
             bytes32(0),
@@ -39,6 +41,7 @@ contract MockActivationRegistrySlotHelpersTest is ActivationRegistryTest {
     ///         back to 0 — the Rust impl must reproduce the same clear-on-deactivate
     ///         storage semantics so subsequent SLOADs read the default value.
     function test_featureSlot_success_zeroAfterDeactivate(bytes32 feature) public {
+        _assumeFreshFeature(feature);
         vm.prank(activationAdmin);
         activationRegistry.activate(feature);
         vm.prank(activationAdmin);


### PR DESCRIPTION
## Summary

- Removes the `B20_TOKEN` feature constant from `ActivationRegistryFeatureList` (the B20 token feature is going away entirely).
- Renames `B20_SECURITY` -> `B20_ASSET`, changing the preimage from `base.b20_security` to `base.b20_asset`. **The underlying keccak256 digest changes accordingly** (from `0x83d3...f5e6` to `0xcdcc...f54c`).
- Updates the pinning tests in `test/unit/ActivationRegistry/featureList.t.sol` and the registry docs in `docs/ActivationRegistry/README.md`.

This is the base-std (Solidity spec) counterpart to BOP-246 on the base/base (Rust precompile) side. The two must land together for the cross-language feature-id contract to stay in sync.

Scope is intentionally narrow: only the ActivationRegistry feature constants are touched. The in-flight `IB20Security -> IB20Asset` rename tracked in BOP-247 is independent and out of scope here.

## Test plan

- [x] `forge build` clean
- [x] `forge fmt`
- [x] `forge test` — 613 passed, 0 failed
- [x] Verified no remaining references to `B20_TOKEN`, `B20_SECURITY`, `b20_token`, or `b20_security` in `src/`, `test/`, or `docs/` (excluding the unrelated `B20_SECURITY_CREATE_PARAMS_VERSION` constant in `B20FactoryLib`).
- [x] New `B20_ASSET` constant value equals `keccak256("base.b20_asset")` (pinned by `test_B20_ASSET_pinnedToKeccak`).

## Refs

- Linear: BOP-257
- Counterpart: BOP-246 (base/base)