### PR TITLE
fix(factory): use MissingRequiredField for empty stablecoin currency (BOP-261)

### DIFF
--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -76,10 +76,10 @@ interface IB20Factory {
 
     /// @notice A required string argument was the empty string.
     ///
-    /// @param field Name of the missing field (e.g. `"isin"`).
+    /// @param field Name of the missing field (e.g. `"currency"`).
     error MissingRequiredField(string field);
 
-    /// @notice The stablecoin `currency` contained a non-`A`-`Z` byte.
+    /// @notice The stablecoin `currency` was non-empty but contained a non-`A`-`Z` byte.
     error InvalidCurrency(string code);
 
     /// @notice One of the `initCalls` reverted. The factory bubbles the underlying revert reason
@@ -116,8 +116,8 @@ interface IB20Factory {
     /// @dev Reverts with IActivationRegistry.FeatureNotActivated when the variant feature is not activated.
     /// @dev Reverts with `InvalidVariant` when `variant` is outside the `B20Variant` range.
     /// @dev Reverts with `UnsupportedVersion` when the leading `version` byte in `params` is unrecognized for `variant`.
-    /// @dev Reverts with `MissingRequiredField` when a required string field is empty.
-    /// @dev Reverts with `InvalidCurrency` when a stablecoin `currency` contains a non-`A`-`Z` byte.
+    /// @dev Reverts with `MissingRequiredField` when a required string field is empty (e.g. stablecoin `currency` or security `isin`).
+    /// @dev Reverts with `InvalidCurrency` when a stablecoin `currency` is non-empty but contains a non-`A`-`Z` byte.
     /// @dev Reverts with `TokenAlreadyExists` when a token already exists at the derived address.
     /// @dev Reverts with `InitCallFailed` (or the bubbled inner reason) when any entry in `initCalls` reverts.
     ///

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -138,9 +138,9 @@ contract MockB20Factory is IB20Factory {
             }
             // Empty currency must be rejected explicitly: the format-check loop below has
             // no bytes to inspect on empty input and would vacuously succeed otherwise.
-            // Reverts InvalidCurrency("") to match the Rust precompile's selector.
+            // Reverts MissingRequiredField("currency") to match the Rust precompile's selector.
             bytes memory cb = bytes(p.currency);
-            if (cb.length == 0) revert InvalidCurrency(p.currency);
+            if (cb.length == 0) revert MissingRequiredField("currency");
             // Format check: every byte must be an uppercase ASCII letter (A-Z).
             for (uint256 i = 0; i < cb.length; ++i) {
                 if (cb[i] < 0x41 || cb[i] > 0x5A) revert InvalidCurrency(p.currency);

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -79,7 +79,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Any non-empty string containing a non-`A`–`Z` byte reverts with `InvalidCurrency(code)`.
     /// @dev Subsumes every point case (lowercase, digits, symbols, multi-byte UTF-8) via
     ///      `vm.assume(!_isValidFiatCode)`. Empty input is covered by
-    ///      `test_createB20_revert_emptyCurrency` (rejected with `InvalidCurrency("")`).
+    ///      `test_createB20_revert_emptyCurrency` (rejected with `MissingRequiredField("currency")`).
     function test_createB20_revert_currency_rejectsInvalidFormat(string memory code, address caller, bytes32 salt)
         public
     {
@@ -133,12 +133,12 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies stablecoin createToken reverts when currency is the empty string
     /// @dev The format-check loop on `currency` is vacuously safe on empty input (no bytes
     ///      to inspect), so an explicit length check is required to reject empty up front.
-    ///      Checks InvalidCurrency("") error, matching the Rust precompile's selector.
+    ///      Checks MissingRequiredField("currency") error, matching the Rust precompile's selector.
     function test_createB20_revert_emptyCurrency(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);
         IB20Factory.B20StablecoinCreateParams memory p = _stablecoinParams("Stablecoin Test", "USD", admin, "");
         vm.prank(caller);
-        vm.expectRevert(abi.encodeWithSelector(IB20Factory.InvalidCurrency.selector, ""));
+        vm.expectRevert(abi.encodeWithSelector(IB20Factory.MissingRequiredField.selector, "currency"));
         factory.createB20(IB20Factory.B20Variant.STABLECOIN, salt, abi.encode(p), new bytes[](0));
     }
 


### PR DESCRIPTION
## Summary

- Swaps the empty-stablecoin-currency revert from \`InvalidCurrency(\"\")\` to \`MissingRequiredField(\"currency\")\` to match the Rust precompile.
- Non-empty-but-malformed currencies (any byte outside \`A-Z\`) still revert with \`InvalidCurrency(code)\`.
- Updates the \`MissingRequiredField\` natspec example from \`\"isin\"\` to \`\"currency\"\` (ISIN is no longer the only consumer).

Linear: [BOP-261](https://linear.app/coinbase/issue/BOP-261/fixbase-std-replace-invalidcurrency-with-missingrequiredfield).

## Test plan

- [x] \`forge build\` clean
- [x] \`forge test\` — 611/611 pass (\`test_createB20_revert_emptyCurrency\` retargeted to new selector; format-check test unchanged)