### PR TITLE
test(regression): B20 asset rename/removal regression suite + spec/doc audit (BOP-258)

### DIFF
--- a/script/mutate.py
+++ b/script/mutate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Hand-rolled mutation testing for MockB20 / MockTokenFactory.
+"""Hand-rolled mutation testing for MockB20 / MockB20Factory.
 
 For each mutation: back up the file, apply a single substitution, run forge test,
 record pass/fail, restore the backup. A mutation that "survives" (all tests pass

--- a/script/mutate.py
+++ b/script/mutate.py
@@ -23,7 +23,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 
 MOCK_B20 = REPO / "test/lib/mocks/MockB20.sol"
-MOCK_FACTORY = REPO / "test/lib/mocks/MockTokenFactory.sol"
+MOCK_FACTORY = REPO / "test/lib/mocks/MockB20Factory.sol"
 MOCK_POLICY = REPO / "test/lib/mocks/MockPolicyRegistry.sol"
 MOCK_STABLECOIN = REPO / "test/lib/mocks/MockB20Stablecoin.sol"
 
@@ -59,9 +59,9 @@ MUTATIONS: list[Mutation] = [
     # === MockB20: pause gate in _transfer ===
     Mutation(
         MOCK_B20,
-        "if (_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);",
-        "if (!_isPaused(PausableFeature.TRANSFER)) revert ContractPaused(PausableFeature.TRANSFER);",
-        "_transfer: invert pause check (paused transfers succeed, unpaused revert)",
+        "if (_isPaused(feature)) revert ContractPaused(feature);",
+        "if (!_isPaused(feature)) revert ContractPaused(feature);",
+        "whenNotPaused: invert pause check (paused ops succeed, unpaused revert)",
     ),
     # === MockB20: role check in _requireRole (the onlyRole modifier body) ===
     # After the modifier refactor, role checks at the call site (mint, pause,
@@ -105,15 +105,15 @@ MUTATIONS: list[Mutation] = [
     # === MockB20: skip policy check on sender (matches new inline pattern) ===
     Mutation(
         MOCK_B20,
-        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(senderPolicyId, from)) {\n                revert PolicyForbids(TRANSFER_SENDER_POLICY, senderPolicyId);\n            }",
-        "            // sender policy check elided\n            if (false) revert PolicyForbids(TRANSFER_SENDER_POLICY, senderPolicyId);",
+        "if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(packed.sender, from)) {\n                revert PolicyForbids(TRANSFER_SENDER_POLICY, packed.sender);\n            }",
+        "if (false) revert PolicyForbids(TRANSFER_SENDER_POLICY, packed.sender);",
         "_transfer: drop TRANSFER_SENDER_POLICY policy check entirely",
     ),
     # === MockB20: skip policy check on receiver (matches new inline pattern) ===
     Mutation(
         MOCK_B20,
-        "            if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(receiverPolicyId, to)) {\n                revert PolicyForbids(TRANSFER_RECEIVER_POLICY, receiverPolicyId);\n            }",
-        "            // receiver policy check elided\n            if (false) revert PolicyForbids(TRANSFER_RECEIVER_POLICY, receiverPolicyId);",
+        "if (!IPolicyRegistry(POLICY_REGISTRY).isAuthorized(packed.receiver, to)) {\n                revert PolicyForbids(TRANSFER_RECEIVER_POLICY, packed.receiver);\n            }",
+        "if (false) revert PolicyForbids(TRANSFER_RECEIVER_POLICY, packed.receiver);",
         "_transfer: drop TRANSFER_RECEIVER_POLICY policy check entirely",
     ),
     # === MockB20: skip MINT_RECEIVER_POLICY policy check (matches new inline pattern) ===
@@ -147,9 +147,9 @@ MUTATIONS: list[Mutation] = [
     # === MockB20: zero-receiver check skipped in _transfer specifically ===
     Mutation(
         MOCK_B20,
-        "    function _transfer(address from, address to, uint256 amount) internal {\n        if (to == address(0)) revert InvalidReceiver(to);",
-        "    function _transfer(address from, address to, uint256 amount) internal {\n        // if (to == address(0)) revert InvalidReceiver(to);",
-        "_transfer: drop zero-recipient guard",
+        "    function _requireNonZeroActors(address from, address to) internal pure {\n        if (to == address(0)) revert InvalidReceiver(to);",
+        "    function _requireNonZeroActors(address from, address to) internal pure {\n        // if (to == address(0)) revert InvalidReceiver(to);",
+        "_requireNonZeroActors: drop zero-recipient guard",
     ),
     # === MockB20: more mutations on accounting / event integrity ===
     Mutation(
@@ -296,40 +296,40 @@ MUTATIONS: list[Mutation] = [
     # === Pausable feature loop bounds (pausedFeatures view) ===
     Mutation(
         MOCK_B20,
-        "for (uint256 i = 0; i < 4; i++) {\n            if (((vectors >> i) & uint256(1)) == 1) count++;",
-        "for (uint256 i = 0; i < 3; i++) {\n            if (((vectors >> i) & uint256(1)) == 1) count++;",
-        "pausedFeatures: count loop misses REDEEM (4 features, loop only iterates 3)",
+        "for (uint256 i = 0; i < featureCount; i++) {\n            if (((vectors >> i) & uint256(1)) == 1) count++;",
+        "for (uint256 i = 0; i < featureCount - 1; i++) {\n            if (((vectors >> i) & uint256(1)) == 1) count++;",
+        "pausedFeatures: count loop drops the highest feature (off-by-one misses BURN)",
     ),
     # === Policy lane wiring (transferPolicyIds reads) ===
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds);",
-        "if (policyType == TRANSFER_SENDER_POLICY) return uint64($.transferPolicyIds >> 64);",
-        "_readPolicyId: TRANSFER_SENDER_POLICY reads RECEIVER lane (wrong shift)",
+        "if (policyScope == TRANSFER_SENDER_POLICY) return $.transferPolicyIds.sender;",
+        "if (policyScope == TRANSFER_SENDER_POLICY) return $.transferPolicyIds.receiver;",
+        "_readPolicyId: TRANSFER_SENDER_POLICY reads RECEIVER lane (wrong field)",
     ),
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 64);",
-        "if (policyType == TRANSFER_RECEIVER_POLICY) return uint64($.transferPolicyIds >> 128);",
-        "_readPolicyId: TRANSFER_RECEIVER_POLICY reads EXECUTOR lane (wrong shift)",
+        "if (policyScope == TRANSFER_RECEIVER_POLICY) return $.transferPolicyIds.receiver;",
+        "if (policyScope == TRANSFER_RECEIVER_POLICY) return $.transferPolicyIds.executor;",
+        "_readPolicyId: TRANSFER_RECEIVER_POLICY reads EXECUTOR lane (wrong field)",
     ),
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds >> 128);",
-        "if (policyType == TRANSFER_EXECUTOR_POLICY) return uint64($.transferPolicyIds);",
-        "_readPolicyId: TRANSFER_EXECUTOR_POLICY reads SENDER lane (wrong shift)",
+        "if (policyScope == TRANSFER_EXECUTOR_POLICY) return $.transferPolicyIds.executor;",
+        "if (policyScope == TRANSFER_EXECUTOR_POLICY) return $.transferPolicyIds.sender;",
+        "_readPolicyId: TRANSFER_EXECUTOR_POLICY reads SENDER lane (wrong field)",
     ),
     # === Permit cross-cutting ===
     Mutation(
         MOCK_B20,
-        "return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));",
-        "return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, uint256(1), address(this)));",
+        "block.chainid,\n                address(this)",
+        "uint256(1),\n                address(this)",
         "DOMAIN_SEPARATOR: hardcoded chainId 1 (signatures replayable across forks)",
     ),
     Mutation(
         MOCK_B20,
-        "return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, block.chainid, address(this)));",
-        "return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, block.chainid, address(0)));",
+        "block.chainid,\n                address(this)\n            )",
+        "block.chainid,\n                address(0)\n            )",
         "DOMAIN_SEPARATOR: verifyingContract hardcoded to zero (cross-token replay)",
     ),
     # === MockB20Stablecoin variant ===
@@ -349,8 +349,8 @@ MUTATIONS: list[Mutation] = [
     # === MockPolicyRegistry: authorization core ===
     Mutation(
         MOCK_POLICY,
-        "return _decodeType(packed) == PolicyType.ALLOWLIST ? member : !member;",
-        "return _decodeType(packed) == PolicyType.ALLOWLIST ? !member : member;",
+        "return _typeOf(policyId) == PolicyType.ALLOWLIST ? member : !member;",
+        "return _typeOf(policyId) == PolicyType.ALLOWLIST ? !member : member;",
         "isAuthorized: ALLOWLIST/BLOCKLIST polarity flipped (allowlist becomes blocklist and vice versa)",
     ),
     Mutation(
@@ -361,21 +361,21 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_POLICY,
-        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return true;\n        return MockPolicyRegistryStorage.layout().policies[policyId] != 0;",
-        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return false;\n        return MockPolicyRegistryStorage.layout().policies[policyId] != 0;",
+        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return true;",
+        "if (policyId == ALWAYS_ALLOW_ID || policyId == ALWAYS_BLOCK_ID) return false;",
         "policyExists: built-ins report as nonexistent (breaks token updatePolicy guard)",
     ),
     # === MockPolicyRegistry: policy creation ===
     Mutation(
         MOCK_POLICY,
-        "if (policyType != PolicyType.ALLOWLIST && policyType != PolicyType.BLOCKLIST) revert InvalidPolicyType();",
-        "if (policyType != PolicyType.ALLOWLIST || policyType != PolicyType.BLOCKLIST) revert InvalidPolicyType();",
-        "_create: && -> || in PolicyType guard (rejects every policy type, including valid ones)",
+        "return PolicyType(uint8(policyId >> POLICY_ID_TYPE_SHIFT));",
+        "return PolicyType(uint8(policyId));",
+        "_typeOf: omit type shift (every policyId decodes as PolicyType 0)",
     ),
     Mutation(
         MOCK_POLICY,
-        "if (admin == address(0)) revert ZeroAddress();",
-        "if (admin != address(0)) revert ZeroAddress();",
+        "if (admin == address(0)) revert ZeroAddress();\n        // Out-of-range",
+        "if (admin != address(0)) revert ZeroAddress();\n        // Out-of-range",
         "_create: zero-admin guard inverted (only zero-admin is allowed)",
     ),
     Mutation(
@@ -399,21 +399,21 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_POLICY,
-        "        if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();\n        $.policies[policyId] = _encode({policyType: _decodeType(packed), admin: address(0)});",
-        "        if (_decodeAdmin(packed) == msg.sender) revert Unauthorized();\n        $.policies[policyId] = _encode({policyType: _decodeType(packed), admin: address(0)});",
+        "if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();\n        // Admin lane cleared",
+        "if (_decodeAdmin(packed) == msg.sender) revert Unauthorized();\n        // Admin lane cleared",
         "renounceAdmin: admin auth check inverted (anyone but admin can renounce)",
     ),
     # === MockPolicyRegistry: list membership ===
     Mutation(
         MOCK_POLICY,
-        "if (_decodeType(packed) != PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
-        "if (_decodeType(packed) == PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
+        "if (_typeOf(policyId) != PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
+        "if (_typeOf(policyId) == PolicyType.ALLOWLIST) revert IncompatiblePolicyType();",
         "updateAllowlist: type check inverted (only NON-allowlists accepted)",
     ),
     Mutation(
         MOCK_POLICY,
-        "if (_decodeType(packed) != PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
-        "if (_decodeType(packed) == PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
+        "if (_typeOf(policyId) != PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
+        "if (_typeOf(policyId) == PolicyType.BLOCKLIST) revert IncompatiblePolicyType();",
         "updateBlocklist: type check inverted",
     ),
     Mutation(
@@ -431,51 +431,51 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         MOCK_POLICY,
-        "return address(uint160(packed >> PACKED_ADMIN_SHIFT));",
         "return address(uint160(packed));",
-        "_decodeAdmin: omits the shift (returns garbage that includes the policyType byte)",
+        "return address(uint160(packed >> 8));",
+        "_decodeAdmin: spurious shift corrupts the decoded admin address",
     ),
     Mutation(
         MOCK_POLICY,
-        "if (uint8(policyId >> POLICY_ID_TYPE_SHIFT) > uint8(type(PolicyType).max)) {\n            revert MalformedPolicyId(policyId);\n        }",
-        "if (uint8(policyId >> POLICY_ID_TYPE_SHIFT) >= uint8(type(PolicyType).max)) {\n            revert MalformedPolicyId(policyId);\n        }",
-        "_requireWellFormed: off-by-one (rejects last valid PolicyType discriminator)",
+        "return uint8(policyId >> POLICY_ID_TYPE_SHIFT) <= uint8(type(PolicyType).max);",
+        "return uint8(policyId >> POLICY_ID_TYPE_SHIFT) < uint8(type(PolicyType).max);",
+        "_isWellFormed: off-by-one (rejects last valid PolicyType discriminator)",
     ),
     # === _writePolicyId lane writes (MockB20, mirror of the read mutations) ===
     Mutation(
         MOCK_B20,
-        "if (policyType == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
-        "if (policyType == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
-        "_writePolicyId: TRANSFER_SENDER_POLICY writes to RECEIVER lane (lane swap)",
+        "if (policyScope == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds.sender = newPolicyId;",
+        "if (policyScope == TRANSFER_SENDER_POLICY) {\n            $.transferPolicyIds.receiver = newPolicyId;",
+        "_writePolicyId: TRANSFER_SENDER_POLICY writes to RECEIVER lane (field swap)",
     ),
     Mutation(
         MOCK_B20,
-        "} else if (policyType == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 64)) | (uint256(newPolicyId) << 64);",
-        "} else if (policyType == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~(mask << 128)) | (uint256(newPolicyId) << 128);",
+        "} else if (policyScope == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds.receiver = newPolicyId;",
+        "} else if (policyScope == TRANSFER_RECEIVER_POLICY) {\n            $.transferPolicyIds.executor = newPolicyId;",
         "_writePolicyId: TRANSFER_RECEIVER_POLICY writes to EXECUTOR lane",
     ),
     Mutation(
         MOCK_B20,
-        "} else if (policyType == MINT_RECEIVER_POLICY) {\n            $.mintPolicyIds = ($.mintPolicyIds & ~mask) | uint256(newPolicyId);",
-        "} else if (policyType == MINT_RECEIVER_POLICY) {\n            $.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
-        "_writePolicyId: MINT_RECEIVER_POLICY writes to transferPolicyIds slot (wrong storage var)",
+        "} else if (policyScope == MINT_RECEIVER_POLICY) {\n            $.mintPolicyIds.receiver = newPolicyId;",
+        "} else if (policyScope == MINT_RECEIVER_POLICY) {\n            $.transferPolicyIds.receiver = newPolicyId;",
+        "_writePolicyId: MINT_RECEIVER_POLICY writes to transfer lane (wrong storage field)",
     ),
     Mutation(
         MOCK_B20,
-        "$.transferPolicyIds = ($.transferPolicyIds & ~mask) | uint256(newPolicyId);",
-        "$.transferPolicyIds = ($.transferPolicyIds & mask) | uint256(newPolicyId);",
-        "_writePolicyId: mask not inverted on SENDER write (zeroes RECEIVER + EXECUTOR lanes)",
+        "if (policyScope == MINT_RECEIVER_POLICY) return $.mintPolicyIds.receiver;",
+        "if (policyScope == MINT_RECEIVER_POLICY) return $.transferPolicyIds.receiver;",
+        "_readPolicyId: MINT_RECEIVER_POLICY reads transfer lane (wrong storage field)",
     ),
     # === _writeStablecoinStorage ===
     Mutation(
         MOCK_FACTORY,
-        "_writeString(\n            token,\n            MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET),\n            currency_\n        );",
-        "_writeString(\n            token,\n            MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET),\n            currency_\n        );",
+        "_writeString(token, MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET), currency_);",
+        "_writeString(token, MockB20Storage.slotOf(MockB20Storage.NAME_OFFSET), currency_);",
         "_writeStablecoinStorage: writes currency to base-token NAME slot instead of variant namespace",
     ),
     Mutation(
         MOCK_FACTORY,
-        "        _writeString(\n            token,\n            MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET),\n            currency_\n        );\n    }",
+        "        _writeString(token, MockB20StablecoinStorage.slotOf(MockB20StablecoinStorage.CURRENCY_OFFSET), currency_);\n    }",
         "        // currency write elided\n    }",
         "_writeStablecoinStorage: never writes the currency field (silent: currency() returns empty)",
     ),

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -130,6 +130,10 @@ interface IB20Factory {
     /// @dev Reverts with `InvalidDecimals` when an asset `decimals` is outside `[B20Constants.MIN_ASSET_DECIMALS, B20Constants.MAX_ASSET_DECIMALS]`.
     /// @dev Reverts with `TokenAlreadyExists` when a token already exists at the derived address.
     /// @dev Reverts with `InitCallFailed` (or the bubbled inner reason) when any entry in `initCalls` reverts.
+    /// @dev Each `initCall` executes on the new token within the creation (bootstrap) window, during which the
+    ///      token's role / policy / pause authorization gates are bypassed for factory-originated calls — so
+    ///      admin-gated setup (e.g. `grantRole`, `updatePolicy`, `updateSupplyCap`) succeeds without the factory
+    ///      holding any role. The window closes when `createB20` returns; the factory retains no persisted access.
     ///
     /// @param variant   Which variant struct `params` decodes as.
     /// @param salt      Caller-chosen salt for deterministic address derivation.

--- a/test/lib/B20FactoryLibTest.sol
+++ b/test/lib/B20FactoryLibTest.sol
@@ -18,5 +18,4 @@ import {BaseTest} from "test/lib/BaseTest.sol";
 /// the rest of the suite. No `setUp` extension is needed.
 contract B20FactoryLibTest is BaseTest {
     // No additional state; `BaseTest`'s actor labels and helpers are sufficient.
-
-    }
+}

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -408,12 +408,15 @@ abstract contract MockB20 is IB20 {
     function pausedFeatures() external view returns (PausableFeature[] memory) {
         uint256 vectors = MockB20Storage.layout().pausedVectors;
         uint256 count;
-        for (uint256 i = 0; i < 4; i++) {
+        // Bound the scan off `type(PausableFeature).max` so it tracks the enum as variants are
+        // added or removed (the REDEEM variant was removed in BOP-251) rather than a stale literal.
+        uint256 featureCount = uint256(type(PausableFeature).max) + 1;
+        for (uint256 i = 0; i < featureCount; i++) {
             if (((vectors >> i) & uint256(1)) == 1) count++;
         }
         PausableFeature[] memory result = new PausableFeature[](count);
         uint256 idx;
-        for (uint256 i = 0; i < 4; i++) {
+        for (uint256 i = 0; i < featureCount; i++) {
             if (((vectors >> i) & uint256(1)) == 1) {
                 // forge-lint: disable-next-line(unsafe-typecast)
                 result[idx++] = PausableFeature(uint8(i));

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -100,10 +100,9 @@ contract MockB20Factory is IB20Factory {
         //       Per-variant features gate which variants can be created at
         //       any moment. Variant-feature mapping:
         //         STABLECOIN → B20_STABLECOIN
-        //         ASSET / DEFAULT → B20_ASSET
-        //       (DEFAULT is folded under `B20_ASSET` until BOP-253 removes
-        //       the variant; the dedicated `B20_TOKEN` feature was retired
-        //       by BOP-257.)
+        //         ASSET      → B20_ASSET
+        //       (The dedicated `B20_TOKEN` feature was retired by BOP-257
+        //       and the `DEFAULT` variant by BOP-253.)
         _enforceActivationGates(variant);
 
         // -- 1. Decode + validate, get the common params --
@@ -147,6 +146,9 @@ contract MockB20Factory is IB20Factory {
             decimals = 6;
             currency_ = p.currency;
         } else {
+            // Unreachable in Solidity: an out-of-range `B20Variant` is rejected by ABI
+            // enum-decoding (Panic 0x21) before this body runs. Retained to mirror the Rust
+            // precompile, which decodes the raw discriminator and surfaces this typed revert.
             revert InvalidVariant();
         }
 
@@ -260,7 +262,7 @@ contract MockB20Factory is IB20Factory {
     // ============================================================
 
     /// @dev Reverts with `IActivationRegistry.FeatureNotActivated(feature)` if
-    ///      the variant-specific gate (`B20_ASSET` for ASSET / DEFAULT,
+    ///      the variant-specific gate (`B20_ASSET` for ASSET,
     ///      `B20_STABLECOIN` for STABLECOIN) is not currently activated in
     ///      the registry. Factored out of `createB20` to keep the dispatcher
     ///      body under the EVM stack-depth limit.

--- a/test/regression/B20Removals.t.sol
+++ b/test/regression/B20Removals.t.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {B20Constants} from "src/lib/B20Constants.sol";
+
+import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+
+/// @title  B20 removal regression suite
+///
+/// @notice Locks in the *removals* from the B-20 asset rework (the
+///         redemption subsystem, batched burn / burn-from, and the `DEFAULT` token variant).
+///         Each test asserts that a function/selector that USED to exist
+///         on the surface no longer resolves, so a future reintroduction
+///         — or a Rust precompile in `base/base` that still exposes the
+///         retired surface — fails here.
+///
+/// @dev    These are *selector-absence* assertions: the token mock (and
+///         the live precompile in fork mode) carries no fallback, so a
+///         call to a removed selector cannot succeed. The same test body
+///         is meaningful against the mock (proves the Solidity reference
+///         dropped the surface) and against the live precompile under
+///         `LIVE_PRECOMPILES=true ... --fork-url` (proves `base/base`
+///         dropped it too). Args are irrelevant — dispatch fails before
+///         decoding for an unknown selector — but old signatures are
+///         reproduced verbatim so each `bytes4` matches the historical
+///         selector exactly.
+///
+///         Removal provenance:
+///         - Redemption subsystem (`redeem`, `redeemWithMemo`,
+///           `minimumRedeemable`, `updateMinimumRedeemable`,
+///           `REDEEM_SENDER_POLICY`, the `REDEEM` pausable feature) — removed in BOP-251.
+///         - `batchBurn` + `BURN_FROM_ROLE` — removed in BOP-250.
+///         - `DEFAULT` B-20 variant — removed in BOP-253.
+contract B20RemovalsTest is B20AssetTest {
+    /// @dev Asserts a low-level call of `signature` (with `args` appended) to the token reverts,
+    ///      i.e. the selector no longer resolves on the B-20 surface.
+    function _assertSelectorRemoved(bytes memory callData, string memory err) internal {
+        (bool ok,) = address(token).call(callData);
+        assertFalse(ok, err);
+    }
+
+    // ============================================================
+    //                    REDEMPTION SUBSYSTEM
+    // ============================================================
+
+    /// @notice Verifies the `redeem(uint256)` selector no longer resolves on the B-20 surface
+    /// @dev Redemption subsystem removed (BOP-251); a reintroduced `redeem` entrypoint trips this.
+    function test_redeem_revert_selectorRemoved(uint256 amount) public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("redeem(uint256)", amount), "redeem(uint256) must not resolve (removed BOP-251)"
+        );
+    }
+
+    /// @notice Verifies the `redeemWithMemo(uint256,bytes32)` selector no longer resolves
+    /// @dev Memo'd redemption removed alongside the redemption subsystem (BOP-251).
+    function test_redeemWithMemo_revert_selectorRemoved(uint256 amount, bytes32 memo) public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("redeemWithMemo(uint256,bytes32)", amount, memo),
+            "redeemWithMemo(uint256,bytes32) must not resolve (removed BOP-251)"
+        );
+    }
+
+    /// @notice Verifies the `minimumRedeemable()` getter no longer resolves
+    /// @dev The redemption floor parameter was removed with the redemption subsystem (BOP-251).
+    function test_minimumRedeemable_revert_selectorRemoved() public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("minimumRedeemable()"), "minimumRedeemable() must not resolve (removed BOP-251)"
+        );
+    }
+
+    /// @notice Verifies the `updateMinimumRedeemable(uint256)` setter no longer resolves
+    /// @dev The redemption floor setter was removed with the redemption subsystem (BOP-251).
+    function test_updateMinimumRedeemable_revert_selectorRemoved(uint256 newMin) public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("updateMinimumRedeemable(uint256)", newMin),
+            "updateMinimumRedeemable(uint256) must not resolve (removed BOP-251)"
+        );
+    }
+
+    /// @notice Verifies the `REDEEM_SENDER_POLICY()` policy-scope constant no longer resolves
+    /// @dev The redemption policy lane was removed with the redemption subsystem (BOP-251).
+    function test_redeemSenderPolicy_revert_selectorRemoved() public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("REDEEM_SENDER_POLICY()"),
+            "REDEEM_SENDER_POLICY() must not resolve (removed BOP-251)"
+        );
+    }
+
+    /// @notice Verifies the `PausableFeature` enum has no fourth (`REDEEM`) member
+    /// @dev `isPaused(PausableFeature)` ABI-decodes its arg as the enum; an out-of-range value (3)
+    ///      reverts (Panic 0x21). Index 2 (`BURN`) still decodes, bracketing the enum at exactly
+    ///      {TRANSFER, MINT, BURN}. The `REDEEM` feature was removed in BOP-251.
+    function test_isPaused_revert_noRedeemFeature() public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("isPaused(uint8)", uint8(3)),
+            "isPaused must reject enum index 3 (REDEEM removed BOP-251)"
+        );
+
+        (bool ok,) = address(token).call(abi.encodeWithSignature("isPaused(uint8)", uint8(2)));
+        assertTrue(ok, "isPaused must still accept enum index 2 (BURN)");
+    }
+
+    /// @notice Verifies the all-features-paused bitmask covers exactly three features
+    /// @dev `ALL_FEATURES_PAUSED == 7` is `TRANSFER | MINT | BURN` (0b111); a fourth feature
+    ///      (REDEEM) would push it to 15. Pins the feature count at the library source-of-truth.
+    function test_allFeaturesPaused_success_threeFeatureBitmask() public pure {
+        assertEq(B20Constants.ALL_FEATURES_PAUSED, 7, "ALL_FEATURES_PAUSED must be TRANSFER|MINT|BURN (0b111)");
+    }
+
+    // ============================================================
+    //                 BATCHED BURN / BURN-FROM
+    // ============================================================
+
+    /// @notice Verifies the `batchBurn(address[],uint256[])` selector no longer resolves
+    /// @dev Batched burn was removed in BOP-250; only `batchMint` remains on the asset variant.
+    function test_batchBurn_revert_selectorRemoved(address account, uint256 amount) public {
+        address[] memory accounts = _singletonAddresses(account);
+        uint256[] memory amounts = _singletonUints(amount);
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("batchBurn(address[],uint256[])", accounts, amounts),
+            "batchBurn(address[],uint256[]) must not resolve (removed BOP-250)"
+        );
+    }
+
+    /// @notice Verifies the `BURN_FROM_ROLE()` role constant no longer resolves
+    /// @dev The burn-from role was removed with batched burn in BOP-250; `burnBlocked` is the
+    ///      remaining seize path and is gated by `BURN_BLOCKED_ROLE`.
+    function test_burnFromRole_revert_selectorRemoved() public {
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("BURN_FROM_ROLE()"), "BURN_FROM_ROLE() must not resolve (removed BOP-250)"
+        );
+    }
+
+    // ============================================================
+    //                      DEFAULT VARIANT
+    // ============================================================
+
+    /// @notice Verifies the factory rejects a third (`DEFAULT`) variant discriminator
+    /// @dev `B20Variant` is now exactly {ASSET=0, STABLECOIN=1} (BOP-253 removed DEFAULT).
+    ///      `createB20` ABI-decodes `variant` as the enum, so discriminator 2 reverts (Panic 0x21)
+    ///      before reaching the factory body. A reintroduced third variant would let this succeed.
+    function test_createB20_revert_defaultVariantRemoved(bytes32 salt) public {
+        bytes memory params = abi.encode(_assetParams());
+        (bool ok,) = address(factory)
+            .call(abi.encodeWithSelector(IB20Factory.createB20.selector, uint8(2), salt, params, new bytes[](0)));
+        assertFalse(ok, "createB20 must reject variant discriminator 2 (DEFAULT removed BOP-253)");
+    }
+}

--- a/test/regression/B20Renames.t.sol
+++ b/test/regression/B20Renames.t.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {B20Constants} from "src/lib/B20Constants.sol";
+
+import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+
+/// @title  B20 rename regression suite
+///
+/// @notice Locks in the *renames* from the B-20 asset rework: the
+///         operator role (`SECURITY_OPERATOR_ROLE` → `OPERATOR_ROLE`,
+///         BOP-248), share-ratio scaling (`sharesToTokensRatio`/`toShares`/
+///         `sharesOf`/`updateShareRatio` → `multiplier`/`toScaledBalance`/
+///         `scaledBalanceOf`/`updateMultiplier`, BOP-249), and the
+///         activation feature namespace (`base.b20_security` → `base.b20_asset`,
+///         `base.b20_token` removed, BOP-257). Each test asserts the new
+///         surface is present and correct AND the old surface is gone, so the
+///         rename cannot silently regress in either the Solidity reference or
+///         the `base/base` Rust precompile (under fork mode).
+///
+/// @dev    Old-selector absence is checked with low-level calls (the token
+///         carries no fallback, so a retired selector cannot resolve). New
+///         surface is checked with typed calls that only compile against the
+///         current interface.
+contract B20RenamesTest is B20AssetTest {
+    /// @dev Asserts a removed selector no longer resolves on the token surface.
+    function _assertSelectorRemoved(bytes memory callData, string memory err) internal {
+        (bool ok,) = address(token).call(callData);
+        assertFalse(ok, err);
+    }
+
+    // ============================================================
+    //              OPERATOR ROLE (BOP-248 rename)
+    // ============================================================
+
+    /// @notice Verifies the operator role is exposed as `OPERATOR_ROLE` and the legacy
+    ///         `SECURITY_OPERATOR_ROLE` selector is gone
+    /// @dev BOP-248 renamed `SECURITY_OPERATOR_ROLE` → `OPERATOR_ROLE`; the wire value
+    ///      (`keccak256("OPERATOR_ROLE")`) and library source-of-truth must agree, and the old
+    ///      getter must not resolve.
+    function test_operatorRole_success_renamedFromSecurityOperator() public {
+        assertEq(asset().OPERATOR_ROLE(), keccak256("OPERATOR_ROLE"), "OPERATOR_ROLE must equal its keccak preimage");
+        assertEq(asset().OPERATOR_ROLE(), B20Constants.OPERATOR_ROLE, "OPERATOR_ROLE must match B20Constants");
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("SECURITY_OPERATOR_ROLE()"),
+            "SECURITY_OPERATOR_ROLE() must not resolve (renamed to OPERATOR_ROLE in BOP-248)"
+        );
+    }
+
+    // ============================================================
+    //              MULTIPLIER (BOP-249 rename)
+    // ============================================================
+
+    /// @notice Verifies share-ratio scaling is exposed under the `multiplier` names and the legacy
+    ///         share-ratio selectors are gone
+    /// @dev BOP-249 renamed the share-ratio surface to multiplier scaling. The new getters resolve
+    ///      (a fresh token reports a WAD multiplier), and every legacy selector must not resolve.
+    function test_multiplier_success_renamedFromShareRatio(uint256 rawBalance) public {
+        rawBalance = bound(rawBalance, 0, type(uint128).max);
+
+        // New surface resolves and behaves (1:1 at the WAD default).
+        assertEq(asset().multiplier(), asset().WAD_PRECISION(), "fresh multiplier must default to WAD");
+        assertEq(asset().toScaledBalance(rawBalance), rawBalance, "toScaledBalance is identity at WAD");
+        assertEq(asset().toRawBalance(rawBalance), rawBalance, "toRawBalance is identity at WAD");
+
+        // Legacy share-ratio surface is gone.
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("sharesToTokensRatio()"),
+            "sharesToTokensRatio() must not resolve (renamed to multiplier() in BOP-249)"
+        );
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("toShares(uint256)", rawBalance),
+            "toShares(uint256) must not resolve (renamed to toScaledBalance in BOP-249)"
+        );
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("sharesOf(address)", alice),
+            "sharesOf(address) must not resolve (renamed to scaledBalanceOf in BOP-249)"
+        );
+        _assertSelectorRemoved(
+            abi.encodeWithSignature("updateShareRatio(uint256)", rawBalance),
+            "updateShareRatio(uint256) must not resolve (renamed to updateMultiplier in BOP-249)"
+        );
+    }
+
+    // ============================================================
+    //          METADATA vs OPERATOR GATING (BOP-248)
+    // ============================================================
+    // BOP-248 split the asset variant's authority: the metadata
+    // setters (updateName / updateSymbol / updateContractURI /
+    // updateExtraMetadata) are gated by METADATA_ROLE, while the
+    // operator actions (announce / updateMultiplier) are gated by
+    // OPERATOR_ROLE. The two tests below pin that split from both sides.
+
+    /// @notice Verifies `updateExtraMetadata` is gated by METADATA_ROLE, not OPERATOR_ROLE
+    /// @dev An OPERATOR_ROLE-only holder is rejected with the METADATA_ROLE selector; a
+    ///      METADATA_ROLE holder succeeds. Locks the BOP-248 gating split for metadata writes.
+    function test_updateExtraMetadata_success_gatedByMetadataRole(string calldata value) public {
+        // Operator (OPERATOR_ROLE only) cannot write metadata.
+        _grantOperator();
+        vm.prank(operator);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, operator, B20Constants.METADATA_ROLE)
+        );
+        asset().updateExtraMetadata(METADATA_EXAMPLE_1, value);
+
+        // METADATA_ROLE holder can.
+        _grantRole(B20Constants.METADATA_ROLE, bob);
+        vm.prank(bob);
+        asset().updateExtraMetadata(METADATA_EXAMPLE_1, value);
+        assertEq(asset().extraMetadata(METADATA_EXAMPLE_1), value, "metadata write by METADATA_ROLE must persist");
+    }
+
+    /// @notice Verifies `updateMultiplier` is gated by OPERATOR_ROLE, not METADATA_ROLE
+    /// @dev A METADATA_ROLE-only holder is rejected with the OPERATOR_ROLE selector — the inverse
+    ///      of the metadata-gating test, confirming the two authorities are genuinely distinct.
+    function test_updateMultiplier_revert_metadataRoleInsufficient(uint256 newMultiplier) public {
+        newMultiplier = bound(newMultiplier, 1, type(uint128).max);
+        _grantRole(B20Constants.METADATA_ROLE, bob);
+        vm.prank(bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(IB20.AccessControlUnauthorizedAccount.selector, bob, B20Constants.OPERATOR_ROLE)
+        );
+        asset().updateMultiplier(newMultiplier);
+    }
+
+    /// @notice Verifies METADATA_ROLE is administered by DEFAULT_ADMIN_ROLE on a freshly created token
+    /// @dev Pins the role-admin wiring: the asset variant does not set a custom admin for METADATA_ROLE,
+    ///      so it defaults to DEFAULT_ADMIN_ROLE (the default admin grants/revokes METADATA_ROLE).
+    ///      Authority over metadata *operations* is separate and split per the two tests above
+    ///      (writes need METADATA_ROLE; operator actions need OPERATOR_ROLE).
+    function test_metadataRole_success_administeredByDefaultAdmin() public view {
+        assertEq(
+            token.getRoleAdmin(B20Constants.METADATA_ROLE),
+            B20Constants.DEFAULT_ADMIN_ROLE,
+            "METADATA_ROLE admin must default to DEFAULT_ADMIN_ROLE"
+        );
+    }
+
+    // ============================================================
+    //        ACTIVATION FEATURE NAMESPACE (BOP-257 rename)
+    // ============================================================
+
+    /// @notice Verifies the asset activation feature is keyed on the `base.b20_asset` namespace
+    /// @dev BOP-257 renamed `base.b20_security` → `base.b20_asset`. This is the cross-language
+    ///      contract with the Rust `ActivationFeature` enum; a preimage drift desyncs the gate.
+    function test_b20Asset_success_keyedOnAssetNamespace() public pure {
+        assertEq(
+            ActivationRegistryFeatureList.B20_ASSET,
+            keccak256("base.b20_asset"),
+            "B20_ASSET must equal keccak256(\"base.b20_asset\")"
+        );
+    }
+
+    /// @notice Verifies the asset feature is not keyed on either retired namespace
+    /// @dev BOP-257 renamed `base.b20_security` and removed `base.b20_token`. Asserting the asset
+    ///      id differs from both retired preimages locks against an accidental revert to the old
+    ///      namespace string.
+    function test_b20Asset_success_notKeyedOnLegacyNamespaces() public pure {
+        assertTrue(
+            ActivationRegistryFeatureList.B20_ASSET != keccak256("base.b20_security"),
+            "B20_ASSET must not use the retired base.b20_security namespace (renamed BOP-257)"
+        );
+        assertTrue(
+            ActivationRegistryFeatureList.B20_ASSET != keccak256("base.b20_token"),
+            "B20_ASSET must not use the retired base.b20_token namespace (removed BOP-257)"
+        );
+    }
+}

--- a/test/unit/B20Asset/batch/batchMint.t.sol
+++ b/test/unit/B20Asset/batch/batchMint.t.sol
@@ -114,6 +114,31 @@ contract B20AssetBatchMintTest is B20AssetTest {
         asset().batchMint(recipients, amounts);
     }
 
+    /// @notice Verifies batchMint reverts when any recipient is the zero address, mid-batch
+    /// @dev Per-element zero-receiver guard fires inside the loop (after PAUSE + MINT_ROLE +
+    ///      length/empty guards). A zero in a non-first slot proves the check is per-element, and
+    ///      the all-or-nothing contract means the earlier valid element's mint is unwound too:
+    ///      total supply stays zero after the revert.
+    function test_batchMint_revert_zeroRecipient(address validRecipient, uint256 a1, uint256 a2) public {
+        _assumeValidActor(validRecipient);
+        a1 = bound(a1, 0, type(uint128).max);
+        a2 = bound(a2, 0, type(uint128).max);
+        _grantRole(B20Constants.MINT_ROLE, minter);
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = validRecipient;
+        recipients[1] = address(0);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = a1;
+        amounts[1] = a2;
+
+        vm.prank(minter);
+        vm.expectRevert(abi.encodeWithSelector(IB20.InvalidReceiver.selector, address(0)));
+        asset().batchMint(recipients, amounts);
+
+        assertEq(token.totalSupply(), 0, "all-or-nothing: earlier element's mint must unwind");
+    }
+
     /// @notice Verifies batchMint succeeds with a single recipient and credits the balance
     /// @dev Single-element happy path; total supply and recipient balance both move by amount.
     function test_batchMint_success_singleRecipient(address to, uint256 amount) public {

--- a/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
+import {IB20Security} from "src/interfaces/IB20Security.sol";
+
+import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+
+contract B20FactoryLibEncodeUpdateMultiplierTest is B20FactoryLibTest {
+    /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20Security.updateMultiplier, ...)`.
+    /// @dev    Pins the selector binding and uint argument shape for the bootstrap multiplier
+    ///         init call. The security variant's scaled-balance reads all derive from the
+    ///         multiplier this call seeds, so a selector/arg drift would silently mis-scale balances.
+    function test_encodeUpdateMultiplier_success_matchesAbiEncodeCall(uint256 newMultiplier) public pure {
+        bytes memory expected = abi.encodeCall(IB20Security.updateMultiplier, (newMultiplier));
+        bytes memory actual = B20FactoryLib.encodeUpdateMultiplier(newMultiplier);
+        assertEq(actual, expected, "init-call must match abi.encodeCall(IB20Security.updateMultiplier, ...)");
+    }
+}

--- a/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
@@ -2,18 +2,18 @@
 pragma solidity ^0.8.20;
 
 import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Security} from "src/interfaces/IB20Security.sol";
+import {IB20Asset} from "src/interfaces/IB20Asset.sol";
 
 import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateMultiplierTest is B20FactoryLibTest {
-    /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20Security.updateMultiplier, ...)`.
+    /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20Asset.updateMultiplier, ...)`.
     /// @dev    Pins the selector binding and uint argument shape for the bootstrap multiplier
-    ///         init call. The security variant's scaled-balance reads all derive from the
+    ///         init call. The asset variant's scaled-balance reads all derive from the
     ///         multiplier this call seeds, so a selector/arg drift would silently mis-scale balances.
     function test_encodeUpdateMultiplier_success_matchesAbiEncodeCall(uint256 newMultiplier) public pure {
-        bytes memory expected = abi.encodeCall(IB20Security.updateMultiplier, (newMultiplier));
+        bytes memory expected = abi.encodeCall(IB20Asset.updateMultiplier, (newMultiplier));
         bytes memory actual = B20FactoryLib.encodeUpdateMultiplier(newMultiplier);
-        assertEq(actual, expected, "init-call must match abi.encodeCall(IB20Security.updateMultiplier, ...)");
+        assertEq(actual, expected, "init-call must match abi.encodeCall(IB20Asset.updateMultiplier, ...)");
     }
 }


### PR DESCRIPTION
## Summary

Codifies the BOP-247..257 rename/removal wave as a regression suite, repairs the mutation-testing harness, closes coverage gaps, and reconciles natspec/docs drift. Regression tests use selector presence/absence so the same body runs against the mock locally and the live precompiles under `--fork-url` (fork-test spec checks).

Rebased onto current `main` (incl. #126, the IB20Security→IB20Asset rename).

## Commits
1. `test(regression)` — `B20Removals.t.sol` / `B20Renames.t.sol` (17 tests): redemption subsystem, batchBurn/BURN_FROM_ROLE, REDEEM feature, removed DEFAULT variant; OPERATOR_ROLE, multiplier, METADATA/OPERATOR split, base.b20_asset namespace.
2. `test(mutate)` — repair `script/mutate.py` (was crashing; ~1/3 patterns stale). 70/70 killed.
3. `test` — coverage gaps: `encodeUpdateMultiplier` (only untested encoder) + standalone `batchMint` zero-recipient revert. B20FactoryLib → 100% funcs.
4. `fix(test)` — drift-proof `pausedFeatures` loop bound (mutation survivor: dead `i<4` from the REDEEM removal).
5. `docs(factory)` — document initCall bootstrap-privilege in the interface; clarify the retained `InvalidVariant` branch.
6. `style` — fix a pre-existing forge-fmt issue on an empty contract body so the branch is fmt-clean.

All green: **602 tests, fmt clean (forge 1.7.1), mutation 70/70.**

## BOP-258 checklist
- [x] Old names removed (redeem, batch burn, BURN_FROM_ROLE, ISIN, minimum_redeemable, DEFAULT variant, b20_security/b20_token, share ratio)
- [x] New names present & accessible (OPERATOR_ROLE, base.b20_asset, B20_ASSET, multiplier)
- [x] METADATA_ROLE gating — pinned actual behavior (ticket's "gated by OPERATOR_ROLE" is a typo; metadata setters need METADATA_ROLE, operator actions need OPERATOR_ROLE, METADATA_ROLE admin defaults to DEFAULT_ADMIN_ROLE)
- [x] IB20Security→IB20Asset rename — landed in #126; member renames asserted here, storage namespace pinned by existing storage tests

## Notes for review
- **`InvalidVariant` kept (not removed).** It reads as unreachable in the Solidity mock (ABI enum-decode panics before the dispatcher `else`), but the out-of-range-variant tests document it as the intended Rust precompile revert — a Solidity-vs-precompile modeling limitation, not dead spec. Added a clarifying comment. Removing it would drop a real spec assertion; flagging rather than deleting.
- Mutation survivor was a genuine find: `pausedFeatures` carried a stale `i<4` bound from the REDEEM removal — now derived from `type(PausableFeature).max`.
- Fork-mode (`LIVE_PRECOMPILES=true … --fork-url`) not run in this environment; the regression tests are written to run there unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
