### PR TITLE
test: auto-detect live precompiles so base-forge test just works; rename fork->live precompile testing

### DIFF
--- a/LIVE_PRECOMPILE_TESTING.md
+++ b/LIVE_PRECOMPILE_TESTING.md
@@ -1,4 +1,4 @@
-# Fork testing: base-std vs Base Rust precompiles
+# Live precompile testing: base-std vs Base Rust precompiles
 
 > Agent / engineer handoff for revalidating base-std's Solidity reference
 > against base/base's Rust precompile impls. Read this when the precompile
@@ -85,6 +85,24 @@ cargo build --release -p anvil -p forge
 ```
 
 ## Run the tests
+
+The simplest path needs no node and no flags — `base-forge` (from the
+base-anvil fork) hosts the live precompiles in-process and `BaseTest`
+auto-detects them:
+
+```bash
+base-forge test
+```
+
+`setUp` prints which world it ran in: **LIVE PRECOMPILE mode** (checking
+base/base against the Solidity reference) under `base-forge`, or **REFERENCE
+mode** (exercising the Solidity mocks; base/base not under test) under stock
+`forge test`. No `LIVE_PRECOMPILES` or `FOUNDRY_PROFILE=fork` needed —
+detection is a behavioral probe of the precompile addresses.
+
+To cross-validate against a **real base-anvil node** (the original harness,
+used in CI), use the Python runner, which boots `anvil --base`, activates the
+gated features, and runs `forge test --fork-url` against it:
 
 ```bash
 cd ~/code/base-std
@@ -242,11 +260,12 @@ or `PORT=8547 make fork-tests`.
 **`anvil exited during startup`** — check `/tmp/anvil.log`. Usual cause:
 rust build is stale after a base/base change; rebuild.
 
