### PR TITLE
docs: fix encodeUpdateSupplyCap no-cap sentinel natspec

### DIFF
--- a/src/lib/B20FactoryLib.sol
+++ b/src/lib/B20FactoryLib.sol
@@ -135,7 +135,7 @@ library B20FactoryLib {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Encodes a bootstrap initCall to `IB20.updateSupplyCap`.
-    /// @param newSupplyCap New supply cap (`type(uint256).max` for no cap).
+    /// @param newSupplyCap New supply cap (`type(uint128).max` for no cap).
     function encodeUpdateSupplyCap(uint256 newSupplyCap) internal pure returns (bytes memory) {
         return abi.encodeCall(IB20.updateSupplyCap, (newSupplyCap));
     }


### PR DESCRIPTION
## Summary

Fixes a stale natspec sentinel in `B20FactoryLib.encodeUpdateSupplyCap`.

The `@param newSupplyCap` doc said `type(uint256).max` is the "no cap" value, but the actual no-cap sentinel — and the maximum permitted supply cap — is `type(uint128).max`:

- `B20Constants.MAX_SUPPLY_CAP = type(uint128).max` ("the unbounded 'no cap' sentinel")
- `IB20.supplyCap()` — "Capped at `type(uint128).max`, which indicates no cap"
- `IB20.updateSupplyCap()` — reverts `InvalidSupplyCap` when `newSupplyCap > type(uint128).max`

Passing `type(uint256).max` as suggested would revert. This corrects the helper's documentation to match the interface it encodes.

## Change

```diff
-    /// @param newSupplyCap New supply cap (`type(uint256).max` for no cap).
+    /// @param newSupplyCap New supply cap (`type(uint128).max` for no cap).
```

Comment-only change; no behavior or ABI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
