### PR TITLE
chore(test): scrub internal ticket/audit IDs from test comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ Deeper reading: `LIVE_PRECOMPILE_TESTING.md` (cross-validation architecture), `d
 - **Don't reshape mock storage layout unilaterally** — match `MockB20Storage.sol` slot constants
   and cross-validate with `make fork-tests` before merging.
 - **Don't commit `.env` or real private keys** — `.env` is gitignored; use funded testnet keys.
+- **Don't introduce internal-only references** — this repo is public. No links or paths to non-public
+  resources (internal wikis, private design docs, dashboards, chat), no internal ticket or
+  audit-finding IDs, no internal codenames or handles — in code, comments, NatSpec, docs, or commit
+  messages. Restate internal rationale inline in public terms instead of linking it; public EIP/ERC
+  and GitHub URLs and `@author Coinbase` are fine. Remove any you find.
 - **Don't hand-edit ABIs for the smoke tests** — `script/smoke/abis.py` loads them from `out/`;
   run `forge build` instead.
 - **Don't weaken a slot-assertion test to make live-precompile tests pass** — investigate the divergence via

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -195,8 +195,8 @@ abstract contract MockB20 is IB20 {
         _requireNonZeroActors(from, to);
         // Allowance is consumed unconditionally — including during the factory
         // bootstrap window (`_isPrivileged()`). Matches the Rust precompile,
-        // which carves no `privileged` exception for allowance accounting
-        // (BOP-230 / L-04); only the executor-policy check below is bypassed
+        // which carves no `privileged` exception for allowance accounting;
+        // only the executor-policy check below is bypassed
         // for a privileged caller. An infinite allowance is still not
         // decremented (handled inside `_consumeAllowance`).
         _consumeAllowance(from, msg.sender, amount);
@@ -244,7 +244,7 @@ abstract contract MockB20 is IB20 {
     {
         _requireNonZeroActors(from, to);
         // Allowance is consumed unconditionally — including during the factory
-        // bootstrap window — matching the Rust precompile (BOP-230 / L-04).
+        // bootstrap window — matching the Rust precompile.
         // Only the executor-policy check below is bypassed for a privileged
         // caller; infinite allowance is still not decremented.
         _consumeAllowance(from, msg.sender, amount);
@@ -717,7 +717,7 @@ abstract contract MockB20 is IB20 {
     ///      this helper. `transferFrom` / `transferFromWithMemo`
     ///      additionally consume the allowance (unconditionally —
     ///      including in the bootstrap window, matching the Rust
-    ///      precompile, see BOP-230 / L-04) and check the executor
+    ///      precompile) and check the executor
     ///      policy in their bodies before calling here; only the
     ///      executor-policy check honors the bootstrap bypass,
     ///      consistent with the sender/receiver policy bypass below.

--- a/test/regression/B20Removals.t.sol
+++ b/test/regression/B20Removals.t.sol
@@ -37,13 +37,13 @@ contract B20RemovalsTest is B20AssetTest {
     // ============================================================
 
     /// @notice Verifies the `redeem(uint256)` selector no longer resolves on the B-20 surface
-    /// @dev A reintroduced `redeem` entrypoint trips this. Regression: BOP-251.
+    /// @dev A reintroduced `redeem` entrypoint trips this.
     function test_redeem_revert_selectorRemoved(uint256 amount) public {
         _assertSelectorRemoved(abi.encodeWithSignature("redeem(uint256)", amount), "redeem(uint256) must not resolve");
     }
 
     /// @notice Verifies the `redeemWithMemo(uint256,bytes32)` selector no longer resolves
-    /// @dev Memo'd variant of the removed redeem path. Regression: BOP-251.
+    /// @dev Memo'd variant of the removed redeem path.
     function test_redeemWithMemo_revert_selectorRemoved(uint256 amount, bytes32 memo) public {
         _assertSelectorRemoved(
             abi.encodeWithSignature("redeemWithMemo(uint256,bytes32)", amount, memo),
@@ -52,13 +52,13 @@ contract B20RemovalsTest is B20AssetTest {
     }
 
     /// @notice Verifies the `minimumRedeemable()` getter no longer resolves
-    /// @dev The redemption floor getter was removed with the redemption subsystem. Regression: BOP-251.
+    /// @dev The redemption floor getter was removed with the redemption subsystem.
     function test_minimumRedeemable_revert_selectorRemoved() public {
         _assertSelectorRemoved(abi.encodeWithSignature("minimumRedeemable()"), "minimumRedeemable() must not resolve");
     }
 
     /// @notice Verifies the `updateMinimumRedeemable(uint256)` setter no longer resolves
-    /// @dev The redemption floor setter was removed with the redemption subsystem. Regression: BOP-251.
+    /// @dev The redemption floor setter was removed with the redemption subsystem.
     function test_updateMinimumRedeemable_revert_selectorRemoved(uint256 newMin) public {
         _assertSelectorRemoved(
             abi.encodeWithSignature("updateMinimumRedeemable(uint256)", newMin),
@@ -67,7 +67,7 @@ contract B20RemovalsTest is B20AssetTest {
     }
 
     /// @notice Verifies the `REDEEM_SENDER_POLICY()` policy-scope constant no longer resolves
-    /// @dev The redemption policy lane was removed with the redemption subsystem. Regression: BOP-251.
+    /// @dev The redemption policy lane was removed with the redemption subsystem.
     function test_redeemSenderPolicy_revert_selectorRemoved() public {
         _assertSelectorRemoved(
             abi.encodeWithSignature("REDEEM_SENDER_POLICY()"), "REDEEM_SENDER_POLICY() must not resolve"
@@ -77,7 +77,7 @@ contract B20RemovalsTest is B20AssetTest {
     /// @notice Verifies the `PausableFeature` enum has no fourth (`REDEEM`) member
     /// @dev `isPaused(PausableFeature)` ABI-decodes its arg as the enum; an out-of-range value (3)
     ///      reverts (Panic 0x21). Index 2 (`BURN`) still decodes, bracketing the enum at exactly
-    ///      {TRANSFER, MINT, BURN}. Regression: BOP-251.
+    ///      {TRANSFER, MINT, BURN}.
     function test_isPaused_revert_noRedeemFeature() public {
         _assertSelectorRemoved(
             abi.encodeWithSignature("isPaused(uint8)", uint8(3)),
@@ -90,7 +90,7 @@ contract B20RemovalsTest is B20AssetTest {
 
     /// @notice Verifies the all-features-paused bitmask covers exactly three features
     /// @dev `ALL_FEATURES_PAUSED == 7` is `TRANSFER | MINT | BURN` (0b111); a fourth feature would
-    ///      push it to 15. Pins the feature count at the library source-of-truth. Regression: BOP-251.
+    ///      push it to 15. Pins the feature count at the library source-of-truth.
     function test_allFeaturesPaused_success_threeFeatureBitmask() public pure {
         assertEq(B20Constants.ALL_FEATURES_PAUSED, 7, "ALL_FEATURES_PAUSED must be TRANSFER|MINT|BURN (0b111)");
     }
@@ -100,7 +100,7 @@ contract B20RemovalsTest is B20AssetTest {
     // ============================================================
 
     /// @notice Verifies the `batchBurn(address[],uint256[])` selector no longer resolves
-    /// @dev Only `batchMint` remains on the asset variant. Regression: BOP-250.
+    /// @dev Only `batchMint` remains on the asset variant.
     function test_batchBurn_revert_selectorRemoved(address account, uint256 amount) public {
         address[] memory accounts = _singletonAddresses(account);
         uint256[] memory amounts = _singletonUints(amount);
@@ -111,7 +111,7 @@ contract B20RemovalsTest is B20AssetTest {
     }
 
     /// @notice Verifies the `BURN_FROM_ROLE()` role constant no longer resolves
-    /// @dev `burnBlocked` (gated by `BURN_BLOCKED_ROLE`) is the remaining seize path. Regression: BOP-250.
+    /// @dev `burnBlocked` (gated by `BURN_BLOCKED_ROLE`) is the remaining seize path.
     function test_burnFromRole_revert_selectorRemoved() public {
         _assertSelectorRemoved(abi.encodeWithSignature("BURN_FROM_ROLE()"), "BURN_FROM_ROLE() must not resolve");
     }
@@ -123,7 +123,7 @@ contract B20RemovalsTest is B20AssetTest {
     /// @notice Verifies the factory rejects a third (`DEFAULT`) variant discriminator
     /// @dev `B20Variant` is now exactly {ASSET=0, STABLECOIN=1}. `createB20` ABI-decodes `variant`
     ///      as the enum, so discriminator 2 reverts (Panic 0x21) before reaching the factory body;
-    ///      a reintroduced third variant would let this succeed. Regression: BOP-253.
+    ///      a reintroduced third variant would let this succeed.
     function test_createB20_revert_defaultVariantRemoved(bytes32 salt) public {
         bytes memory params = abi.encode(_assetParams());
         (bool ok,) = address(factory)

--- a/test/regression/B20Renames.t.sol
+++ b/test/regression/B20Renames.t.sol
@@ -23,8 +23,7 @@ import {ActivationRegistryFeatureList} from "base-std-test/lib/mocks/ActivationR
 ///
 /// @dev    Old-selector absence is checked with low-level calls (the token carries no fallback, so
 ///         a retired selector cannot resolve); new surface is checked with typed calls that only
-///         compile against the current interface. Each test tags the change it guards with a
-///         trailing `Regression: BOP-XXX.` line.
+///         compile against the current interface.
 contract B20RenamesTest is B20AssetTest {
     /// @dev Asserts a removed selector no longer resolves on the token surface.
     function _assertSelectorRemoved(bytes memory callData, string memory err) internal {
@@ -38,7 +37,6 @@ contract B20RenamesTest is B20AssetTest {
 
     /// @notice Verifies the operator role is exposed as `OPERATOR_ROLE`.
     /// @dev The wire value (`keccak256("OPERATOR_ROLE")`) and library source-of-truth must agree.
-    ///      Regression: BOP-248.
     function test_operatorRole_success_renamedFromSecurityOperator() public view {
         assertEq(asset().OPERATOR_ROLE(), keccak256("OPERATOR_ROLE"), "OPERATOR_ROLE must equal its keccak preimage");
         assertEq(asset().OPERATOR_ROLE(), B20Constants.OPERATOR_ROLE, "OPERATOR_ROLE must match B20Constants");
@@ -51,7 +49,7 @@ contract B20RenamesTest is B20AssetTest {
     /// @notice Verifies share-ratio scaling is exposed under the `multiplier` names and the legacy
     ///         share-ratio selectors are gone
     /// @dev The new getters resolve (a fresh token reports a WAD multiplier) and every legacy
-    ///      selector must not resolve. Regression: BOP-249.
+    ///      selector must not resolve.
     function test_multiplier_success_renamedFromShareRatio(uint256 rawBalance) public {
         rawBalance = bound(rawBalance, 0, type(uint128).max);
 
@@ -89,7 +87,7 @@ contract B20RenamesTest is B20AssetTest {
     /// @notice Verifies the multiplier-change event was widened/renamed to the ERC-8056
     ///         `UIMultiplierUpdated(old, new, effectiveAt)` and the legacy `MultiplierUpdated(uint256)`
     ///         is gone
-    /// @dev `updateMultiplier` must emit the ERC-8056 topic and never the legacy topic. Regression: BOP-431.
+    /// @dev `updateMultiplier` must emit the ERC-8056 topic and never the legacy topic.
     function test_multiplierEvent_success_widenedToUIMultiplierUpdated(uint256 newMultiplier) public {
         newMultiplier = bound(newMultiplier, 1, type(uint128).max);
         _grantOperator();
@@ -108,7 +106,7 @@ contract B20RenamesTest is B20AssetTest {
     /// @notice Verifies the ERC-8056 surface resolves and aliases the native B20 names
     /// @dev `uiMultiplier` aliases `multiplier`; `balanceOfUI` aliases `scaledBalanceOf`; the pending
     ///      surface, `totalSupplyUI`, and `supportsInterface` all resolve. These typed calls only
-    ///      compile against the current interface, so their presence is the guard. Regression: BOP-431.
+    ///      compile against the current interface, so their presence is the guard.
     function test_erc8056Surface_success_aliasesResolve(uint256 amount) public {
         amount = bound(amount, 0, type(uint128).max);
         if (amount > 0) _mint(alice, amount);
@@ -130,7 +128,7 @@ contract B20RenamesTest is B20AssetTest {
 
     /// @notice Verifies `updateExtraMetadata` is gated by METADATA_ROLE, not OPERATOR_ROLE
     /// @dev An OPERATOR_ROLE-only holder is rejected with the METADATA_ROLE selector; a
-    ///      METADATA_ROLE holder succeeds. Regression: BOP-248.
+    ///      METADATA_ROLE holder succeeds.
     function test_updateExtraMetadata_success_gatedByMetadataRole(string calldata value) public {
         // Operator (OPERATOR_ROLE only) cannot write metadata.
         _grantOperator();
@@ -149,7 +147,7 @@ contract B20RenamesTest is B20AssetTest {
 
     /// @notice Verifies `updateMultiplier` is gated by OPERATOR_ROLE, not METADATA_ROLE
     /// @dev A METADATA_ROLE-only holder is rejected with the OPERATOR_ROLE selector — the inverse
-    ///      of the metadata-gating test, confirming the two authorities are distinct. Regression: BOP-248.
+    ///      of the metadata-gating test, confirming the two authorities are distinct.
     function test_updateMultiplier_revert_metadataRoleInsufficient(uint256 newMultiplier) public {
         newMultiplier = bound(newMultiplier, 1, type(uint128).max);
         _grantRole(B20Constants.METADATA_ROLE, bob);
@@ -163,7 +161,7 @@ contract B20RenamesTest is B20AssetTest {
     /// @notice Verifies METADATA_ROLE is administered by DEFAULT_ADMIN_ROLE on a freshly created token
     /// @dev The asset variant does not set a custom admin for METADATA_ROLE, so it defaults to
     ///      DEFAULT_ADMIN_ROLE (the default admin grants/revokes METADATA_ROLE). Authority over
-    ///      metadata *operations* is separate and split per the two tests above. Regression: BOP-248.
+    ///      metadata *operations* is separate and split per the two tests above.
     function test_metadataRole_success_administeredByDefaultAdmin() public view {
         assertEq(
             token.getRoleAdmin(B20Constants.METADATA_ROLE),
@@ -178,7 +176,7 @@ contract B20RenamesTest is B20AssetTest {
 
     /// @notice Verifies the asset activation feature is keyed on the `base.b20_asset` namespace
     /// @dev This is the cross-language contract with the Rust `ActivationFeature` enum; a preimage
-    ///      drift desyncs the gate. Regression: BOP-257.
+    ///      drift desyncs the gate.
     function test_b20Asset_success_keyedOnAssetNamespace() public pure {
         assertEq(
             ActivationRegistryFeatureList.B20_ASSET,
@@ -189,7 +187,7 @@ contract B20RenamesTest is B20AssetTest {
 
     /// @notice Verifies the asset feature is not keyed on either retired namespace
     /// @dev Asserting the asset id differs from both retired preimages locks against an accidental
-    ///      revert to the old `base.b20_security` / `base.b20_token` namespace string. Regression: BOP-257.
+    ///      revert to the old `base.b20_security` / `base.b20_token` namespace string.
     function test_b20Asset_success_notKeyedOnLegacyNamespaces() public pure {
         assertTrue(
             ActivationRegistryFeatureList.B20_ASSET != keccak256("base.b20_security"),

--- a/test/unit/ActivationRegistry/isActivated.t.sol
+++ b/test/unit/ActivationRegistry/isActivated.t.sol
@@ -7,7 +7,7 @@ contract ActivationRegistryIsActivatedTest is ActivationRegistryTest {
     /// @notice Verifies isActivated returns false for any feature id that has never been activated
     /// @dev Default state across the entire bytes32 id space. IActivationRegistry NatSpec L45-47
     ///      explicitly carves this out: "not raised by `isActivated`, which returns `false`
-    ///      instead." Regression test for L-04 (was: revert "not implemented").
+    ///      instead." Regression test (was: revert "not implemented").
     function test_isActivated_success_defaultFalse(bytes32 feature) public view {
         _assumeFreshFeature(feature);
         assertFalse(activationRegistry.isActivated(feature), "isActivated must return false for unactivated features");

--- a/test/unit/B20/erc20/transferFrom.t.sol
+++ b/test/unit/B20/erc20/transferFrom.t.sol
@@ -369,15 +369,15 @@ contract B20TransferFromTest is B20Test {
     }
 
     // ============================================================
-    //        REGRESSION: PRIVILEGED BOOTSTRAP ALLOWANCE (BOP-230 / L-04)
+    //        REGRESSION: PRIVILEGED BOOTSTRAP ALLOWANCE
     // ============================================================
     //
     // A privileged transferFrom (factory caller during the bootstrap
     // window) consumes allowance exactly like an ordinary transferFrom:
     // the allowance is both CHECKED and DECREMENTED. The Rust precompile
     // carves no `privileged` exception for allowance accounting — only the
-    // executor-policy check is bypassed for a privileged caller. Before
-    // BOP-230 the Solidity reference skipped the entire allowance block
+    // executor-policy check is bypassed for a privileged caller. Previously
+    // the Solidity reference skipped the entire allowance block
     // during the window (neither checking nor decrementing); these tests
     // pin the corrected, Rust-aligned behavior.
     //
@@ -388,8 +388,8 @@ contract B20TransferFromTest is B20Test {
 
     /// @notice Verifies a privileged transferFrom reverts InsufficientAllowance when allowance is below the spend
     /// @dev Pins that the allowance check is unconditional — a privileged caller is still
-    ///      rejected for insufficient allowance; before BOP-230 the privileged path skipped
-    ///      the check entirely. Regression: BOP-230 / L-04.
+    ///      rejected for insufficient allowance; previously the privileged path skipped
+    ///      the check entirely.
     function test_transferFrom_revert_privileged_insufficientAllowance(
         address from,
         address to,
@@ -425,8 +425,8 @@ contract B20TransferFromTest is B20Test {
 
     /// @notice Verifies a privileged transferFrom decrements allowance by the spent amount
     /// @dev Allowance is consumed during the bootstrap window exactly as outside it, matching
-    ///      the Rust precompile. Before BOP-230 the privileged path left the allowance
-    ///      untouched. Regression: BOP-230 / L-04.
+    ///      the Rust precompile. Previously the privileged path left the allowance
+    ///      untouched.
     function test_transferFrom_success_privileged_decrementsAllowance(
         address from,
         address to,
@@ -472,7 +472,7 @@ contract B20TransferFromTest is B20Test {
     ///      accounting): this isolates the executor-policy bypass. With TRANSFER_EXECUTOR_POLICY set to
     ///      ALWAYS_BLOCK a non-privileged transferFrom reverts PolicyForbids; the privileged (factory
     ///      bootstrap) path must succeed and still burn the allowance. Only the executor-policy check
-    ///      honors the privileged bypass — the allowance is consumed unconditionally (BOP-230 / L-04).
+    ///      honors the privileged bypass — the allowance is consumed unconditionally.
     function test_transferFrom_success_privileged_skipsExecutorPolicy(address from, address to, uint256 amount) public {
         // Mock-only by necessity: like test_transferFrom_revert_privileged_insufficientAllowance,
         // the privileged path needs a pre-existing allowance[from][factory] (from != factory) that

--- a/test/unit/B20/memo/transferFromWithMemo.t.sol
+++ b/test/unit/B20/memo/transferFromWithMemo.t.sol
@@ -182,7 +182,7 @@ contract B20TransferFromWithMemoTest is B20Test {
     }
 
     // ============================================================
-    //        REGRESSION: PRIVILEGED BOOTSTRAP ALLOWANCE (BOP-230 / L-04)
+    //        REGRESSION: PRIVILEGED BOOTSTRAP ALLOWANCE
     // ============================================================
     //
     // Mirrors the transferFrom regression: a privileged transferFromWithMemo
@@ -193,8 +193,8 @@ contract B20TransferFromWithMemoTest is B20Test {
 
     /// @notice Verifies a privileged transferFromWithMemo reverts InsufficientAllowance when allowance is below the spend
     /// @dev Pins that the allowance check is unconditional — a privileged caller is still
-    ///      rejected for insufficient allowance; before BOP-230 the privileged path skipped
-    ///      the check entirely. Regression: BOP-230 / L-04.
+    ///      rejected for insufficient allowance; previously the privileged path skipped
+    ///      the check entirely.
     function test_transferFromWithMemo_revert_privileged_insufficientAllowance(
         address from,
         address to,
@@ -231,8 +231,8 @@ contract B20TransferFromWithMemoTest is B20Test {
 
     /// @notice Verifies a privileged transferFromWithMemo decrements allowance by the spent amount
     /// @dev Allowance is consumed during the bootstrap window exactly as outside it, matching
-    ///      the Rust precompile. Before BOP-230 the privileged path left the allowance
-    ///      untouched. Regression: BOP-230 / L-04.
+    ///      the Rust precompile. Previously the privileged path left the allowance
+    ///      untouched.
     function test_transferFromWithMemo_success_privileged_decrementsAllowance(
         address from,
         address to,

--- a/test/unit/B20/supply/mint.t.sol
+++ b/test/unit/B20/supply/mint.t.sol
@@ -76,7 +76,7 @@ contract B20MintTest is B20Test {
     }
 
     /// @notice Verifies MINT_RECEIVER_POLICY is enforced even for a privileged (factory bootstrap) mint
-    /// @dev Mint-side counterpart to the transfer privileged-bypass tests (BOP-332): the bootstrap window
+    /// @dev Mint-side counterpart to the transfer privileged-bypass tests: the bootstrap window
     ///      bypasses the transfer-side policies but ALWAYS enforces MINT_RECEIVER_POLICY, so new supply is
     ///      never issued to a policy-denied recipient even at creation. Privilege is reached through a
     ///      genuine bootstrap: the token is created with initCalls that (1) set the mint-receiver policy to

--- a/test/unit/B20Factory/createToken.t.sol
+++ b/test/unit/B20Factory/createToken.t.sol
@@ -667,7 +667,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         assertEq(actual, address(expectedAddr), "factory must derive address via abi.encode of (sender, salt)");
     }
 
-    /// @notice Verifies an empty `name` round-trips as the empty string (regression test for L-04)
+    /// @notice Verifies an empty `name` round-trips as the empty string
     /// @dev The factory's `_writeString` short-string path uses `mload(add(data, 32))` even when
     ///      `data.length == 0`, which reads adjacent memory rather than zero bytes. With name=""
     ///      and symbol="ETH", the ABI decoder places symbol's length word at name's data+32, so
@@ -687,7 +687,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         assertEq(vm.load(tokenAddr, MockB20Storage.nameSlot()), bytes32(0), "empty name field slot must be all-zero");
     }
 
-    /// @notice Verifies an empty `symbol` round-trips as the empty string (regression test for L-04)
+    /// @notice Verifies an empty `symbol` round-trips as the empty string
     /// @dev Symmetric to the empty-name test. Symbol is the second string written so the OOB read
     ///      reads past it, into whatever the next memory allocation placed there. Whether it's
     ///      garbage from the free-memory pointer or padded zeros depends on calling context; we
@@ -703,7 +703,7 @@ contract B20FactoryCreateB20Test is B20FactoryTest {
         );
     }
 
-    /// @notice Verifies both empty name and empty symbol round-trip correctly (regression test for L-04)
+    /// @notice Verifies both empty name and empty symbol round-trip correctly
     /// @dev Belt-and-suspenders: both strings empty is the most degenerate case and would be
     ///      most likely to surface memory-layout assumptions in the writer.
     function test_createB20_success_bothEmpty_roundTripAsEmpty(address caller, bytes32 salt) public {


### PR DESCRIPTION
## Summary

Removes internal identifiers from OSS test comments so nothing internal ships in the public repo, and adds an `AGENTS.md` boundary so it stays that way. Comments/docs only — **no test logic or assertions change**.

- **Linear ticket IDs (`BOP-###`)** stripped from regression/unit test comments. Trailing `Regression: BOP-XXX.` tags removed; temporal references reworded (e.g. "before BOP-230 the privileged path…" → "previously the privileged path…") so the technical intent is preserved.
- **Audit-finding IDs (`L-04`)** removed from `createToken` / `isActivated` test comments the same way.
- Updated the `B20RenamesTest` contract-level doc that described the now-removed `Regression: BOP-XXX.` tagging convention.
- **New `AGENTS.md` boundary**: forbids internal-only references (private docs/links, ticket/audit IDs, internal codenames) from ever entering this public repo. Described *by class* rather than naming internal hosts (which would itself be a leak).

## Scope

8 test files (`transferFrom.t.sol`, `transferFromWithMemo.t.sol`, `mint.t.sol`, `createToken.t.sol`, `isActivated.t.sol`, `B20Removals.t.sol`, `B20Renames.t.sol`, `MockB20.sol`) plus a one-bullet addition to `AGENTS.md`.

## Not included

The `D9` reference in `src/interfaces/IScaledUIAmount.sol` (points at a private design doc) is removed by a separate in-flight PR that rewrites that interface's NatSpec, to avoid a merge conflict on the same block.

## Testing

`forge build` passes; no behavioral changes.