-**Hundreds of `EvmError: Revert` with `gas: 0` in `setUp`** — either the
-`LIVE_PRECOMPILES` env var wasn't set (BaseTest etched the mocks over the
-precompile addresses) or `[profile.fork] base = true` is missing from
-`foundry.toml` (forge isn't installing the precompiles). The runner sets
-both, but if you're invoking forge directly, set both.
+**Hundreds of `EvmError: Revert` / `cannot use precompile ... as an argument`
+in `setUp`** — `BaseTest` tried to etch the mocks over live precompile
+addresses. Auto-detection prevents this under `base-forge` or a `--fork-url`
+node; if you still hit it, the precompiles aren't actually present (e.g.
+`base = true` / `--base` missing, so forge isn't installing them). Force the
+intended world with `LIVE_PRECOMPILES=true` if detection is ever wrong.
 
 **`FeatureNotActivated(bytes32)` revert payload** — a new gated feature
 landed in base/base. Add its ID to the derived feature set (see Step 2 above:
@@ -289,7 +308,7 @@ If this returns garbage / fails, the fork's build is broken or out of date.
 |---|---|---|
 | The test runner | `script/fork/` (`make fork-tests`) | Python + web3; forwards forge args through `ARGS` |
 | Forge profile config | `foundry.toml`, `[profile.fork]` | `base = true` enables Rust precompile dispatch |
-| Skip-etch logic | `test/lib/BaseTest.sol` | guarded by `LIVE_PRECOMPILES` env var |
+| Mode detection / skip-etch | `test/lib/BaseTest.sol` | auto-probes for live precompiles; `LIVE_PRECOMPILES=true` forces live |
 | Slot assertions | `test/unit/**/*.t.sol`, `test/lib/mocks/Mock*Storage.sol` | `vm.load`-based slot-layout assertions paired with surface tests |
 | Storage helpers | `test/lib/mocks/MockB20Storage.sol`, `MockPolicyRegistryStorage.sol` | the slot-derivation library every assertion uses |
 | Patched forge + anvil | `~/code/base-anvil/target/.../{forge,anvil}` | built by `cargo build -p forge -p anvil` |

--- a/LIVE_PRECOMPILE_TESTING.md
+++ b/LIVE_PRECOMPILE_TESTING.md
@@ -4,6 +4,49 @@
 > against base/base's Rust precompile impls. Read this when the precompile
 > code in `base/base` changes (or when you're picking the workflow up cold).
 
+## Quick start (installed binaries)
+
+Most devs don't need to build base-anvil from source. Install it alongside your
+stock Foundry (it never touches your existing `forge`/`anvil`) to get
+`base-forge` and `base-anvil`:
+
+```bash
+curl -L https://raw.githubusercontent.com/base/base-anvil/HEAD/foundryup/install | bash
+base-foundryup
+```
+
+**In-process, no node — the common case.** `base-forge` hosts the precompiles
+in `forge`'s own EVM and seeds the gated features active, so the suite just runs
+and `BaseTest` auto-detects the live world:
+
+```bash
+base-forge test
+```
+
+`setUp` logs which world ran: **LIVE PRECOMPILE mode** (under `base-forge`) or
+**REFERENCE mode** (stock `forge test`, exercising the Solidity mocks).
+
+**Against a real base-anvil node — genuine fork testing.** Point the Python
+runner at your installed binaries; it boots `anvil --base`, activates the gated
+features, and runs `forge test --fork-url` against the node:
+
+```bash
+make smoke-setup   # one-time: Python 3.13 venv + web3
+ANVIL_BIN="$HOME/.foundry/versions/base-nightly/anvil" \
+FORGE_BIN="$HOME/.foundry/versions/base-nightly/forge" \
+  make fork-tests
+```
+
+> A base-anvil **node** starts with the gated features **inactive** — it mirrors
+> a real chain, where only the activation admin flips features on. (Forge's
+> in-process `--base` is the exception: it seeds them active for the no-node
+> path above.) `make fork-tests` activates them for you; if you start a node by
+> hand, activate via the admin first or calls revert `FeatureNotActivated` (see
+> "When the precompiles update" below).
+
+Build base-anvil from source only if you're changing base-anvil itself — see
+the from-source setup below.
+
 ## What this does
 
 Runs base-std's existing unit test suite (~346 tests with paired
@@ -46,7 +89,10 @@ base-std/                  base-anvil/                base/
   if you want to iterate on an unpushed branch (see "Local-iteration
   override" below).
 
-## Prerequisites (first-time setup)
+## Building base-anvil from source (contributors)
+
+> Only needed if you're modifying base-anvil itself. Most devs should use the
+> installed binaries from [Quick start](#quick-start-installed-binaries) above.
 
 Clone two repos as siblings (base/base is fetched automatically by cargo):
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,24 @@ Solidity version: `0.8.30` for reference implementations. Interfaces are
 written for broader compatibility (`>=0.8.20 <0.9.0`) so consumers can
 import them without forcing a specific compiler.
 
-### Fork testing against live precompiles
+### Live precompile testing
 
-The unit suite can run against a chain hosting the live Rust precompile
-implementations to verify the Rust impls match the Solidity reference's
-behavior and storage layout. The same test bodies are reused — only the
-backend changes.
+The same unit suite runs against the live Rust precompiles to verify they
+match the Solidity reference's behavior and storage layout — only the backend
+changes. The simplest way is `base-forge` (from
+[base-anvil](https://github.com/base/base-anvil)), which hosts the precompiles
+in-process; `BaseTest` auto-detects them, so no flags are needed:
+
+```bash
+base-forge test
+```
+
+Stock `forge test` runs the same suite against the Solidity mocks instead
+(reference mode); `setUp` logs which mode ran. See
+[LIVE_PRECOMPILE_TESTING.md](./LIVE_PRECOMPILE_TESTING.md) for the full
+workflow, including running against a real base-anvil node.
+
+To run against a forked chain that already hosts the precompiles:
 
 ```bash
 LIVE_PRECOMPILES=true FOUNDRY_PROFILE=fork forge test --fork-url vibenet

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,12 +18,12 @@ optimizer_runs = 200
 runs = 256
 
 # Named RPC endpoints. Referenced via `forge test --fork-url <name>`.
-# See README "Fork testing" section for the invocation that runs the
+# See README "Live precompile testing" section for the invocation that runs the
 # full unit-test suite against the live Rust precompiles.
 [rpc_endpoints]
 vibenet = "https://rpc.vibes.base.org/"
 
-# Fork-testing profile. Reduces fuzz runs since each iteration may
+# Live-precompile testing profile. Reduces fuzz runs since each iteration may
 # trigger RPC round-trips against the live precompiles, and the test
 # author cares more about "does the layout / behavior match" than
 # fuzz coverage at this stage.

--- a/test/lib/B20FactoryTest.sol
+++ b/test/lib/B20FactoryTest.sol
@@ -147,10 +147,10 @@ contract B20FactoryTest is BaseTest {
     ///         the same test body is meaningful under both backends.
     ///         Tests that specifically pin the SOLIDITY MOCK's slot
     ///         layout (e.g. `MockB20SlotHelpers.t.sol`) should
-    ///         `vm.skip(vm.envOr("LIVE_PRECOMPILES", false))` instead —
+    ///         `vm.skip(livePrecompiles)` instead —
     ///         those assertions are inherently mock-world invariants.
     function _assertInitialized(address token, string memory err) internal view {
-        if (vm.envOr("LIVE_PRECOMPILES", false)) {
+        if (livePrecompiles) {
             assertGt(token.code.length, 0, err);
         } else {
             assertEq(uint256(vm.load(token, MockB20Storage.initializedSlot())), 1, err);

--- a/test/lib/BaseTest.sol
+++ b/test/lib/BaseTest.sol
@@ -3,12 +3,14 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
+import {console2} from "forge-std/console2.sol";
 
 import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationRegistryFeatureList.sol";
 import {MockActivationRegistry} from "base-std-test/lib/mocks/MockActivationRegistry.sol";
 import {MockPolicyRegistry} from "base-std-test/lib/mocks/MockPolicyRegistry.sol";
 import {MockB20Factory} from "base-std-test/lib/mocks/MockB20Factory.sol";
 
+import {IActivationRegistry} from "base-std/interfaces/IActivationRegistry.sol";
 import {IPolicyRegistry} from "base-std/interfaces/IPolicyRegistry.sol";
 import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 
@@ -19,23 +21,23 @@ import {StdPrecompiles} from "base-std/StdPrecompiles.sol";
 /// (`B20FactoryTest`, `PolicyRegistryTest`, ...) extend this and
 /// layer on their own helpers and any test-class-specific state.
 ///
-/// **Mock-vs-live.** `setUp` etches each precompile mock at its
-/// canonical address by default. Set the `LIVE_PRECOMPILES`
-/// environment variable to `true` to skip etching so calls dispatch
-/// to whatever's deployed at the precompile addresses on the forked
-/// chain. The canonical fork-test invocation is:
+/// **Reference vs. live precompiles.** The suite runs in one of two
+/// worlds, detected automatically (no flag to remember):
+///   - **Reference mode** (stock `forge test`): the precompile
+///     addresses are empty, so `setUp` etches the Solidity mocks — you
+///     are testing the reference implementation itself.
+///   - **Live precompile mode** (`base-forge test`, or `forge test
+///     --fork-url <base-anvil node>`): base-anvil's `--base` mode makes
+///     the real Rust precompiles present, so `setUp` skips the etch —
+///     you are checking base/base against the reference (conformance).
 ///
-///     LIVE_PRECOMPILES=true FOUNDRY_PROFILE=fork forge test --fork-url vibenet
-///
-/// Why an explicit env var rather than auto-detecting whether the
-/// live precompile is deployed? Native EVM precompiles (which is what
-/// the Rust impls are deployed as on vibenet) return zero code via
-/// `eth_getCode` even when they respond to calls. The previous
-/// `code.length == 0` check was unreliable for that reason and would
-/// silently clobber a live precompile with the mock, producing
-/// false-pass results that mask layout / behavior mismatches between
-/// the Solidity reference and the Rust impl. An explicit opt-in is
-/// the surface that makes the intent unambiguous.
+/// Detection is a behavioral probe (STATICCALL `ActivationRegistry.admin()`
+/// before any etch), not an `extcodesize` check: native precompiles
+/// report zero code even when they respond to calls, so a code-size
+/// check is unreliable and would silently clobber a live precompile
+/// with a mock. `LIVE_PRECOMPILES=true` forces live mode as an escape
+/// hatch. The detected world is recorded in `livePrecompiles` and
+/// announced via a `setUp` log line.
 ///
 /// **Cross-precompile dependency model.** Every test gets all three
 /// precompile mocks etched. Token tests need the factory mock to
@@ -79,6 +81,12 @@ abstract contract BaseTest is Test {
     address internal bob = makeAddr("bob");
     address internal attacker = makeAddr("attacker");
 
+    /// @notice True when the live base/base precompiles are present
+    ///         (`base-forge` / base-anvil), false when the Solidity mocks are
+    ///         etched (stock `forge`). Set in setUp; read by tests that are
+    ///         only meaningful in one world.
+    bool internal livePrecompiles;
+
     // -- Setup --
     function setUp() public virtual {
         vm.label(admin, "admin");
@@ -90,29 +98,49 @@ abstract contract BaseTest is Test {
         vm.label(StdPrecompiles.POLICY_REGISTRY_ADDRESS, "PolicyRegistry");
         vm.label(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, "ActivationRegistry");
 
-        // Etch the mocks unless the user explicitly opts into
-        // running against the live precompiles. See the contract-
-        // level NatSpec for the rationale on the env var rather than
-        // auto-detection.
-        if (!vm.envOr("LIVE_PRECOMPILES", false)) {
-            vm.etch(StdPrecompiles.B20_FACTORY_ADDRESS, type(MockB20Factory).runtimeCode);
-            vm.etch(StdPrecompiles.POLICY_REGISTRY_ADDRESS, type(MockPolicyRegistry).runtimeCode);
-            vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
-
-            // Activate every B-20 feature so the bulk of the suite — which
-            // exercises behaviors orthogonal to the activation gate — doesn't
-            // have to repeat the bootstrap. Tests that pin the gating
-            // behavior itself (`B20Factory/activation.t.sol`) deactivate the
-            // specific feature under test before exercising it.
-            // In fork mode (LIVE_PRECOMPILES=true) the features are already
-            // active on the live chain, so this bootstrap is skipped.
-            address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
-            vm.startPrank(activationAdmin);
-            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
-            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
-            StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);
-            vm.stopPrank();
+        // Pick the world by detecting whether the live precompiles are
+        // present (see contract NatSpec), then announce it so a run is never
+        // ambiguous about what it validated.
+        livePrecompiles = _detectLivePrecompiles();
+        if (livePrecompiles) {
+            console2.log("[base-std] LIVE PRECOMPILE mode: exercising base/base's precompiles (conformance check)");
+            // The precompiles are present and base-anvil's --base mode seeds
+            // their features, so there is nothing to etch or bootstrap.
+            return;
         }
+
+        console2.log("[base-std] REFERENCE mode: exercising the Solidity mocks; base/base is NOT under test");
+
+        vm.etch(StdPrecompiles.B20_FACTORY_ADDRESS, type(MockB20Factory).runtimeCode);
+        vm.etch(StdPrecompiles.POLICY_REGISTRY_ADDRESS, type(MockPolicyRegistry).runtimeCode);
+        vm.etch(StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS, type(MockActivationRegistry).runtimeCode);
+
+        // Activate every B-20 feature so the bulk of the suite — which
+        // exercises behaviors orthogonal to the activation gate — doesn't
+        // have to repeat the bootstrap. Tests that pin the gating behavior
+        // itself (`B20Factory/activation.t.sol`) deactivate the specific
+        // feature under test before exercising it.
+        address activationAdmin = StdPrecompiles.ACTIVATION_REGISTRY.admin();
+        vm.startPrank(activationAdmin);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_ASSET);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.B20_STABLECOIN);
+        StdPrecompiles.ACTIVATION_REGISTRY.activate(ActivationRegistryFeatureList.POLICY_REGISTRY);
+        vm.stopPrank();
+    }
+
+    /// @notice Detect whether the live precompiles are present in this EVM.
+    ///
+    /// @dev Behavioral probe rather than `extcodesize`: native precompiles
+    ///      report zero code even when they respond, so a code-size check is
+    ///      unreliable. We STATICCALL `ActivationRegistry.admin()` before any
+    ///      mock is etched — a live precompile returns a 32-byte address; an
+    ///      empty address (stock forge) returns zero-length returndata.
+    ///      `LIVE_PRECOMPILES=true` forces live as an escape hatch.
+    function _detectLivePrecompiles() private view returns (bool) {
+        if (vm.envOr("LIVE_PRECOMPILES", false)) return true;
+        (bool ok, bytes memory ret) =
+            StdPrecompiles.ACTIVATION_REGISTRY_ADDRESS.staticcall(abi.encodeCall(IActivationRegistry.admin, ()));
+        return ok && ret.length >= 32;
     }
 
     /// @notice Filters out addresses that are unsafe to use as a fuzzed

--- a/test/regression/B20Removals.t.sol
+++ b/test/regression/B20Removals.t.sol
@@ -16,7 +16,7 @@ import {B20AssetTest} from "base-std-test/lib/B20AssetTest.sol";
 ///         surface — fails here.
 ///
 /// @dev    These are *selector-absence* assertions: the token mock (and the live precompile in
-///         fork mode) carries no fallback, so a call to a removed selector cannot succeed. The
+///         live precompile mode) carries no fallback, so a call to a removed selector cannot succeed. The
 ///         same test body is meaningful against the mock (proves the Solidity reference dropped
 ///         the surface) and against the live precompile under `LIVE_PRECOMPILES=true ... --fork-url`
 ///         (proves `base/base` dropped it too). Args are irrelevant — dispatch fails before decoding

--- a/test/regression/B20Renames.t.sol
+++ b/test/regression/B20Renames.t.sol
@@ -17,7 +17,7 @@ import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationR
 ///         authority split, and the `base.b20_asset` activation namespace. Each test asserts the
 ///         new surface is present and correct AND the old surface is gone, so the rename cannot
 ///         silently regress in either the Solidity reference or the `base/base` Rust precompile
-///         (under fork mode).
+///         (under live precompile mode).
 ///
 /// @dev    Old-selector absence is checked with low-level calls (the token carries no fallback, so
 ///         a retired selector cannot resolve); new surface is checked with typed calls that only

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -403,7 +403,7 @@ contract B20TransferFromTest is B20Test {
         // window OPEN (during which the factory is the only caller). The two states are mutually
         // exclusive in any real sequence, so there is no fork-reachable construction. The mock
         // observes it only by reopening the window via vm.store, which has no live-precompile analog.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidActor(from);
         _assumeValidActor(to);
         allowanceAmount = bound(allowanceAmount, 0, B20Constants.MAX_SUPPLY_CAP - 1);
@@ -436,7 +436,7 @@ contract B20TransferFromTest is B20Test {
         // Mock-only by necessity: see test_transferFrom_revert_privileged_insufficientAllowance.
         // The privileged path needs a pre-existing allowance[from][factory] that cannot be
         // established inside the atomic bootstrap window, so there is no fork-reachable construction.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidActor(from);
         _assumeValidActor(to);
         vm.assume(from != to);
@@ -478,7 +478,7 @@ contract B20TransferFromTest is B20Test {
         // the privileged path needs a pre-existing allowance[from][factory] (from != factory) that
         // cannot be set inside the atomic bootstrap window (the factory is the only in-window
         // caller). No fork-reachable construction exists; the mock reaches it via vm.store.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidActor(from);
         _assumeValidActor(to);
         vm.assume(from != to);

--- a/test/unit/B20/memo/transferFromWithMemo.t.sol
+++ b/test/unit/B20/memo/transferFromWithMemo.t.sol
@@ -209,7 +209,7 @@ contract B20TransferFromWithMemoTest is B20Test {
         // the window OPEN (during which the factory is the only caller). The two states are mutually
         // exclusive in any real sequence, so there is no fork-reachable construction. The mock
         // observes it only by reopening the window via vm.store, which has no live-precompile analog.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidActor(from);
         _assumeValidActor(to);
         allowanceAmount = bound(allowanceAmount, 0, B20Constants.MAX_SUPPLY_CAP - 1);
@@ -243,7 +243,7 @@ contract B20TransferFromWithMemoTest is B20Test {
         // Mock-only by necessity: see test_transferFromWithMemo_revert_privileged_insufficientAllowance.
         // The privileged path needs a pre-existing allowance[from][factory] that cannot be
         // established inside the atomic bootstrap window, so there is no fork-reachable construction.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidActor(from);
         _assumeValidActor(to);
         vm.assume(from != to);

--- a/test/unit/B20Asset/batch/batchMint_rollback.t.sol
+++ b/test/unit/B20Asset/batch/batchMint_rollback.t.sol
@@ -18,7 +18,7 @@ import {B20Constants} from "base-std/lib/B20Constants.sol";
 ///
 ///         Mock mode gets this for free from revm's journaled storage —
 ///         a passing test there just confirms revm works. The
-///         signal is in fork mode against the real Rust precompile,
+///         signal is in live precompile mode against the real Rust precompile,
 ///         where any break in the `precompile-storage` journal hookup
 ///         would leave the earlier writes persisted across the revert.
 ///         Companion to the Rust-side unit tests.

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -301,7 +301,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
     /// @notice Verifies asset createToken initializes the supply cap to the maximum (uint128.max).
     /// @dev The factory writes `B20Constants.MAX_SUPPLY_CAP` at bootstrap — the unbounded
     ///      ("no cap") sentinel and the highest value the cap may ever hold. Pinning this on the
-    ///      factory-creation path (fuzzed caller/salt) means fork mode catches a precompile that
+    ///      factory-creation path (fuzzed caller/salt) means live precompile mode catches a precompile that
     ///      fails to seed the cap at creation. Paired surface + slot assertions.
     function test_createB20_success_assetSupplyCapDefaultsToMax(address caller, bytes32 salt) public {
         _assumeValidCaller(caller);

--- a/test/unit/B20Factory/nonPayable.t.sol
+++ b/test/unit/B20Factory/nonPayable.t.sol
@@ -26,7 +26,7 @@ contract B20FactoryNonPayableTest is B20FactoryTest {
     /// @notice Verifies `createB20` reverts with `NonPayable` when ETH is attached.
     /// @dev Arbitrary value, variant, and calldata: the guard fires before decoding.
     function test_createB20_revert_nonPayable(address caller, uint256 value, bytes32 salt) public {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidCaller(caller);
         vm.assume(value != 0);
         vm.deal(caller, value);
@@ -44,7 +44,7 @@ contract B20FactoryNonPayableTest is B20FactoryTest {
     function test_createB20_revertOrder_nonPayable_beats_activation(address caller, uint256 value, bytes32 salt)
         public
     {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         _assumeValidCaller(caller);
         vm.assume(value != 0);
         vm.deal(caller, value);

--- a/test/unit/B20Factory/nonPayable.t.sol
+++ b/test/unit/B20Factory/nonPayable.t.sol
@@ -14,7 +14,7 @@ import {B20FactoryTest} from "base-std-test/lib/B20FactoryTest.sol";
 ///         decoding, or any other validation — so value-bearing calls never advance past
 ///         the pre-flight check regardless of the calldata they carry.
 ///
-/// @dev Tests in this file are skipped in fork mode until base/base#3362 (the nonpayable
+/// @dev Tests in this file are skipped in live precompile mode until base/base#3362 (the nonpayable
 ///      guard implementation) is merged and deployed: before that PR the live precompile
 ///      silently accepts ETH-bearing calls.
 contract B20FactoryNonPayableTest is B20FactoryTest {

--- a/test/unit/PolicyRegistry/createPolicy.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy.t.sol
@@ -132,7 +132,7 @@ contract PolicyRegistryCreatePolicyTest is PolicyRegistryTest {
     ///         test is skipped when running against live precompiles.
     ///         Matches the Rust precompile which reverts with Panic(UnderOverflow) = Panic(0x11).
     function test_createPolicy_revert_counterOverflow(address caller, address admin_, uint8 typeIdx) public {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
 
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));

--- a/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
+++ b/test/unit/PolicyRegistry/createPolicyWithAccounts_rollback.t.sol
@@ -32,7 +32,7 @@ contract PolicyRegistryCreatePolicyWithAccountsRollbackTest is PolicyRegistryTes
     /// @dev    Reads the relevant slots with `vm.load` before and after
     ///         the reverting call — the test's signal is the byte-level
     ///         equality, which is the strictest possible "state
-    ///         unchanged" assertion across both mock and fork modes.
+    ///         unchanged" assertion across both mock and live precompile modes.
     function test_createPolicyWithAccounts_rollback_batchSizeTooLarge(
         address caller,
         address admin_,

--- a/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createPolicy_revertOrder.t.sol
@@ -19,7 +19,7 @@ import {MockPolicyRegistryStorage} from "base-std-test/lib/mocks/MockPolicyRegis
 contract PolicyRegistryCreatePolicyRevertOrderTest is PolicyRegistryTest {
     /// @notice Walks through every revert in canonical order, fixing one per step, ending at success.
     function test_createPolicy_revertOrder(address caller, address admin_, uint8 typeIdx) public {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
 
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));

--- a/test/unit/PolicyRegistry/dispatch_inactive.t.sol
+++ b/test/unit/PolicyRegistry/dispatch_inactive.t.sol
@@ -21,7 +21,7 @@ contract PolicyRegistryDispatchInactiveTest is PolicyRegistryTest {
     bytes32 internal constant FEATURE = ActivationRegistryFeatureList.POLICY_REGISTRY;
 
     function _forkMode() internal view returns (bool) {
-        return vm.envOr("LIVE_PRECOMPILES", false);
+        return livePrecompiles;
     }
 
     /// @dev Deactivate the feature if active; no-op otherwise (idempotent across both run modes).

--- a/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
+++ b/test/unit/PolicyRegistry/pendingPolicyAdmin.t.sol
@@ -80,7 +80,7 @@ contract PolicyRegistryPendingPolicyAdminTest is PolicyRegistryTest {
     ///         test is skipped when running against live precompiles.
     function test_pendingPolicyAdmin_success_zeroForBuiltinsEvenWithStoragePoison() public {
         // Skip when running against live precompiles — vm.store cannot target native precompiles.
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         address poison = address(0xDEAD);
         vm.store(
             address(policyRegistry),

--- a/test/unit/storage/B20FullLayout.t.sol
+++ b/test/unit/storage/B20FullLayout.t.sol
@@ -220,7 +220,7 @@ contract B20FullLayoutTest is B20Test {
         // The other slot-by-slot assertions in this test are NOT
         // dual-backend; they pin the Solidity layout exactly. Per-slot
         // divergence against the Rust impl is the cross-validation
-        // signal documented in FORK_TESTING.md's bucket table.
+        // signal documented in LIVE_PRECOMPILE_TESTING.md's bucket table.
         _assertInitialized(tokenAddr, "initialized marker must be set");
     }
 

--- a/test/unit/storage/MockB20SlotHelpers.t.sol
+++ b/test/unit/storage/MockB20SlotHelpers.t.sol
@@ -268,7 +268,7 @@ contract MockB20SlotHelpersTest is B20Test {
     ///      slot pinned here is a Solidity-mock invariant with no
     ///      counterpart on the live precompile. Skip under LIVE_PRECOMPILES.
     function test_initializedSlot_success_decodesAfterBootstrap() public {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         assertEq(
             uint256(vm.load(address(token), MockB20Storage.initializedSlot())),
             1,
@@ -285,7 +285,7 @@ contract MockB20SlotHelpersTest is B20Test {
     ///      layout doesn't have an `initialized` slot at all, so disjointness
     ///      from `adminCountSlot` is a Solidity-mock invariant.
     function test_adminCountSlot_success_disjointFromInitializedSlot() public {
-        vm.skip(vm.envOr("LIVE_PRECOMPILES", false));
+        vm.skip(livePrecompiles);
         assertTrue(
             MockB20Storage.adminCountSlot() != MockB20Storage.initializedSlot(),
             "adminCount and initialized must live in disjoint slots"


### PR DESCRIPTION
## What

`base-forge test` against base-std previously failed every `setUp` with `vm.etch: cannot use precompile ... as an argument`: base-forge makes the real precompiles present, but `BaseTest` still etched the Solidity mocks over them unless `LIVE_PRECOMPILES=true` was set by hand.

This makes the suite detect its world and adapt:
- **Reference mode** (stock `forge test`): precompiles absent -> etch the Solidity mocks -> testing the reference implementation.
- **Live precompile mode** (`base-forge test`, or `forge test --fork-url <base-anvil node>`): precompiles present -> skip the etch -> checking base/base against the reference (conformance).

Detection is a behavioral probe (STATICCALL `ActivationRegistry.admin()` before any etch), not `extcodesize` (native precompiles report zero code). `setUp` logs which world ran; `LIVE_PRECOMPILES=true` remains a force-live override.

## Result
- `base-forge test` -> 616 passed, 0 failed, 13 skipped (was 145 failing), no env var, no node.
- `forge test` -> 625 passed, 0 failed, 4 skipped (reference world unchanged).

## Also
- Rename `FORK_TESTING.md` -> `LIVE_PRECOMPILE_TESTING.md`, reframed to lead with `base-forge test`; the Python node-runner stays documented as the against-a-real-node / CI path. "fork mode" -> "live precompile mode" terminology swept. Functional names (`make fork-tests`, `script/fork/`, the workflow) left intact to avoid breaking CI.

## Test plan
Ran the full suite both ways on macOS arm64 against the v1.1.0 base-anvil build; both green (counts above).