### PR TITLE
fix(fork-tests): update FEATURE_IDS for B20_ASSET rename (BOP-265)

### DIFF
--- a/script/run-fork-tests.sh
+++ b/script/run-fork-tests.sh
@@ -80,10 +80,9 @@ LOG_FILE="${ANVIL_LOG:-/tmp/anvil.log}"
 # If a new feature is added there, append its ID here.
 FEATURE_IDS=(
     0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800  # B20_FACTORY
-    0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752  # B20_TOKEN
     0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f  # POLICY_REGISTRY
-    0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601  # B20_STABLECOIN (added base/base#2806)
-    0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6  # B20_SECURITY (added base/base#2813)
+    0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601  # B20_STABLECOIN
+    0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c  # B20_ASSET (renamed from base.b20_security, BOP-257)
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/script/run-fork-tests.sh
+++ b/script/run-fork-tests.sh
@@ -26,7 +26,7 @@
 #   PORT             local RPC port for anvil (default: 8546)
 #   ACTIVATION_ADMIN address authorized to activate features
 #                    (default: 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc, the
-#                    canonical local-dev admin codified in base/base#2811)
+#                    canonical local-dev admin)
 #   ANVIL_LOG        anvil stdout/stderr log path (default: /tmp/anvil.log)
 #
 # Exit codes:
@@ -76,13 +76,12 @@ ACTIVATION_ADMIN="${ACTIVATION_ADMIN:-0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc
 REGISTRY=0x8453000000000000000000000000000000000001
 LOG_FILE="${ANVIL_LOG:-/tmp/anvil.log}"
 
-# Feature IDs from base/base/crates/common/precompiles/src/activation/storage.rs.
-# If a new feature is added there, append its ID here.
+# Feature IDs mirror the canonical set in test/lib/mocks/ActivationRegistryFeatureList.sol
+# (the Solidity reference is the source of truth). If a feature is added there, append its ID here.
 FEATURE_IDS=(
-    0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800  # B20_FACTORY
+    0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c  # B20_ASSET
     0xb582ebae03f16fee49a6763f78df482fb11ae73f103ed0d330bbe556aa90a43f  # POLICY_REGISTRY
     0xecfa0def2c10020caaf65e6155aa69c84b24892aaef76eeac52e0e2b3a0b8601  # B20_STABLECOIN
-    0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c  # B20_ASSET (renamed from base.b20_security, BOP-257)
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
[BOP-265](https://linear.app/coinbase/issue/BOP-265/base-std-update-run-fork-testssh-feature-ids-for-b20-asset-rename)

## Motivation

`script/run-fork-tests.sh` hardcodes the feature IDs that are activated on the fork chain before tests run. After BOP-257 renamed the asset feature from `base.b20_security` to `base.b20_asset`, the script still activated the old ID. Tests that deactivate `B20_ASSET` and expect `FeatureNotActivated` were failing because the Rust precompile checked for the new ID while the script only activated the old one.

Also removes the retired `B20_TOKEN` feature entry and `B20_FACTORY` (which was eliminated separately).

## What changed

In `script/run-fork-tests.sh`:
- Removed `0x47a1afe8d3d691b87e090ee972d223a11f4da971ff5416c04985bb2393aca752` (B20_TOKEN = `keccak256("base.b20_token")`, retired)
- Removed `0x78751e29c8bcc0d609ab18e9fbc4158e73f7db25ae2ee095dad42e2578b1e800` (B20_FACTORY = `keccak256("base.b20_factory")`, eliminated)
- Replaced `0x83d32fab502ae0e8bc4352a117767262cb5e47cc8d67a744008ed4ff03fcf5e6` (old B20_SECURITY) with `0xcdcc772fe4cbdb1029f822861176d09e646db96723d4c1e82ddfdeb8163ef54c` (B20_ASSET = `keccak256("base.b20_asset")`)

The canonical list of feature IDs is defined in [`test/lib/mocks/ActivationRegistryFeatureList.sol`](https://github.com/base/base-std/blob/main/test/lib/mocks/ActivationRegistryFeatureList.sol) and the corresponding Rust constants live in [`crates/common/precompiles/src/activation/storage.rs`](https://github.com/base/base/blob/main/crates/common/precompiles/src/activation/storage.rs) in base/base.

type=routine
risk=low
impact=sev5