### PR TITLE
fix(ci): correct fork-test PASS/FAIL counting in result comment

### DIFF
--- a/.github/workflows/base-std-fork-tests.yml
+++ b/.github/workflows/base-std-fork-tests.yml
@@ -140,8 +140,8 @@ jobs:
         shell: bash
         run: |
           output="$RUNNER_TEMP/fork-test-output.txt"
-          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
-          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
+          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || true); passed=${passed:-0}
+          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || true); failed=${failed:-0}
 
           {
             echo "## Fork Test Results"
@@ -168,8 +168,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           output="$RUNNER_TEMP/fork-test-output.txt"
-          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
-          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
+          passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || true); passed=${passed:-0}
+          failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || true); failed=${failed:-0}
           marker="<!-- fork-test-results -->"
 
           if [ ! -s "$output" ] || [ "$((passed + failed))" -eq 0 ]; then


### PR DESCRIPTION
## The bug

The "Summarize fork test results" and "Comment fork test results on PR" steps counted passing/failing tests with:

```bash
passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || echo 0)
failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || echo 0)
```

`grep -c` is dual-natured: when there are **no matches** it prints the count `0` *and* exits non-zero. The `|| echo 0` fallback then fires and appends a **second** `0`, so `failed` becomes the two-line string `"0\n0"`.

The later guard

```bash
if [ ! -s "$output" ] || [ "$((passed + failed))" -eq 0 ]; then
```

then expands to an arithmetic expression containing a newline (`$((603 + 0<newline>0))`), which raises `syntax error in expression`. Under the step's `set -e`, that aborts the step, and the follow-up `gh api ... --field body=...` runs with an unset body, returning **HTTP 422**.

## Why it only surfaces on all-green runs

The bug is self-masking. The extra `0` is only appended when `grep -c` finds **zero** matches, i.e. when no tests fail. So the broken arithmetic only happens when **every** fork test passes — which is exactly the first all-green run that exposed it. Any run with at least one failing test took a clean path.

## The fix

```bash
passed=$(grep -c '\[PASS\]' "$output" 2>/dev/null || true); passed=${passed:-0}
failed=$(grep -c '\[FAIL' "$output" 2>/dev/null || true); failed=${failed:-0}
```

- `|| true` keeps the command substitution's exit status `0`, so `set -e` does not abort and no second `0` is echoed.
- `${var:-0}` defaults to `0` when the output file is missing or empty (grep prints nothing).

Applied at **both** occurrences. Verified in a scratch shell: the old form reproduces the `0\n0` value and the `syntax error in expression` abort on all-green input; the new form yields `passed=<n>`, `failed=0`, a clean `$((passed + failed))`, and also returns `0`/`0` for empty/missing files and correct counts when failures exist.

## Scope

Infra-only. No contract or test changes — only `.github/workflows/base-std-fork-tests.yml`. The same buggy lines exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
