### PR TITLE
Normalize Solidity imports to public prefixes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,10 @@ src = "src"
 out = "out"
 libs = ["lib"]
 test = "test"
+remappings = [
+    "base-std/=src/",
+    "base-std-test/=test/",
+]
 ast = true
 
 solc = "0.8.30"

--- a/test/lib/ActivationRegistryTest.sol
+++ b/test/lib/ActivationRegistryTest.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
-import {BaseTest} from "test/lib/BaseTest.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {BaseTest} from "base-std-test/lib/BaseTest.sol";
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
 /// @notice Base test contract for `IActivationRegistry` unit tests.
 ///

--- a/test/lib/B20AssetTest.sol
+++ b/test/lib/B20AssetTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
 /// @notice Base test contract for `IB20Asset` unit tests.
 ///

--- a/test/lib/B20FactoryLibTest.sol
+++ b/test/lib/B20FactoryLibTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {BaseTest} from "test/lib/BaseTest.sol";
+import {BaseTest} from "base-std-test/lib/BaseTest.sol";
 
 /// @notice Base test contract for `B20FactoryLib` unit tests.
 ///
@@ -16,6 +16,5 @@ import {BaseTest} from "test/lib/BaseTest.sol";
 /// helper, even though the library itself does not consult `msg.sender`.
 /// Re-using those gives the test contracts a uniform vocabulary with
 /// the rest of the suite. No `setUp` extension is needed.
-contract B20FactoryLibTest is BaseTest {
-    // No additional state; `BaseTest`'s actor labels and helpers are sufficient.
-}
+/// @dev No additional state; `BaseTest`'s actor labels and helpers are sufficient.
+contract B20FactoryLibTest is BaseTest {}

--- a/test/lib/B20FactoryTest.sol
+++ b/test/lib/B20FactoryTest.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {BaseTest} from "test/lib/BaseTest.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {BaseTest} from "base-std-test/lib/BaseTest.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
 /// @notice Base test contract for `IB20Factory` unit tests, and the
 ///         parent for token-test bases (`B20Test`, `B20StablecoinTest`)

--- a/test/lib/B20StablecoinTest.sol
+++ b/test/lib/B20StablecoinTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
 /// @notice Base test contract for `IB20Stablecoin` unit tests.
 ///

--- a/test/lib/B20Test.sol
+++ b/test/lib/B20Test.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @notice Base test contract for `IB20` unit tests.
 ///

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.20;
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
 
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
-import {MockActivationRegistry} from "test/lib/mocks/MockActivationRegistry.sol";
-import {MockPolicyRegistry} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockB20Factory} from "test/lib/mocks/MockB20Factory.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {MockActivationRegistry} from "base-std-test/lib/mocks/MockActivationRegistry.sol";
+import {MockPolicyRegistry} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
+import {MockB20Factory} from "base-std-test/lib/mocks/MockB20Factory.sol";
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
 /// @notice Common base for every test contract in this suite.
 ///

--- a/test/lib/PolicyRegistryTest.sol
+++ b/test/lib/PolicyRegistryTest.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {BaseTest} from "test/lib/BaseTest.sol";
+import {BaseTest} from "base-std-test/lib/BaseTest.sol";
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Base test contract for `IPolicyRegistry` unit tests.
 ///

--- a/test/lib/mocks/MockActivationRegistry.sol
+++ b/test/lib/mocks/MockActivationRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 
-import {MockActivationRegistryStorage} from "test/lib/mocks/MockActivationRegistryStorage.sol";
+import {MockActivationRegistryStorage} from "base-std-test/lib/mocks/MockActivationRegistryStorage.sol";
 
 /// @title MockActivationRegistry
 /// @notice Reference implementation of the `IActivationRegistry` precompile.

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
 /// @title MockB20
 /// @notice Reference implementation of the `IB20` default-token surface.

--- a/test/lib/mocks/MockB20Asset.sol
+++ b/test/lib/mocks/MockB20Asset.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {MockB20} from "test/lib/mocks/MockB20.sol";
-import {MockB20AssetStorage, MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20AssetStorage, MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @title MockB20Asset
 /// @author Coinbase

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -3,17 +3,21 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
 
-import {MockB20Stablecoin} from "test/lib/mocks/MockB20Stablecoin.sol";
-import {MockB20Asset} from "test/lib/mocks/MockB20Asset.sol";
-import {MockB20} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage, MockB20AssetStorage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20Stablecoin} from "base-std-test/lib/mocks/MockB20Stablecoin.sol";
+import {MockB20Asset} from "base-std-test/lib/mocks/MockB20Asset.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
+import {
+    MockB20Storage,
+    MockB20AssetStorage,
+    MockB20StablecoinStorage
+} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @title MockB20Factory
 /// @notice Reference implementation of the `IB20Factory` precompile

--- a/test/lib/mocks/MockB20Stablecoin.sol
+++ b/test/lib/mocks/MockB20Stablecoin.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20Stablecoin} from "base-std/interfaces/IB20Stablecoin.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {MockB20} from "test/lib/mocks/MockB20.sol";
-import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20StablecoinStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @title MockB20Stablecoin
 /// @notice Reference implementation of the `IB20Stablecoin` variant.

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Canonical built-in policy ID constants. Declared as a library
 ///         so tests can reference them at compile time via

--- a/test/regression/B20Removals.t.sol
+++ b/test/regression/B20Removals.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 /// @title  B20 removal regression suite
 ///

--- a/test/regression/B20Renames.t.sol
+++ b/test/regression/B20Renames.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
 
 /// @title  B20 rename regression suite
 ///

