### PR TITLE
test(smoke): pin composite policyType → IncompatiblePolicyType at the precompile boundary (BOP-476)

### DIFF
--- a/script/smoke/journeys/precompile_invariants.py
+++ b/script/smoke/journeys/precompile_invariants.py
@@ -34,6 +34,7 @@ FACTORY = config.B20_FACTORY
 POLICY = config.POLICY_REGISTRY
 ALLOWLIST = config.POLICY_TYPE_ALLOWLIST
 UNION = config.POLICY_TYPE_UNION
+INTERSECT = config.POLICY_TYPE_INTERSECT
 
 # Check names that are known/accepted divergences: reported, but do not fail the run.
 INFORMATIONAL: set[str] = set()
@@ -93,6 +94,27 @@ def _truncated_args_revert(c: Chain, _probe) -> None:
 def _enum_out_of_range_reverts(c: Chain, _probe) -> None:
     bad_enum = _selector("createPolicy(address,uint8)") + _addr_word(c.DEPLOYER) + (5).to_bytes(32, "big")
     c.expect_raw_revert("enum out of range", POLICY, bad_enum)
+
+
+def _create_policy_composite_type_reverts(c: Chain, _probe) -> None:
+    # UNION (2) / INTERSECT (3) decode at Cobalt (the enum widened to 4 variants) and reach the logic,
+    # which rejects them with IncompatiblePolicyType rather than a decode failure or Panic. Both simple
+    # constructors share the guard (after the zero-admin check, before the batch-size guard); composites
+    # are minted only via createCompositePolicy. Well-formed ABI, so build it with the canonical encoder
+    # (a non-zero admin isolates the type check from the ZeroAddress path; an empty batch confirms the
+    # type check precedes the batch-size guard on the with-accounts path).
+    for policy_type in (UNION, INTERSECT):
+        create = _clean(c.policy, "createPolicy", c.DEPLOYER, policy_type)
+        c.expect_raw_revert(
+            f"createPolicy composite type {policy_type}", POLICY, create, error_name="IncompatiblePolicyType"
+        )
+        with_accounts = _clean(c.policy, "createPolicyWithAccounts", c.DEPLOYER, policy_type, [])
+        c.expect_raw_revert(
+            f"createPolicyWithAccounts composite type {policy_type}",
+            POLICY,
+            with_accounts,
+            error_name="IncompatiblePolicyType",
+        )
 
 
 def _dirty_high_bits_rejected(c: Chain, _probe) -> None:
@@ -201,6 +223,10 @@ CHECKS: list[tuple[str, Callable[[Chain, object], None]]] = [
     ("empty calldata reverts (no implicit receive/fallback)", _empty_calldata_reverts),
     ("truncated args revert (strict ABI decode)", _truncated_args_revert),
     ("out-of-range enum reverts", _enum_out_of_range_reverts),
+    (
+        "createPolicy/createPolicyWithAccounts composite type reverts IncompatiblePolicyType",
+        _create_policy_composite_type_reverts,
+    ),
     ("dirty high bits rejected (strict ABI decode)", _dirty_high_bits_rejected),
     ("STATICCALL read-only enforced", _staticcall_read_only),
     ("value forwarding rejected through a contract", _value_forwarding_rejected),


### PR DESCRIPTION
## Summary

Adds a raw-calldata `precompile-invariants` probe that pins the composite-`policyType` revert behavior of the two simple-policy constructors **against the live Rust precompile**:

- `createPolicy(admin, UNION|INTERSECT)` → reverts `IncompatiblePolicyType`
- `createPolicyWithAccounts(admin, UNION|INTERSECT, [])` → reverts `IncompatiblePolicyType`

At Cobalt the `PolicyType` enum widened to 4 variants, so discriminant `2`/`3` now *decodes* and reaches the logic layer — which must reject it with the typed `IncompatiblePolicyType` error (not an ABI-decode failure or `Panic(0x21)`). Composites are minted only via `createCompositePolicy`.

The probe sends both constructors' calldata via raw `eth_call` and matches the `IncompatiblePolicyType` selector (`expect_raw_revert(..., error_name="IncompatiblePolicyType")`), so the behavior is pinned against **published binaries**, independent of the forge/mock unit suite. It complements #178's composite-*write* payable/value coverage.

## Context / coordination

This is the smoke half of BOP-476's fork+smoke coverage requirement. It pairs with:
- **base/base #4210** — the V2 Rust fix that makes `validate_create_policy_inputs` return `IncompatiblePolicyType` for a composite type.
- **base-std #176** — the mock guard + forge revert/revert-order tests (the *fork* half).

The probe only asserts the new behavior; it will pass against a Cobalt binary that carries #4210 and (correctly) fail against one that still returns `Panic(0x21)`. It does not run in base-std forge CI (`ci.yml` is forge/mocks); it executes via the smoke suite (`make smoke-invariants`) and base-anvil's smoke workflow against published binaries.

## Test plan

- [x] `script/smoke/journeys/precompile_invariants.py` parses; diff vs `main` is additive only.
- [x] Verified against the real `POLICY_ABI` that `_clean` encodes both constructors for UNION+INTERSECT with the correct 4-byte selectors, and that `IncompatiblePolicyType()` resolves in `ERROR_BY_SELECTOR` (the map `expect_raw_revert` matches against).
- [ ] `make smoke-invariants` green against a Cobalt base-anvil binary built with base/base #4210 (run in lockstep once #4210 is on a Cobalt build).

Made with [Cursor](https://cursor.com)