### PR TITLE
fix(policy-registry): guard createPolicy against uint56 counter overflow (BOP-248)

### DIFF
--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -42,6 +42,9 @@ interface IPolicyRegistry {
     /// @notice `finalizeUpdateAdmin` was called with no pending admin staged.
     error NoPendingAdmin();
 
+    /// @notice The policy counter has reached the maximum uint56 value and cannot be incremented.
+    error CounterOverflow();
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -69,6 +72,7 @@ interface IPolicyRegistry {
     /// @notice Creates a new policy with no initial members. Permissionless.
     ///
     /// @dev Reverts with `ZeroAddress` when `admin` is `address(0)`.
+    /// @dev Reverts with `CounterOverflow` when the policy counter has reached its maximum value.
     ///
     /// @param admin      Initial admin authorized to modify membership and transfer or renounce administration.
     /// @param policyType BLOCKLIST or ALLOWLIST.
@@ -80,6 +84,7 @@ interface IPolicyRegistry {
     ///
     /// @dev Reverts with `ZeroAddress` when `admin` is `address(0)`. Takes precedence over `BatchSizeTooLarge`.
     /// @dev Reverts with `BatchSizeTooLarge` when `accounts.length` exceeds the registry limit.
+    /// @dev Reverts with `CounterOverflow` when the policy counter has reached its maximum value.
     ///
     /// @param admin      Initial admin authorized to modify membership and transfer or renounce administration.
     /// @param policyType BLOCKLIST or ALLOWLIST.

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -42,9 +42,6 @@ interface IPolicyRegistry {
     /// @notice `finalizeUpdateAdmin` was called with no pending admin staged.
     error NoPendingAdmin();
 
-    /// @notice The policy counter has reached the maximum uint56 value and cannot be incremented.
-    error CounterOverflow();
-
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -72,7 +69,7 @@ interface IPolicyRegistry {
     /// @notice Creates a new policy with no initial members. Permissionless.
     ///
     /// @dev Reverts with `ZeroAddress` when `admin` is `address(0)`.
-    /// @dev Reverts with `CounterOverflow` when the policy counter has reached its maximum value.
+    /// @dev Panics with arithmetic overflow (Panic 0x11) when the policy counter has reached its maximum value.
     ///
     /// @param admin      Initial admin authorized to modify membership and transfer or renounce administration.
     /// @param policyType BLOCKLIST or ALLOWLIST.
@@ -84,7 +81,7 @@ interface IPolicyRegistry {
     ///
     /// @dev Reverts with `ZeroAddress` when `admin` is `address(0)`. Takes precedence over `BatchSizeTooLarge`.
     /// @dev Reverts with `BatchSizeTooLarge` when `accounts.length` exceeds the registry limit.
-    /// @dev Reverts with `CounterOverflow` when the policy counter has reached its maximum value.
+    /// @dev Panics with arithmetic overflow (Panic 0x11) when the policy counter has reached its maximum value.
     ///
     /// @param admin      Initial admin authorized to modify membership and transfer or renounce administration.
     /// @param policyType BLOCKLIST or ALLOWLIST.

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -243,7 +243,8 @@ contract MockPolicyRegistry is IPolicyRegistry {
         _writeBuiltins();
         MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
         uint56 counter = $.nextCounter;
-        if (counter >= type(uint56).max) revert CounterOverflow();
+        // Solidity checked arithmetic panics with Panic(0x11) on uint56 overflow,
+        // matching the Rust precompile which reverts with Panic(UnderOverflow) at COUNTER_MASK.
         $.nextCounter = counter + 1;
         newPolicyId = _makeId({policyType: policyType, counter: counter});
         $.policies[newPolicyId] = _encode(admin);

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -243,11 +243,8 @@ contract MockPolicyRegistry is IPolicyRegistry {
         _writeBuiltins();
         MockPolicyRegistryStorage.Layout storage $ = MockPolicyRegistryStorage.layout();
         uint56 counter = $.nextCounter;
-        // No overflow guard: at one policy per 2-second block, exhausting the
-        // 56-bit counter space (~7.2e16 values) takes ~4.6 billion years.
-        unchecked {
-            $.nextCounter = counter + 1;
-        }
+        if (counter >= type(uint56).max) revert CounterOverflow();
+        $.nextCounter = counter + 1;
         newPolicyId = _makeId({policyType: policyType, counter: counter});
         $.policies[newPolicyId] = _encode(admin);
         emit PolicyCreated(newPolicyId, msg.sender, policyType);

--- a/test/unit/PolicyRegistry/createPolicy.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy.t.sol
@@ -125,4 +125,22 @@ contract PolicyRegistryCreatePolicyTest is PolicyRegistryTest {
         vm.prank(caller);
         policyRegistry.createPolicy(admin_, pt);
     }
+
+    /// @notice Verifies createPolicy reverts with CounterOverflow when the counter is at uint56 max.
+    /// @dev    Slot-writes nextCounter to type(uint56).max to avoid iterating 2^56 times.
+    function test_createPolicy_revert_counterOverflow(address caller, address admin_, uint8 typeIdx) public {
+        _assumeValidCaller(caller);
+        vm.assume(admin_ != address(0));
+        IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
+
+        vm.store(
+            address(policyRegistry),
+            MockPolicyRegistryStorage.nextCounterSlot(),
+            bytes32(uint256(type(uint56).max))
+        );
+
+        vm.expectRevert(IPolicyRegistry.CounterOverflow.selector);
+        vm.prank(caller);
+        policyRegistry.createPolicy(admin_, pt);
+    }
 }

--- a/test/unit/PolicyRegistry/createPolicy.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy.t.sol
@@ -126,20 +126,19 @@ contract PolicyRegistryCreatePolicyTest is PolicyRegistryTest {
         policyRegistry.createPolicy(admin_, pt);
     }
 
-    /// @notice Verifies createPolicy reverts with CounterOverflow when the counter is at uint56 max.
+    /// @notice Verifies createPolicy panics with arithmetic overflow when the counter is at uint56 max.
     /// @dev    Slot-writes nextCounter to type(uint56).max to avoid iterating 2^56 times.
+    ///         Matches the Rust precompile which reverts with Panic(UnderOverflow) = Panic(0x11).
     function test_createPolicy_revert_counterOverflow(address caller, address admin_, uint8 typeIdx) public {
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));
         IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
 
         vm.store(
-            address(policyRegistry),
-            MockPolicyRegistryStorage.nextCounterSlot(),
-            bytes32(uint256(type(uint56).max))
+            address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot(), bytes32(uint256(type(uint56).max))
         );
 
-        vm.expectRevert(IPolicyRegistry.CounterOverflow.selector);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
         vm.prank(caller);
         policyRegistry.createPolicy(admin_, pt);
     }

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -10,7 +10,7 @@ import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorag
 ///
 /// @notice **Canonical order:**
 ///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
-///         2. COUNTER-OVERFLOW (nextCounter == type(uint56).max) → `CounterOverflow`
+///         2. COUNTER-OVERFLOW (nextCounter == type(uint56).max) → `Panic(0x11)`
 ///
 ///         Walks from the first failing condition to success.
 contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
@@ -22,9 +22,7 @@ contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
 
         // 1. ZERO-ADMIN: admin == address(0) → ZeroAddress
         vm.store(
-            address(policyRegistry),
-            MockPolicyRegistryStorage.nextCounterSlot(),
-            bytes32(uint256(type(uint56).max))
+            address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot(), bytes32(uint256(type(uint56).max))
         );
         vm.prank(caller);
         vm.expectRevert(IPolicyRegistry.ZeroAddress.selector);
@@ -32,9 +30,9 @@ contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
 
         // Fix: use a non-zero admin.
 
-        // 2. COUNTER-OVERFLOW: nextCounter == type(uint56).max → CounterOverflow
+        // 2. COUNTER-OVERFLOW: nextCounter == type(uint56).max → Panic(0x11)
         vm.prank(caller);
-        vm.expectRevert(IPolicyRegistry.CounterOverflow.selector);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
         policyRegistry.createPolicy(admin_, pt);
 
         // Fix: reset counter to a valid value.

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -4,13 +4,15 @@ pragma solidity ^0.8.20;
 import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
 
 import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @title Sequential revert-order test for `createPolicy`.
 ///
 /// @notice **Canonical order:**
 ///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
+///         2. COUNTER-OVERFLOW (nextCounter == type(uint56).max) → `CounterOverflow`
 ///
-///         Single revert condition; walks from that condition to success.
+///         Walks from the first failing condition to success.
 contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
     /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
     function test_createPolicy_revertOrder(address caller, address admin_, uint8 typeIdx) public {
@@ -19,11 +21,24 @@ contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
         IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);
 
         // 1. ZERO-ADMIN: admin == address(0) → ZeroAddress
+        vm.store(
+            address(policyRegistry),
+            MockPolicyRegistryStorage.nextCounterSlot(),
+            bytes32(uint256(type(uint56).max))
+        );
         vm.prank(caller);
         vm.expectRevert(IPolicyRegistry.ZeroAddress.selector);
         policyRegistry.createPolicy(address(0), pt);
 
         // Fix: use a non-zero admin.
+
+        // 2. COUNTER-OVERFLOW: nextCounter == type(uint56).max → CounterOverflow
+        vm.prank(caller);
+        vm.expectRevert(IPolicyRegistry.CounterOverflow.selector);
+        policyRegistry.createPolicy(admin_, pt);
+
+        // Fix: reset counter to a valid value.
+        vm.store(address(policyRegistry), MockPolicyRegistryStorage.nextCounterSlot(), bytes32(uint256(2)));
 
         // Success
         vm.prank(caller);


### PR DESCRIPTION
[BOP-248](https://linear.app/coinbase/issue/BOP-248)

## Motivation

The Rust precompile reverts with `Panic(UnderOverflow)` (Panic code `0x11`) when the
policy counter reaches `COUNTER_MASK = (1 << 56) - 1`. The original Solidity mock used
`unchecked { $.nextCounter = counter + 1; }` with a comment explaining overflow was
unreachable in practice, which silently wrapped the `uint56` counter to 0 on overflow.
A wrapped counter produces a policy ID that collides with the `ALWAYS_ALLOW_ID` built-in
sentinel. This was identified as finding I-04 in the BlockSec audit (BLOCKSEC-5173).

## What changed

- Removed `unchecked` from `$.nextCounter = counter + 1` in `MockPolicyRegistry._create()`.
  Solidity's default checked arithmetic panics with `Panic(0x11)` on `uint56` overflow,
  matching the Rust behavior exactly.
- `createPolicy` and `createPolicyWithAccounts` NatSpec updated to document the panic.
- `test_createPolicy_revert_counterOverflow` added to `createPolicy.t.sol`, slot-writing
  `nextCounter` to `type(uint56).max` and expecting `Panic(0x11)`.
- `createPolicy_revertOrder.t.sol` updated with the counter overflow as the second
  revert condition, after `ZeroAddress`.

## What was considered

Adding a named `CounterOverflow()` custom error was tried first, but the Rust precompile
emits `Panic(0x11)` (arithmetic underflow/overflow), not a custom ABI error. Using
Solidity's checked arithmetic produces the same panic code with no extra code.

Removing the Rust overflow guard to match the old silent-wrap behavior was rejected:
a wrapped counter collides with `ALWAYS_ALLOW_ID`, which would be a serious invariant
violation.
