### PR TITLE
ci: enforce base-std/ and base-std-test/ import prefixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,22 @@ jobs:
         if: steps.check.outputs.exit_code != '0'
         run: exit 1
 
+  import-paths:
+    name: Import Paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce base-std/ and base-std-test/ import prefixes
+        run: |
+          # Raw src/ or test/ imports must use the public remapping prefixes instead.
+          bad=$(grep -rn --include="*.sol" -E 'import(\s+\{[^}]*\}\s+from)?\s+"(src|test)/' src/ test/ || true)
+          if [ -n "$bad" ]; then
+            echo "Raw src/ or test/ imports found — use base-std/ or base-std-test/ instead:"
+            echo "$bad"
+            exit 1
+          fi
+
   fmt:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Now that #143 normalized all internal imports to use the public `base-std/` and `base-std-test/` remapping prefixes, this adds a CI gate to keep them that way.

Adds an **Import Paths** job that greps all `.sol` files in `src/` and `test/` for raw `"src/` or `"test/` imports and fails if any are found. The job requires no Foundry install — it is a pure grep — so it is fast and has no toolchain dependency.

The current codebase passes cleanly.