### PR TITLE
fix(test): drop DEFAULT-variant references orphaned by #115 merge

### DIFF
--- a/test/unit/B20Factory/isB20Initialized.t.sol
+++ b/test/unit/B20Factory/isB20Initialized.t.sol
@@ -27,15 +27,9 @@ contract B20FactoryIsB20InitializedTest is B20FactoryTest {
         public
         view
     {
-        address predicted = factory.getB20Address(IB20Factory.B20Variant.DEFAULT, sender, salt);
+        address predicted = factory.getB20Address(IB20Factory.B20Variant.SECURITY, sender, salt);
         vm.assume(predicted.code.length == 0);
         assertFalse(factory.isB20Initialized(predicted), "B-20-prefixed but uncreated address must not be initialized");
-    }
-
-    /// @notice Verifies isB20Initialized returns true for a freshly-created DEFAULT-variant token
-    function test_isB20Initialized_success_trueForDefaultToken(bytes32 salt) public {
-        address token = _createDefault(alice, salt, _b20Params(), new bytes[](0));
-        assertTrue(factory.isB20Initialized(token), "DEFAULT token must be recognized as initialized");
     }
 
     /// @notice Verifies isB20Initialized returns true for a freshly-created STABLECOIN-variant token


### PR DESCRIPTION
## Summary

\`main\` no longer builds. \`test/unit/B20Factory/isB20Initialized.t.sol\` (added in #111) still references the \`DEFAULT\` variant and the \`_createDefault\` / \`_b20Params\` test helpers, which #115 (BOP-253) removed. Both PRs merged against an older base that didn't see the conflict.

This PR:
- drops \`test_isB20Initialized_success_trueForDefaultToken\` outright (DEFAULT no longer exists);
- retargets \`test_isB20Initialized_success_falseForUncreatedB20PrefixedAddress\` to use \`SECURITY\` (the new ordinal-0 variant).

One file, +1 / -7.

## Test plan

- [x] \`forge build\` clean
- [x] \`forge test\` — 607/607 pass