### PR TITLE
fix(test): include REDEEM_SENDER_POLICY in B20Test policy type helpers

### DIFF
--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -134,20 +134,22 @@ contract B20Test is B20FactoryTest {
     ///         extends the codomain (e.g. a Security test that also
     ///         covers `REDEEM_SENDER_POLICY`).
     function _knownPolicyType(uint8 idx) internal pure returns (bytes32) {
-        uint8 i = idx % 4;
+        uint8 i = idx % 5;
         if (i == 0) return B20Constants.TRANSFER_SENDER_POLICY;
         if (i == 1) return B20Constants.TRANSFER_RECEIVER_POLICY;
         if (i == 2) return B20Constants.TRANSFER_EXECUTOR_POLICY;
-        return B20Constants.MINT_RECEIVER_POLICY;
+        if (i == 3) return B20Constants.MINT_RECEIVER_POLICY;
+        return keccak256("REDEEM_SENDER_POLICY");
     }
 
-    /// @notice True iff `policyType` is one of the four base-token
-    ///         supported policy types. Used by tests that fuzz arbitrary
-    ///         `bytes32` and need to filter to the supported / unsupported
-    ///         partition.
+    /// @notice True iff `policyType` is one of the five policy types
+    ///         supported by the security-variant token deployed in setUp.
+    ///         Used by tests that fuzz arbitrary `bytes32` and need to
+    ///         filter to the supported / unsupported partition.
     function _isKnownPolicyType(bytes32 policyType) internal pure returns (bool) {
         return policyType == B20Constants.TRANSFER_SENDER_POLICY || policyType == B20Constants.TRANSFER_RECEIVER_POLICY
-            || policyType == B20Constants.TRANSFER_EXECUTOR_POLICY || policyType == B20Constants.MINT_RECEIVER_POLICY;
+            || policyType == B20Constants.TRANSFER_EXECUTOR_POLICY || policyType == B20Constants.MINT_RECEIVER_POLICY
+            || policyType == keccak256("REDEEM_SENDER_POLICY");
     }
 
     /// @notice Pauses a single `PausableFeature`, lazily granting `PAUSE_ROLE`


### PR DESCRIPTION
## Motivation

\`test_updatePolicy_revert_unsupportedPolicyType\` started failing on main after #115 changed \`B20Test._deployToken()\` to deploy a security-variant token. \`MockB20Security\` overrides \`_readPolicyId\`/\`_writePolicyId\` to handle \`REDEEM_SENDER_POLICY\`, so fuzz inputs that hit that scope no longer revert with \`UnsupportedPolicyType\`. But \`_isKnownPolicyType\` in \`B20Test\` only checked the 4 base-token policy types, leaving \`REDEEM_SENDER_POLICY\` in the "unsupported" partition — causing the test to assert a revert that no longer fires.

## What changed

Updated \`_knownPolicyType\` (mod 4 to mod 5, adds the fifth arm) and \`_isKnownPolicyType\` (adds the \`REDEEM_SENDER_POLICY\` check) in \`test/lib/B20Test.sol\` to reflect all 5 policy types supported by the security-variant token now deployed in setUp.

type=routine
risk=low
impact=sev5