### PR TITLE
docs(IActivationRegistry): warn integrators not to use code presence as activation signal (BOP-322)

### DIFF
--- a/src/interfaces/IActivationRegistry.sol
+++ b/src/interfaces/IActivationRegistry.sol
@@ -4,6 +4,12 @@ pragma solidity >=0.8.20 <0.9.0;
 /// @title IActivationRegistry
 /// @notice Singleton precompile that gates Base-native features behind an activation admin. Each feature
 ///         is identified by an opaque `bytes32` id and is either active or inactive.
+///
+/// @dev    INTEGRATION NOTE — do not use code presence as a feature gate. The precompile writes a
+///         bytecode marker to its own storage account on the first successful `activate` call and does
+///         not clear it when features are subsequently deactivated. `EXTCODESIZE` and `EXTCODEHASH` at
+///         this address therefore reflect initialisation state, not live activation state. Always use
+///         `isActivated(feature)` as the authoritative signal.
 interface IActivationRegistry {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS


### PR DESCRIPTION
## Summary

- Adds an explicit NatSpec integration note to `IActivationRegistry` warning that `EXTCODESIZE`/`EXTCODEHASH` at the registry address are not reliable signals for feature activation state (BOP-322).
- The precompile writes a bytecode marker to its storage account on first `activate` and does not clear it if features are later deactivated, so code presence only reflects initialisation, not live state.
- Directs integrators to always use `isActivated(feature)` as the authoritative source.

Companion to base/base#3366 (`ericliu/bop-322-fix-v2`) which addresses the implementation side.

## Test plan

- [ ] No logic changes; NatSpec only — review the added comment in `src/interfaces/IActivationRegistry.sol` for accuracy and clarity.