### PR TITLE
fix(IB20Factory): add NonPayable guard matching precompile (BOP-324)

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -26,6 +26,12 @@ interface IB20 {
                                 ERRORS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice ETH was attached to a call targeting a nonpayable token selector.
+    ///
+    /// @dev The precompile checks `msg.value != 0` at the top of dispatch before any other
+    ///      validation. All B-20 token selectors are nonpayable.
+    error NonPayable();
+
     /// @notice `account` does not hold `neededRole`.
     ///
     /// @param account    Account that failed the role check.

--- a/src/interfaces/IB20Factory.sol
+++ b/src/interfaces/IB20Factory.sol
@@ -64,6 +64,9 @@ interface IB20Factory {
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice ETH was attached to a call targeting a nonpayable factory selector.
+    error NonPayable();
+
     /// @notice A token already exists at the deterministic address derived from
     ///         `(variant, msg.sender, salt)`. Caller must use a different salt.
     error TokenAlreadyExists(address token);
@@ -122,6 +125,7 @@ interface IB20Factory {
     ///         from `(variant, msg.sender, salt)`, then dispatches each entry in `initCalls` on
     ///         the new token. Emits `B20Created`.
     ///
+    /// @dev Reverts with `NonPayable` when ETH is attached to the call.
     /// @dev Reverts with IActivationRegistry.FeatureNotActivated when the variant feature is not activated.
     /// @dev Reverts with `InvalidVariant` when `variant` is outside the `B20Variant` range.
     /// @dev Reverts with `UnsupportedVersion` when the leading `version` byte in `params` is unrecognized for `variant`.
@@ -152,6 +156,7 @@ interface IB20Factory {
     /// @return token The address of the newly created token.
     function createB20(B20Variant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
         external
+        payable
         returns (address token);
 
     /*//////////////////////////////////////////////////////////////

--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -23,6 +23,12 @@ interface IPolicyRegistry {
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice ETH was attached to a call targeting a nonpayable policy registry selector.
+    ///
+    /// @dev The precompile checks `msg.value != 0` at the top of dispatch before any other
+    ///      validation. All policy registry selectors are nonpayable.
+    error NonPayable();
+
     /// @notice Caller is not the admin required by the attempted operation.
     error Unauthorized();
 

--- a/test/lib/mocks/MockB20Factory.sol
+++ b/test/lib/mocks/MockB20Factory.sol
@@ -98,8 +98,14 @@ contract MockB20Factory is IB20Factory {
     /// @inheritdoc IB20Factory
     function createB20(B20Variant variant, bytes32 salt, bytes calldata params, bytes[] calldata initCalls)
         external
+        payable
         returns (address token)
     {
+        // -- Pre-flight: reject any call that attaches ETH. Mirrors the Rust precompile's
+        //    nonpayable guard which fires before calldata-cost deduction — matched here so
+        //    mock and live-precompile surfaces behave identically.
+        if (msg.value != 0) revert NonPayable();
+
         // -- 0. Activation gates.
         //       Per-variant features gate which variants can be created at
         //       any moment. Variant-feature mapping:

--- a/test/unit/B20Factory/nonPayable.t.sol
+++ b/test/unit/B20Factory/nonPayable.t.sol
@@ -14,7 +14,9 @@ import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 ///         decoding, or any other validation — so value-bearing calls never advance past
 ///         the pre-flight check regardless of the calldata they carry.
 ///
-/// @dev Regression for BOP-324.
+/// @dev Regression for BOP-324. Tests in this file are skipped in fork mode until
+///      base/base#3362 (the nonpayable guard implementation) is merged and deployed:
+///      before that PR the live precompile silently accepts ETH-bearing calls.
 contract B20FactoryNonPayableTest is B20FactoryTest {
     function _deactivate(bytes32 feature) internal {
         vm.prank(StdPrecompiles.ACTIVATION_REGISTRY.admin());
@@ -24,6 +26,7 @@ contract B20FactoryNonPayableTest is B20FactoryTest {
     /// @notice Verifies `createB20` reverts with `NonPayable` when ETH is attached.
     /// @dev Arbitrary value, variant, and calldata: the guard fires before decoding.
     function test_createB20_revert_nonPayable(address caller, uint256 value, bytes32 salt) public {
+        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
         _assumeValidCaller(caller);
         vm.assume(value != 0);
         vm.deal(caller, value);
@@ -41,6 +44,7 @@ contract B20FactoryNonPayableTest is B20FactoryTest {
     function test_createB20_revertOrder_nonPayable_beats_activation(address caller, uint256 value, bytes32 salt)
         public
     {
+        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
         _assumeValidCaller(caller);
         vm.assume(value != 0);
         vm.deal(caller, value);

--- a/test/unit/B20Factory/nonPayable.t.sol
+++ b/test/unit/B20Factory/nonPayable.t.sol
@@ -14,9 +14,9 @@ import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 ///         decoding, or any other validation — so value-bearing calls never advance past
 ///         the pre-flight check regardless of the calldata they carry.
 ///
-/// @dev Regression for BOP-324. Tests in this file are skipped in fork mode until
-///      base/base#3362 (the nonpayable guard implementation) is merged and deployed:
-///      before that PR the live precompile silently accepts ETH-bearing calls.
+/// @dev Tests in this file are skipped in fork mode until base/base#3362 (the nonpayable
+///      guard implementation) is merged and deployed: before that PR the live precompile
+///      silently accepts ETH-bearing calls.
 contract B20FactoryNonPayableTest is B20FactoryTest {
     function _deactivate(bytes32 feature) internal {
         vm.prank(StdPrecompiles.ACTIVATION_REGISTRY.admin());

--- a/test/unit/B20Factory/nonPayable.t.sol
+++ b/test/unit/B20Factory/nonPayable.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IB20Factory} from "base-std/interfaces/IB20Factory.sol";
+import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
+
+import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
+import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
+
+/// @title Nonpayable guard tests for the B20 factory.
+///
+/// @notice The factory precompile rejects any call that attaches ETH with `NonPayable`.
+///         The guard fires at the very top of dispatch, before activation checks, variant
+///         decoding, or any other validation — so value-bearing calls never advance past
+///         the pre-flight check regardless of the calldata they carry.
+///
+/// @dev Regression for BOP-324.
+contract B20FactoryNonPayableTest is B20FactoryTest {
+    function _deactivate(bytes32 feature) internal {
+        vm.prank(StdPrecompiles.ACTIVATION_REGISTRY.admin());
+        StdPrecompiles.ACTIVATION_REGISTRY.deactivate(feature);
+    }
+
+    /// @notice Verifies `createB20` reverts with `NonPayable` when ETH is attached.
+    /// @dev Arbitrary value, variant, and calldata: the guard fires before decoding.
+    function test_createB20_revert_nonPayable(address caller, uint256 value, bytes32 salt) public {
+        _assumeValidCaller(caller);
+        vm.assume(value != 0);
+        vm.deal(caller, value);
+
+        IB20Factory.B20AssetCreateParams memory p = _assetParams();
+
+        vm.prank(caller);
+        vm.expectRevert(IB20Factory.NonPayable.selector);
+        factory.createB20{value: value}(IB20Factory.B20Variant.ASSET, salt, abi.encode(p), new bytes[](0));
+    }
+
+    /// @notice Verifies `NonPayable` fires before activation checks.
+    /// @dev Both conditions broken: ETH attached AND the ASSET feature deactivated.
+    ///      The nonpayable guard comes first in dispatch — activation is checked second.
+    function test_createB20_revertOrder_nonPayable_beats_activation(address caller, uint256 value, bytes32 salt)
+        public
+    {
+        _assumeValidCaller(caller);
+        vm.assume(value != 0);
+        vm.deal(caller, value);
+
+        _deactivate(ActivationRegistryFeatureList.B20_ASSET);
+
+        IB20Factory.B20AssetCreateParams memory p = _assetParams();
+
+        vm.prank(caller);
+        vm.expectRevert(IB20Factory.NonPayable.selector);
+        factory.createB20{value: value}(IB20Factory.B20Variant.ASSET, salt, abi.encode(p), new bytes[](0));
+    }
+}


### PR DESCRIPTION
## Motivation

The factory precompile (base/base#3362) rejects any ETH-bearing call with a typed `NonPayable` error before dispatch reaches any other logic. The base-std interface had no corresponding error and the mock applied no check at all. This left a gap: code testing against the mock saw a generic Solidity nonpayable revert (empty revert data) rather than the `NonPayable` selector the live precompile emits, and the interface gave callers no way to catch or anticipate the error by name.

## What changed

**`IB20Factory.sol`**

- Added `error NonPayable()` to the errors section.
- Marked `createB20` `payable` in the interface. The precompile accepts ETH at the EVM level and then immediately reverts it; marking the interface `payable` lets callers attach value and receive the typed revert, which is the correct observable behavior.
- Added `@dev Reverts with NonPayable when ETH is attached` to the `createB20` NatSpec.

**`MockB20Factory.sol`**

- Changed `createB20` to `payable` (required to override a `payable` interface function).
- Added `if (msg.value != 0) revert NonPayable();` at the very top of the function body, before activation gates, matching the ordering in the precompile's `dispatch.rs`.

**`test/unit/B20Factory/nonPayable.t.sol`** (new)

- `test_createB20_revert_nonPayable`: fuzz over any non-zero value; verifies `NonPayable` is emitted.
- `test_createB20_revertOrder_nonPayable_beats_activation`: both conditions broken (ETH attached, ASSET feature deactivated); verifies `NonPayable` fires first.

## Related

- base/base#3362 (precompile implementation this tracks)
- BOP-324