### PR TITLE
repo: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stevieraykatz @amiecorso @eric-ships @ilikesymmetry @rayyan224


### PR DESCRIPTION
## Motivation

Establishes the five core maintainers as code owners across the whole repo. Once this is merged, a branch protection ruleset requiring 1 code owner review will be added, so all PRs — including ones from external contributors — get a sanity check before landing.

Code owners: @stevieraykatz @amiecorso @eric-ships @ilikesymmetry @rayyan224