### PR TITLE
fix(test): move activation bootstrap inside LIVE_PRECOMPILES guard

### DIFF
--- a/test/lib/B20FactoryLibTest.sol
+++ b/test/lib/B20FactoryLibTest.sol
@@ -18,5 +18,4 @@ import {BaseTest} from "test/lib/BaseTest.sol";
 /// the rest of the suite. No `setUp` extension is needed.
 contract B20FactoryLibTest is BaseTest {
     // No additional state; `BaseTest`'s actor labels and helpers are sufficient.
-
-    }
+}

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -98,19 +98,21 @@ abstract contract BaseTest is Test {
             vm.etch(StdPrecompiles.B20_FACTORY_ADDRESS, type(MockB20Factory).runtimeCode);
             vm.etch(StdPrecompiles.POLICY_REGISTRY_ADDRESS, type(MockPolicyRegistry).runtimeCode);
             vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
-        }
 
-        // Activate every B-20 feature so the bulk of the suite — which
-        // exercises behaviors orthogonal to the activation gate — doesn't
-        // have to repeat the bootstrap. Tests that pin the gating
-        // behavior itself (`B20Factory/activation.t.sol`) deactivate the
-        // specific feature under test before exercising it.
-        address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
-        vm.startPrank(activationAdmin);
-        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
-        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
-        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);
-        vm.stopPrank();
+            // Activate every B-20 feature so the bulk of the suite — which
+            // exercises behaviors orthogonal to the activation gate — doesn't
+            // have to repeat the bootstrap. Tests that pin the gating
+            // behavior itself (`B20Factory/activation.t.sol`) deactivate the
+            // specific feature under test before exercising it.
+            // In fork mode (LIVE_PRECOMPILES=true) the features are already
+            // active on the live chain, so this bootstrap is skipped.
+            address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
+            vm.startPrank(activationAdmin);
+            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
+            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
+            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);
+            vm.stopPrank();
+        }
     }
 
     /// @notice Filters out addresses that are unsafe to use as a fuzzed


### PR DESCRIPTION
## Motivation

Fork tests were failing with `AlreadyActivated(0xecfa...)` in `setUp()` for every test suite. The cause: PR #116 added an unconditional activation bootstrap in `BaseTest.setUp()` that calls `activate(B20_ASSET)`, `activate(B20_STABLECOIN)`, and `activate(POLICY_REGISTRY)`. In unit test mode this works fine because the `MockActivationRegistry` starts empty. In fork mode (`LIVE_PRECOMPILES=true`) the features are already active on the live chain, so `activate()` reverts.

## What changed

Moved the three `activate()` calls inside the existing `!LIVE_PRECOMPILES` guard. The mocks start from a clean state and need the bootstrap; the live chain already has the features active and does not.

## Test plan

- Unit tests: 583 passed, 0 failed
- Fork tests: 0 `AlreadyActivated` errors (fix confirmed). 116 pre-existing Rust/Solidity divergence failures unrelated to this change.

type=routine
risk=low
impact=sev5