--- a/test/unit/ActivationRegistry/activate.t.sol
+++ b/test/unit/ActivationRegistry/activate.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
-import {MockActivationRegistryStorage} from "test/lib/mocks/MockActivationRegistryStorage.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
+import {MockActivationRegistryStorage} from "base-std-test/lib/mocks/MockActivationRegistryStorage.sol";
 
 contract ActivationRegistryActivateTest is ActivationRegistryTest {
     /// @notice Verifies activate reverts when called by any non-admin caller

--- a/test/unit/ActivationRegistry/activate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/activate_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryActivateRevertOrderTest is ActivationRegistryTest {
     /// @notice Verifies Unauthorized fires before AlreadyActivated when caller is not admin

--- a/test/unit/ActivationRegistry/admin.t.sol
+++ b/test/unit/ActivationRegistry/admin.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryAdminTest is ActivationRegistryTest {
     /// @notice Verifies admin returns the configured activation admin address

--- a/test/unit/ActivationRegistry/deactivate.t.sol
+++ b/test/unit/ActivationRegistry/deactivate.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
-import {MockActivationRegistryStorage} from "test/lib/mocks/MockActivationRegistryStorage.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
+import {MockActivationRegistryStorage} from "base-std-test/lib/mocks/MockActivationRegistryStorage.sol";
 
 contract ActivationRegistryDeactivateTest is ActivationRegistryTest {
     /// @notice Verifies deactivate reverts when called by any non-admin caller

--- a/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
+++ b/test/unit/ActivationRegistry/deactivate_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryDeactivateRevertOrderTest is ActivationRegistryTest {
     /// @notice Verifies Unauthorized fires before FeatureNotActivated when caller is not admin

--- a/test/unit/ActivationRegistry/featureList.t.sol
+++ b/test/unit/ActivationRegistry/featureList.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
 
 /// @notice Pins each feature id constant in `ActivationRegistryFeatureList` to
 ///         its canonical `keccak256("base.<feature>")` preimage.

--- a/test/unit/ActivationRegistry/isActivated.t.sol
+++ b/test/unit/ActivationRegistry/isActivated.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
 
 contract ActivationRegistryIsActivatedTest is ActivationRegistryTest {
     /// @notice Verifies isActivated returns false for any feature id that has never been activated

--- a/test/unit/B20/erc20/allowance.t.sol
+++ b/test/unit/B20/erc20/allowance.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
 contract B20AllowanceTest is B20Test {
     /// @notice Verifies allowance returns zero for any unconfigured (owner, spender) pair

--- a/test/unit/B20/erc20/approve.t.sol
+++ b/test/unit/B20/erc20/approve.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20ApproveTest is B20Test {
     /// @notice Verifies approve reverts for the zero spender address

--- a/test/unit/B20/erc20/approve_revertOrder.t.sol
+++ b/test/unit/B20/erc20/approve_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `approve`.
 ///

--- a/test/unit/B20/erc20/balanceOf.t.sol
+++ b/test/unit/B20/erc20/balanceOf.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
 contract B20BalanceOfTest is B20Test {
     /// @notice Verifies balanceOf returns zero for any account that has never received tokens

--- a/test/unit/B20/erc20/decimals.t.sol
+++ b/test/unit/B20/erc20/decimals.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
 contract B20DecimalsTest is B20Test {
     /// @notice Verifies asset-token decimals are fixed at 6

--- a/test/unit/B20/erc20/name.t.sol
+++ b/test/unit/B20/erc20/name.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20NameTest is B20Test {
     /// @notice Verifies name returns the value passed to the factory at creation

--- a/test/unit/B20/erc20/symbol.t.sol
+++ b/test/unit/B20/erc20/symbol.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20SymbolTest is B20Test {
     /// @notice Verifies symbol returns the value passed to the factory at creation

--- a/test/unit/B20/erc20/totalSupply.t.sol
+++ b/test/unit/B20/erc20/totalSupply.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20TotalSupplyTest is B20Test {
     /// @notice Verifies totalSupply returns the cumulative minted-minus-burned amount

--- a/test/unit/B20/erc20/transfer.t.sol
+++ b/test/unit/B20/erc20/transfer.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20TransferTest is B20Test {
     /// @notice Verifies transfer reverts when the TRANSFER feature is paused

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20TransferFromTest is B20Test {
     /// @notice Verifies transferFrom reverts when the TRANSFER feature is paused

--- a/test/unit/B20/erc20/transferFromWithMemo_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transferFromWithMemo_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Sequential check-order test for `transferFromWithMemo`.
 ///

--- a/test/unit/B20/erc20/transferFrom_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transferFrom_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Differential check-order tests for `transferFrom`.
 ///

--- a/test/unit/B20/erc20/transferWithMemo_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transferWithMemo_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Sequential check-order test for `transferWithMemo`.
 ///

--- a/test/unit/B20/erc20/transfer_revertOrder.t.sol
+++ b/test/unit/B20/erc20/transfer_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Differential check-order tests for `transfer`.
 ///

--- a/test/unit/B20/memo/burnWithMemo.t.sol
+++ b/test/unit/B20/memo/burnWithMemo.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20BurnWithMemoTest is B20Test {
     /// @notice Verifies burnWithMemo inherits all burn guards

--- a/test/unit/B20/memo/mintWithMemo.t.sol
+++ b/test/unit/B20/memo/mintWithMemo.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20MintWithMemoTest is B20Test {
     /// @notice Verifies mintWithMemo inherits all mint guards

--- a/test/unit/B20/memo/transferFromWithMemo.t.sol
+++ b/test/unit/B20/memo/transferFromWithMemo.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20TransferFromWithMemoTest is B20Test {
     /// @notice Verifies transferFromWithMemo inherits all transferFrom guards

--- a/test/unit/B20/memo/transferWithMemo.t.sol
+++ b/test/unit/B20/memo/transferWithMemo.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20TransferWithMemoTest is B20Test {
     /// @notice Verifies transferWithMemo applies the same pause / policy / balance checks as transfer

--- a/test/unit/B20/metadata/contractURI.t.sol
+++ b/test/unit/B20/metadata/contractURI.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20ContractURITest is B20Test {
     /// @notice Verifies contractURI returns the value set at token creation

--- a/test/unit/B20/metadata/updateContractURI.t.sol
+++ b/test/unit/B20/metadata/updateContractURI.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20UpdateContractURITest is B20Test {
     /// @notice Verifies updateContractURI reverts when caller lacks METADATA_ROLE

--- a/test/unit/B20/metadata/updateContractURI_revertOrder.t.sol
+++ b/test/unit/B20/metadata/updateContractURI_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `updateContractURI`.
 ///

--- a/test/unit/B20/metadata/updateName.t.sol
+++ b/test/unit/B20/metadata/updateName.t.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20UpdateNameTest is B20Test {
     /// @notice Verifies updateName reverts when caller lacks METADATA_ROLE

--- a/test/unit/B20/metadata/updateName_revertOrder.t.sol
+++ b/test/unit/B20/metadata/updateName_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `updateName`.
 ///

--- a/test/unit/B20/metadata/updateSymbol.t.sol
+++ b/test/unit/B20/metadata/updateSymbol.t.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20UpdateSymbolTest is B20Test {
     /// @notice Verifies updateSymbol reverts when caller lacks METADATA_ROLE

--- a/test/unit/B20/metadata/updateSymbol_revertOrder.t.sol
+++ b/test/unit/B20/metadata/updateSymbol_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `updateSymbol`.
 ///

--- a/test/unit/B20/pause/isPaused.t.sol
+++ b/test/unit/B20/pause/isPaused.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20IsPausedTest is B20Test {
     /// @notice Verifies isPaused returns false for every feature on a freshly-created token

--- a/test/unit/B20/pause/pause.t.sol
+++ b/test/unit/B20/pause/pause.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20PauseTest is B20Test {
     /// @notice Verifies pause reverts when caller lacks PAUSE_ROLE

--- a/test/unit/B20/pause/pause_revertOrder.t.sol
+++ b/test/unit/B20/pause/pause_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `pause`.
 ///

--- a/test/unit/B20/pause/pausedFeatures.t.sol
+++ b/test/unit/B20/pause/pausedFeatures.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20PausedFeaturesTest is B20Test {
     /// @notice Verifies pausedFeatures returns an empty array on a freshly-created token

--- a/test/unit/B20/pause/unpause.t.sol
+++ b/test/unit/B20/pause/unpause.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20UnpauseTest is B20Test {
     /// @notice Verifies unpause reverts when caller lacks UNPAUSE_ROLE

--- a/test/unit/B20/pause/unpause_revertOrder.t.sol
+++ b/test/unit/B20/pause/unpause_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `unpause`.
 ///

--- a/test/unit/B20/permit/DOMAIN_SEPARATOR.t.sol
+++ b/test/unit/B20/permit/DOMAIN_SEPARATOR.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20DomainSeparatorTest is B20Test {
     /// @dev Canonical EIP-2612 domain type hash, recomputed in-test from the

--- a/test/unit/B20/permit/eip712Domain.t.sol
+++ b/test/unit/B20/permit/eip712Domain.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20Eip712DomainTest is B20Test {
     /// @notice Verifies eip712Domain returns the documented (name, version, chainId, verifyingContract) shape

--- a/test/unit/B20/permit/nonces.t.sol
+++ b/test/unit/B20/permit/nonces.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
 contract B20NoncesTest is B20Test {
     /// @notice Verifies nonces returns zero for any account that has never permitted

--- a/test/unit/B20/permit/permit.t.sol
+++ b/test/unit/B20/permit/permit.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20PermitTest is B20Test {
     /// @notice Verifies permit reverts when the deadline has passed

--- a/test/unit/B20/permit/permit_revertOrder.t.sol
+++ b/test/unit/B20/permit/permit_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `permit`.
 ///

--- a/test/unit/B20/policy/policyId.t.sol
+++ b/test/unit/B20/policy/policyId.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20PolicyIdTest is B20Test {
     /// @notice Verifies policyId returns 0 (always-allow built-in) for any supported slot before configuration

--- a/test/unit/B20/policy/policyTypeConstants.t.sol
+++ b/test/unit/B20/policy/policyTypeConstants.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @notice Folds the four trivial policy-type constant readers
 ///         into one file since each is a one-stub assertion against a

--- a/test/unit/B20/policy/updatePolicy.t.sol
+++ b/test/unit/B20/policy/updatePolicy.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20UpdatePolicyTest is B20Test {
     /// @notice Reads the policy id stored in the slot lane that

--- a/test/unit/B20/policy/updatePolicy_revertOrder.t.sol
+++ b/test/unit/B20/policy/updatePolicy_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Differential check-order tests for `updatePolicy`.
 ///

--- a/test/unit/B20/roles/getRoleAdmin.t.sol
+++ b/test/unit/B20/roles/getRoleAdmin.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20GetRoleAdminTest is B20Test {
     /// @notice Verifies getRoleAdmin returns DEFAULT_ADMIN_ROLE for any role that hasn't been customized

--- a/test/unit/B20/roles/grantRole.t.sol
+++ b/test/unit/B20/roles/grantRole.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20GrantRoleTest is B20Test {
     /// @notice Verifies grantRole reverts when caller does not hold the role's admin role

--- a/test/unit/B20/roles/grantRole_revertOrder.t.sol
+++ b/test/unit/B20/roles/grantRole_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `grantRole`.
 ///

--- a/test/unit/B20/roles/hasRole.t.sol
+++ b/test/unit/B20/roles/hasRole.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 contract B20HasRoleTest is B20Test {
     /// @notice Verifies hasRole returns false for any (role, account) pair that has never been granted

--- a/test/unit/B20/roles/renounceLastAdmin.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20RenounceLastAdminTest is B20Test {
     /// @notice Verifies renounceLastAdmin reverts when caller does not hold DEFAULT_ADMIN_ROLE

--- a/test/unit/B20/roles/renounceLastAdmin_revertOrder.t.sol
+++ b/test/unit/B20/roles/renounceLastAdmin_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `renounceLastAdmin`.
 ///

--- a/test/unit/B20/roles/renounceRole.t.sol
+++ b/test/unit/B20/roles/renounceRole.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20RenounceRoleTest is B20Test {
     /// @notice Verifies renounceRole reverts when callerConfirmation does not equal msg.sender

--- a/test/unit/B20/roles/renounceRole_revertOrder.t.sol
+++ b/test/unit/B20/roles/renounceRole_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `renounceRole`.
 ///

--- a/test/unit/B20/roles/revokeRole.t.sol
+++ b/test/unit/B20/roles/revokeRole.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20RevokeRoleTest is B20Test {
     /// @notice Verifies revokeRole reverts when caller does not hold the role's admin role

--- a/test/unit/B20/roles/revokeRole_revertOrder.t.sol
+++ b/test/unit/B20/roles/revokeRole_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `revokeRole`.
 ///

--- a/test/unit/B20/roles/roleConstants.t.sol
+++ b/test/unit/B20/roles/roleConstants.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @notice Folds the seven trivial role-constant readers into one
 ///         file since each is a one-stub assertion against a fixed keccak

--- a/test/unit/B20/roles/setRoleAdmin.t.sol
+++ b/test/unit/B20/roles/setRoleAdmin.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20SetRoleAdminTest is B20Test {
     /// @notice Verifies setRoleAdmin reverts when caller does not hold the role's current admin role

--- a/test/unit/B20/roles/setRoleAdmin_revertOrder.t.sol
+++ b/test/unit/B20/roles/setRoleAdmin_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `setRoleAdmin`.
 ///

--- a/test/unit/B20/supply/burn.t.sol
+++ b/test/unit/B20/supply/burn.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20BurnTest is B20Test {
     /// @notice Verifies burn reverts when caller lacks BURN_ROLE

--- a/test/unit/B20/supply/burnBlocked.t.sol
+++ b/test/unit/B20/supply/burnBlocked.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20BurnBlockedTest is B20Test {
     /// @notice Verifies burnBlocked reverts when caller lacks BURN_BLOCKED_ROLE

--- a/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
+++ b/test/unit/B20/supply/burnBlocked_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Differential check-order tests for `burnBlocked`.
 ///

--- a/test/unit/B20/supply/burnWithMemo_revertOrder.t.sol
+++ b/test/unit/B20/supply/burnWithMemo_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Sequential check-order test for `burnWithMemo` (self-burn with memo).
 ///

--- a/test/unit/B20/supply/burn_revertOrder.t.sol
+++ b/test/unit/B20/supply/burn_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `burn` (self-burn).
 ///

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20MintTest is B20Test {
     /// @notice Verifies mint reverts when caller lacks MINT_ROLE

--- a/test/unit/B20/supply/mintWithMemo_revertOrder.t.sol
+++ b/test/unit/B20/supply/mintWithMemo_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Sequential check-order test for `mintWithMemo`.
 ///

--- a/test/unit/B20/supply/mint_revertOrder.t.sol
+++ b/test/unit/B20/supply/mint_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @title Differential check-order tests for `mint`.
 ///

--- a/test/unit/B20/supply/supplyCap.t.sol
+++ b/test/unit/B20/supply/supplyCap.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Test} from "test/lib/B20Test.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
 
 contract B20SupplyCapTest is B20Test {
     /// @notice Verifies supplyCap returns the value set at token creation

--- a/test/unit/B20/supply/updateSupplyCap.t.sol
+++ b/test/unit/B20/supply/updateSupplyCap.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20UpdateSupplyCapTest is B20Test {
     /// @notice Verifies updateSupplyCap reverts when caller lacks DEFAULT_ADMIN_ROLE

--- a/test/unit/B20/supply/updateSupplyCap_revertOrder.t.sol
+++ b/test/unit/B20/supply/updateSupplyCap_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `updateSupplyCap`.
 ///

--- a/test/unit/B20Asset/announcement/announce.t.sol
+++ b/test/unit/B20Asset/announcement/announce.t.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
 contract B20AssetAnnounceTest is B20AssetTest {
     /// @notice Verifies announce reverts when caller lacks OPERATOR_ROLE

--- a/test/unit/B20Asset/announcement/announce_revertOrder.t.sol
+++ b/test/unit/B20Asset/announcement/announce_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 /// @title Differential check-order tests for `announce`.
 ///

--- a/test/unit/B20Asset/announcement/isAnnouncementIdUsed.t.sol
+++ b/test/unit/B20Asset/announcement/isAnnouncementIdUsed.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20AssetStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20AssetIsAnnouncementIdUsedTest is B20AssetTest {
     /// @notice Verifies isAnnouncementIdUsed returns false for an unseen id

--- a/test/unit/B20Asset/batch/batchMint.t.sol
+++ b/test/unit/B20Asset/batch/batchMint.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20AssetBatchMintTest is B20AssetTest {
     /// @notice Verifies batchMint reverts when recipients.length != amounts.length

--- a/test/unit/B20Asset/batch/batchMint_revertOrder.t.sol
+++ b/test/unit/B20Asset/batch/batchMint_revertOrder.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
-import {B20Constants} from "test/lib/mocks/MockB20.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
+import {B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
 
 /// @title Differential check-order tests for `batchMint` (asset variant).
 ///

--- a/test/unit/B20Asset/batch/batchMint_rollback.t.sol
+++ b/test/unit/B20Asset/batch/batchMint_rollback.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
 /// @title B20AssetBatchMintRollbackTest
 /// @notice Verifies a revert mid-batchMint leaves no orphan token state.

--- a/test/unit/B20Asset/constants/precisionConstants.t.sol
+++ b/test/unit/B20Asset/constants/precisionConstants.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetPrecisionConstantsTest is B20AssetTest {
     /// @notice Verifies WAD_PRECISION equals 1e18

--- a/test/unit/B20Asset/constants/roleConstants.t.sol
+++ b/test/unit/B20Asset/constants/roleConstants.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetRoleConstantsTest is B20AssetTest {
     /// @notice Verifies OPERATOR_ROLE equals keccak256("OPERATOR_ROLE")

--- a/test/unit/B20Asset/extraMetadata/extraMetadata.t.sol
+++ b/test/unit/B20Asset/extraMetadata/extraMetadata.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetExtraMetadataTest is B20AssetTest {
     /// @notice Verifies extraMetadata returns the empty string for an unset entry

--- a/test/unit/B20Asset/extraMetadata/updateExtraMetadata.t.sol
+++ b/test/unit/B20Asset/extraMetadata/updateExtraMetadata.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
 contract B20AssetUpdateExtraMetadataTest is B20AssetTest {
     /// @notice Verifies updateExtraMetadata reverts when caller lacks METADATA_ROLE

--- a/test/unit/B20Asset/extraMetadata/updateExtraMetadata_revertOrder.t.sol
+++ b/test/unit/B20Asset/extraMetadata/updateExtraMetadata_revertOrder.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 /// @title Sequential revert-order test for `updateExtraMetadata`.
 ///

--- a/test/unit/B20Asset/multiplier/multiplier.t.sol
+++ b/test/unit/B20Asset/multiplier/multiplier.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20AssetStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20AssetMultiplierTest is B20AssetTest {
     /// @notice Verifies the default (unwritten) multiplier resolves to WAD_PRECISION

--- a/test/unit/B20Asset/multiplier/scaledBalanceOf.t.sol
+++ b/test/unit/B20Asset/multiplier/scaledBalanceOf.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetScaledBalanceOfTest is B20AssetTest {
     /// @notice Verifies scaledBalanceOf is zero for an account with no balance

--- a/test/unit/B20Asset/multiplier/toRawBalance.t.sol
+++ b/test/unit/B20Asset/multiplier/toRawBalance.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetToRawBalanceTest is B20AssetTest {
     /// @notice Verifies toRawBalance is the identity on a fresh token (WAD multiplier)

--- a/test/unit/B20Asset/multiplier/toScaledBalance.t.sol
+++ b/test/unit/B20Asset/multiplier/toScaledBalance.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 contract B20AssetToScaledBalanceTest is B20AssetTest {
     /// @notice Verifies toScaledBalance is the identity on a fresh token (WAD multiplier)

--- a/test/unit/B20Asset/multiplier/updateMultiplier.t.sol
+++ b/test/unit/B20Asset/multiplier/updateMultiplier.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {MockB20AssetStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 contract B20AssetUpdateMultiplierTest is B20AssetTest {
     /// @notice Verifies updateMultiplier reverts when caller lacks OPERATOR_ROLE

--- a/test/unit/B20Asset/multiplier/updateMultiplier_revertOrder.t.sol
+++ b/test/unit/B20Asset/multiplier/updateMultiplier_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
 /// @title Sequential revert-order test for `updateMultiplier`.
 ///

--- a/test/unit/B20Asset/policy/policyId.t.sol
+++ b/test/unit/B20Asset/policy/policyId.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
 contract B20AssetPolicyIdTest is B20AssetTest {
     /// @notice Verifies policyId still resolves the four base policy types on the asset variant.

--- a/test/unit/B20Asset/policy/updatePolicy.t.sol
+++ b/test/unit/B20Asset/policy/updatePolicy.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 
-import {B20Constants} from "src/lib/B20Constants.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract B20AssetUpdatePolicyTest is B20AssetTest {
     /// @notice Verifies updatePolicy still routes base policy types through the inherited write path on the asset variant.

--- a/test/unit/B20Factory/createB20_activation.t.sol
+++ b/test/unit/B20Factory/createB20_activation.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IActivationRegistry} from "src/interfaces/IActivationRegistry.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
-import {ActivationRegistryFeatureList} from "test/lib/mocks/ActivationRegistryFeatureList.sol";
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 /// @notice Pins the activation gating on `createB20`.
 ///

--- a/test/unit/B20Factory/createB20_asset_decimals.t.sol
+++ b/test/unit/B20Factory/createB20_asset_decimals.t.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {MockB20} from "test/lib/mocks/MockB20.sol";
-import {MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {MockB20} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20AssetStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 /// @notice Coverage for the asset variant's configurable `decimals` field.
 ///

--- a/test/unit/B20Factory/createB20_revertOrder.t.sol
+++ b/test/unit/B20Factory/createB20_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
 
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 /// @title Differential check-order tests for `createB20`.
 ///

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -3,16 +3,16 @@ pragma solidity ^0.8.20;
 
 import {Vm} from "forge-std/Vm.sol";
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IB20Stablecoin} from "base-std/interfaces/IB20Stablecoin.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
 
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockB20Storage, MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
+import {MockB20Storage, MockB20StablecoinStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 contract B20FactoryCreateB20Test is B20FactoryTest {
     // Role constants are accessed as `MINT_ROLE` etc. — these are

--- a/test/unit/B20Factory/getTokenAddress.t.sol
+++ b/test/unit/B20Factory/getTokenAddress.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
 
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 contract B20FactoryGetTokenAddressTest is B20FactoryTest {
     /// @notice Wraps an arbitrary uint8 into a valid B20Variant ordinal.

--- a/test/unit/B20Factory/isB20.t.sol
+++ b/test/unit/B20Factory/isB20.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 contract B20FactoryIsB20Test is B20FactoryTest {
     /// @notice Verifies isB20 returns true for a freshly-created token

--- a/test/unit/B20Factory/isB20Initialized.t.sol
+++ b/test/unit/B20Factory/isB20Initialized.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
-import {B20FactoryTest} from "test/lib/B20FactoryTest.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 
 contract B20FactoryIsB20InitializedTest is B20FactoryTest {
     /// @notice Verifies isB20Initialized returns false for any address lacking the B-20 prefix

--- a/test/unit/B20FactoryLib/buildExtraMetadataUpdates.t.sol
+++ b/test/unit/B20FactoryLib/buildExtraMetadataUpdates.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibBuildExtraMetadataUpdatesTest is B20FactoryLibTest {
     /// @notice External wrapper that re-exposes

--- a/test/unit/B20FactoryLib/buildRoleGrants.t.sol
+++ b/test/unit/B20FactoryLib/buildRoleGrants.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {B20Constants} from "src/lib/B20Constants.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibBuildRoleGrantsTest is B20FactoryLibTest {
     /// @notice External wrapper that re-exposes

--- a/test/unit/B20FactoryLib/concat.t.sol
+++ b/test/unit/B20FactoryLib/concat.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibConcatTest is B20FactoryLibTest {
     /// @notice Concatenating two empty arrays produces an empty result.

--- a/test/unit/B20FactoryLib/encodeAssetCreateParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeAssetCreateParams.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeAssetCreateParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20AssetCreateParams`

--- a/test/unit/B20FactoryLib/encodeBatchMint.t.sol
+++ b/test/unit/B20FactoryLib/encodeBatchMint.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeBatchMintTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20Asset.batchMint, ...)`.

--- a/test/unit/B20FactoryLib/encodeGrantRole.t.sol
+++ b/test/unit/B20FactoryLib/encodeGrantRole.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeGrantRoleTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.grantRole, ...)`.

--- a/test/unit/B20FactoryLib/encodeRevokeRole.t.sol
+++ b/test/unit/B20FactoryLib/encodeRevokeRole.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeRevokeRoleTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.revokeRole, ...)`.

--- a/test/unit/B20FactoryLib/encodeSetRoleAdmin.t.sol
+++ b/test/unit/B20FactoryLib/encodeSetRoleAdmin.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeSetRoleAdminTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.setRoleAdmin, ...)`.

--- a/test/unit/B20FactoryLib/encodeStablecoinCreateParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinCreateParams.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeStablecoinCreateParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20StablecoinCreateParams`

--- a/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
+++ b/test/unit/B20FactoryLib/encodeStablecoinEventParams.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Factory} from "src/interfaces/IB20Factory.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeStablecoinEventParamsTest is B20FactoryLibTest {
     /// @notice Verifies the output decodes back to a `B20StablecoinEventParams`

--- a/test/unit/B20FactoryLib/encodeUpdateContractURI.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateContractURI.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateContractURITest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.updateContractURI, ...)`.

--- a/test/unit/B20FactoryLib/encodeUpdateExtraMetadata.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateExtraMetadata.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateExtraMetadataTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches

--- a/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateMultiplier.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20Asset} from "src/interfaces/IB20Asset.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20Asset} from "base-std/interfaces/IB20Asset.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateMultiplierTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20Asset.updateMultiplier, ...)`.

--- a/test/unit/B20FactoryLib/encodeUpdateName.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateName.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateNameTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.updateName, ...)`.

--- a/test/unit/B20FactoryLib/encodeUpdatePolicy.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdatePolicy.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdatePolicyTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.updatePolicy, ...)`.

--- a/test/unit/B20FactoryLib/encodeUpdateSupplyCap.t.sol
+++ b/test/unit/B20FactoryLib/encodeUpdateSupplyCap.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20FactoryLib} from "src/lib/B20FactoryLib.sol";
-import {IB20} from "src/interfaces/IB20.sol";
+import {B20FactoryLib} from "base-std/lib/B20FactoryLib.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20FactoryLibTest} from "test/lib/B20FactoryLibTest.sol";
+import {B20FactoryLibTest} from "base-std-test/lib/B20FactoryLibTest.sol";
 
 contract B20FactoryLibEncodeUpdateSupplyCapTest is B20FactoryLibTest {
     /// @notice Verifies the encoded blob matches `abi.encodeCall(IB20.updateSupplyCap, ...)`.

--- a/test/unit/B20Stablecoin/currency.t.sol
+++ b/test/unit/B20Stablecoin/currency.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+import {IB20Stablecoin} from "base-std/interfaces/IB20Stablecoin.sol";
 
-import {B20StablecoinTest} from "test/lib/B20StablecoinTest.sol";
+import {B20StablecoinTest} from "base-std-test/lib/B20StablecoinTest.sol";
 
 contract B20StablecoinCurrencyTest is B20StablecoinTest {
     /// @notice Verifies currency returns the string passed to the factory at creation

--- a/test/unit/PolicyRegistry/createPolicy.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryCreatePolicyTest is PolicyRegistryTest {
     /// @notice Verifies createPolicy reverts when admin is the zero address

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryCreatePolicyWithAccountsTest is PolicyRegistryTest {
     /// @notice Verifies createPolicyWithAccounts reverts when admin is the zero address

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `createPolicyWithAccounts`.
 ///

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @title PolicyRegistryCreatePolicyWithAccountsRollbackTest
 /// @notice Verifies a revert from createPolicyWithAccounts leaves no orphan

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @title Sequential revert-order test for `createPolicy`.
 ///

--- a/test/unit/PolicyRegistry/finalizeUpdateAdmin.t.sol
+++ b/test/unit/PolicyRegistry/finalizeUpdateAdmin.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryFinalizeUpdateAdminTest is PolicyRegistryTest {
     /// @notice Verifies finalizeUpdateAdmin reverts when no admin transfer is in flight

--- a/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/finalizeUpdateAdmin_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `finalizeUpdateAdmin`.
 ///

--- a/test/unit/PolicyRegistry/isAuthorized.t.sol
+++ b/test/unit/PolicyRegistry/isAuthorized.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract PolicyRegistryIsAuthorizedTest is PolicyRegistryTest {
     /// @notice Verifies isAuthorized on an uncreated ALLOWLIST id returns false

--- a/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
+++ b/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 contract PolicyRegistryPendingPolicyAdminTest is PolicyRegistryTest {
     /// @notice Verifies pendingPolicyAdmin returns address(0) before any transfer is staged

--- a/test/unit/PolicyRegistry/policyAdmin.t.sol
+++ b/test/unit/PolicyRegistry/policyAdmin.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract PolicyRegistryPolicyAdminTest is PolicyRegistryTest {
     /// @notice Verifies policyAdmin returns address(0) for a well-formed but uncreated id

--- a/test/unit/PolicyRegistry/policyExists.t.sol
+++ b/test/unit/PolicyRegistry/policyExists.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 contract PolicyRegistryPolicyExistsTest is PolicyRegistryTest {
     function test_policyExists_success_builtinAlwaysAllow() public view {

--- a/test/unit/PolicyRegistry/renounceAdmin.t.sol
+++ b/test/unit/PolicyRegistry/renounceAdmin.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryRenounceAdminTest is PolicyRegistryTest {
     /// @notice Verifies renounceAdmin reverts when called by any non-admin caller

--- a/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/renounceAdmin_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `renounceAdmin`.
 ///

--- a/test/unit/PolicyRegistry/stageUpdateAdmin.t.sol
+++ b/test/unit/PolicyRegistry/stageUpdateAdmin.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryStageUpdateAdminTest is PolicyRegistryTest {
     /// @notice Verifies stageUpdateAdmin reverts when called by any non-admin caller

--- a/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/stageUpdateAdmin_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `stageUpdateAdmin`.
 ///

--- a/test/unit/PolicyRegistry/updateAllowlist.t.sol
+++ b/test/unit/PolicyRegistry/updateAllowlist.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryUpdateAllowlistTest is PolicyRegistryTest {
     /// @notice Verifies updateAllowlist reverts when called by any non-admin caller

--- a/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateAllowlist_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `updateAllowlist`.
 ///

--- a/test/unit/PolicyRegistry/updateBlocklist.t.sol
+++ b/test/unit/PolicyRegistry/updateBlocklist.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 contract PolicyRegistryUpdateBlocklistTest is PolicyRegistryTest {
     /// @notice Verifies updateBlocklist reverts when called by any non-admin caller

--- a/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateBlocklist_revertOrder.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 
 /// @title Sequential revert-order test for `updateBlocklist`.
 ///

--- a/test/unit/PolicyRegistry/writeBuiltins.t.sol
+++ b/test/unit/PolicyRegistry/writeBuiltins.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Tests for the lazy built-in-policy initialization that mirrors
 ///         the Rust precompile's `PolicyRegistryStorage::write_builtins`.

--- a/test/unit/storage/B20AssetFullLayout.t.sol
+++ b/test/unit/storage/B20AssetFullLayout.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {B20Constants} from "src/lib/B20Constants.sol";
+import {B20Constants} from "base-std/lib/B20Constants.sol";
 
-import {B20AssetTest} from "test/lib/B20AssetTest.sol";
-import {MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
+import {MockB20AssetStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @notice Exhaustive layout spec for the `base.b20.asset` namespace.
 ///

--- a/test/unit/storage/B20FullLayout.t.sol
+++ b/test/unit/storage/B20FullLayout.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
-import {StdPrecompiles} from "src/StdPrecompiles.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @notice Exhaustive layout spec for the `base.b20` namespace.
 ///

--- a/test/unit/storage/B20StablecoinFullLayout.t.sol
+++ b/test/unit/storage/B20StablecoinFullLayout.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+import {IB20Stablecoin} from "base-std/interfaces/IB20Stablecoin.sol";
 
-import {B20StablecoinTest} from "test/lib/B20StablecoinTest.sol";
-import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20StablecoinTest} from "base-std-test/lib/B20StablecoinTest.sol";
+import {MockB20StablecoinStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @notice Exhaustive layout spec for the `base.b20.stablecoin` namespace.
 ///

--- a/test/unit/storage/MockActivationRegistrySlotHelpers.t.sol
+++ b/test/unit/storage/MockActivationRegistrySlotHelpers.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ActivationRegistryTest} from "test/lib/ActivationRegistryTest.sol";
-import {MockActivationRegistryStorage} from "test/lib/mocks/MockActivationRegistryStorage.sol";
+import {ActivationRegistryTest} from "base-std-test/lib/ActivationRegistryTest.sol";
+import {MockActivationRegistryStorage} from "base-std-test/lib/mocks/MockActivationRegistryStorage.sol";
 
 /// @notice Self-tests for `MockActivationRegistryStorage`'s slot-derivation helpers.
 ///

--- a/test/unit/storage/MockActivationRegistryStorage.t.sol
+++ b/test/unit/storage/MockActivationRegistryStorage.t.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {MockActivationRegistryStorage} from "test/lib/mocks/MockActivationRegistryStorage.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {MockActivationRegistryStorage} from "base-std-test/lib/mocks/MockActivationRegistryStorage.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Asserts the hardcoded `STORAGE_LOCATION` constant on
 ///         `MockActivationRegistryStorage` matches the ERC-7201 formula it documents.

--- a/test/unit/storage/MockB20SlotHelpers.t.sol
+++ b/test/unit/storage/MockB20SlotHelpers.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20} from "src/interfaces/IB20.sol";
+import {IB20} from "base-std/interfaces/IB20.sol";
 
-import {B20Test} from "test/lib/B20Test.sol";
-import {MockB20, B20Constants} from "test/lib/mocks/MockB20.sol";
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistry, PolicyRegistryConstants} from "test/lib/mocks/MockPolicyRegistry.sol";
+import {B20Test} from "base-std-test/lib/B20Test.sol";
+import {MockB20, B20Constants} from "base-std-test/lib/mocks/MockB20.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistry, PolicyRegistryConstants} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 
 /// @notice Self-tests for `MockB20Storage`'s slot-derivation and
 ///         packed-slot codec helpers. Each test sets a known value via

--- a/test/unit/storage/MockB20StablecoinSlotHelpers.t.sol
+++ b/test/unit/storage/MockB20StablecoinSlotHelpers.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IB20Stablecoin} from "src/interfaces/IB20Stablecoin.sol";
+import {IB20Stablecoin} from "base-std/interfaces/IB20Stablecoin.sol";
 
-import {B20StablecoinTest} from "test/lib/B20StablecoinTest.sol";
-import {MockB20StablecoinStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {B20StablecoinTest} from "base-std-test/lib/B20StablecoinTest.sol";
+import {MockB20StablecoinStorage} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @notice Self-tests for `MockB20StablecoinStorage`'s slot helper.
 ///

--- a/test/unit/storage/MockB20Storage.t.sol
+++ b/test/unit/storage/MockB20Storage.t.sol
@@ -3,7 +3,11 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {MockB20Storage, MockB20StablecoinStorage, MockB20AssetStorage} from "test/lib/mocks/MockB20Storage.sol";
+import {
+    MockB20Storage,
+    MockB20StablecoinStorage,
+    MockB20AssetStorage
+} from "base-std-test/lib/mocks/MockB20Storage.sol";
 
 /// @notice Asserts the hardcoded `STORAGE_LOCATION` constants on the B-20
 ///         storage libraries match the ERC-7201 formula they document.

--- a/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
+++ b/test/unit/storage/MockPolicyRegistrySlotHelpers.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Self-tests for `MockPolicyRegistryStorage`'s slot-derivation
 ///         and packed-slot codec helpers.

--- a/test/unit/storage/MockPolicyRegistryStorage.t.sol
+++ b/test/unit/storage/MockPolicyRegistryStorage.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 
-import {MockB20Storage} from "test/lib/mocks/MockB20Storage.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {MockB20Storage} from "base-std-test/lib/mocks/MockB20Storage.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Asserts the hardcoded `STORAGE_LOCATION` constant on
 ///         `MockPolicyRegistryStorage` matches the ERC-7201 formula it documents.

--- a/test/unit/storage/PolicyRegistryFullLayout.t.sol
+++ b/test/unit/storage/PolicyRegistryFullLayout.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IPolicyRegistry} from "src/interfaces/IPolicyRegistry.sol";
+import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 
-import {PolicyRegistryTest} from "test/lib/PolicyRegistryTest.sol";
-import {MockPolicyRegistryStorage} from "test/lib/mocks/MockPolicyRegistryStorage.sol";
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegistryStorage.sol";
 
 /// @notice Exhaustive layout spec for the `base.policy_registry` namespace.
 ///


### PR DESCRIPTION
Use base-std/ and base-std-test/ for base-std's internal Solidity imports so downstream consumers can import base-std-test helpers with the two public remappings only, instead of carrying compatibility remappings for raw src/ and test/ paths. Add matching local Foundry remappings so the same public prefixes resolve inside this repo.

Validation: forge fmt --check; forge test; raw src/test import scan.