### PR TITLE
fix(test): Align Live Precompile Tests

### DIFF
--- a/test/regression/B20Renames.t.sol
+++ b/test/regression/B20Renames.t.sol
@@ -11,7 +11,7 @@ import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFe
 /// @title  B20 rename regression suite
 ///
 /// @notice Locks in the *renames* from the B-20 asset rework: the operator role
-///         (`OPERATOR_ROLE` → `OPERATOR_ROLE`), share-ratio scaling
+///         surface (`OPERATOR_ROLE`), share-ratio scaling
 ///         (`sharesToTokensRatio`/`toShares`/`sharesOf`/`updateShareRatio` → `multiplier`/
 ///         `toScaledBalance`/`scaledBalanceOf`/`updateMultiplier`), the METADATA/OPERATOR
 ///         authority split, and the `base.b20_asset` activation namespace. Each test asserts the
@@ -34,17 +34,12 @@ contract B20RenamesTest is B20AssetTest {
     //                      OPERATOR ROLE
     // ============================================================
 
-    /// @notice Verifies the operator role is exposed as `OPERATOR_ROLE` and the legacy
-    ///         `OPERATOR_ROLE` selector is gone
-    /// @dev The wire value (`keccak256("OPERATOR_ROLE")`) and library source-of-truth must agree,
-    ///      and the old getter must not resolve. Regression: BOP-248.
-    function test_operatorRole_success_renamedFromSecurityOperator() public {
+    /// @notice Verifies the operator role is exposed as `OPERATOR_ROLE`.
+    /// @dev The wire value (`keccak256("OPERATOR_ROLE")`) and library source-of-truth must agree.
+    ///      Regression: BOP-248.
+    function test_operatorRole_success_renamedFromSecurityOperator() public view {
         assertEq(asset().OPERATOR_ROLE(), keccak256("OPERATOR_ROLE"), "OPERATOR_ROLE must equal its keccak preimage");
         assertEq(asset().OPERATOR_ROLE(), B20Constants.OPERATOR_ROLE, "OPERATOR_ROLE must match B20Constants");
-        _assertSelectorRemoved(
-            abi.encodeWithSignature("OPERATOR_ROLE()"),
-            "OPERATOR_ROLE() must not resolve (renamed to OPERATOR_ROLE)"
-        );
     }
 
     // ============================================================

--- a/test/unit/PolicyRegistry/createPolicy.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy.t.sol
@@ -128,8 +128,12 @@ contract PolicyRegistryCreatePolicyTest is PolicyRegistryTest {
 
     /// @notice Verifies createPolicy panics with arithmetic overflow when the counter is at uint56 max.
     /// @dev    Slot-writes nextCounter to type(uint56).max to avoid iterating 2^56 times.
+    ///         Mock-only: `vm.store` cannot write to native precompile addresses, so this
+    ///         test is skipped when running against live precompiles.
     ///         Matches the Rust precompile which reverts with Panic(UnderOverflow) = Panic(0x11).
     function test_createPolicy_revert_counterOverflow(address caller, address admin_, uint8 typeIdx) public {
+        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));
         IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -13,9 +13,14 @@ import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorag
 ///         2. COUNTER-OVERFLOW (nextCounter == type(uint56).max) → `Panic(0x11)`
 ///
 ///         Walks from the first failing condition to success.
+///
+/// @dev    Mock-only: this test forces `nextCounter` with `vm.store`, which cannot
+///         write to native precompile addresses under `LIVE_PRECOMPILES=true`.
 contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
     /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
     function test_createPolicy_revertOrder(address caller, address admin_, uint8 typeIdx) public {
+        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));
         IPolicyRegistry.PolicyType pt = _creatablePolicyType(typeIdx);


### PR DESCRIPTION
## Summary

This fixes the live-precompile fork test failures by removing the contradictory OPERATOR_ROLE removed-selector assertion while keeping the role presence check. The PolicyRegistry counter-overflow tests are now explicitly mock-only because they force unreachable counter state with vm.store, matching the existing convention that live native precompile state may be read with vm.load but not mutated with vm.store. I validated the focused mock tests and the full fork runner with the local patched base-anvil binaries.