### PR TITLE
fix(b20-asset): bubble inner-call Panic from `announce` (BOP-477)

### DIFF
--- a/script/smoke/chain.py
+++ b/script/smoke/chain.py
@@ -36,6 +36,10 @@ from .codec import topic0
 from .errors import ERROR_BY_SELECTOR
 from .provider import ConsistentHTTPProvider
 
+# Solidity built-in `Panic(uint256)` selector. Not a custom error in any ABI, so it is not in
+# `ERROR_BY_SELECTOR`; matched directly by `expect_raw_panic`.
+PANIC_SELECTOR = bytes.fromhex("4e487b71")
+
 
 class Skip(Exception):
     """Raised by a journey to signal it does not apply to this chain (recorded as a skip, not a fail).
@@ -512,6 +516,42 @@ class Chain:
             return
         self._diagnose(f"{desc}: expected revert but call succeeded", repro_call=tx)
         die(f"{desc}: expected revert but call succeeded")
+
+    def expect_raw_panic(
+        self,
+        desc: str,
+        to: ChecksumAddress,
+        data: bytes,
+        code: int,
+        *,
+        frm: ChecksumAddress | None = None,
+    ) -> None:
+        """Simulate a hand-built call; assert it reverts with a Solidity `Panic(uint256)` of `code`.
+
+        `Panic` is a built-in error (selector 0x4e487b71), not a custom error in any ABI, so it is
+        not resolvable through `expect_raw_revert`'s selector map. Asserts the raw revert data is the
+        Panic selector followed by the 32-byte `code` (e.g. 0x11 for arithmetic overflow). Used to
+        pin that an inner-call system fault propagates raw out of `announce` (see BOP-477) rather
+        than being wrapped as `InternalCallFailed`.
+        """
+        tx = {"to": to, "from": frm or self.DEPLOYER, "data": HexBytes(data), "value": 0}
+        try:
+            self.w3.eth.call(tx)
+        except ContractLogicError as exc:
+            raw = self._revert_bytes(exc)
+            if raw is None or len(raw) < 4 or raw[:4] != PANIC_SELECTOR:
+                self._diagnose(f"{desc}: expected Panic({code:#x})", repro_call=tx)
+                die(f"{desc}: expected Panic(uint256) 0x4e487b71 but got {('0x' + raw.hex()) if raw else raw!r}")
+            got_code = int.from_bytes(raw[4:36], "big") if len(raw) >= 36 else None
+            if got_code != code:
+                self._diagnose(f"{desc}: wrong Panic code", repro_call=tx)
+                die(f"{desc}: expected Panic code {code:#x} but got {got_code if got_code is None else hex(got_code)}")
+            ok(f"{desc} (reverts Panic({code:#x}))")
+            return
+        except Exception as exc:  # noqa: BLE001 - surface any non-revert failure
+            die(f"{desc}: expected Panic({code:#x}) but call raised {type(exc).__name__}: {exc}")
+        self._diagnose(f"{desc}: expected Panic but call succeeded", repro_call=tx)
+        die(f"{desc}: expected Panic({code:#x}) but call succeeded")
 
     def send_expecting_revert(self, fn, account: LocalAccount, *, gas: int = 2_000_000) -> TxReceipt:
         """Broadcast a real tx with explicit gas (skips estimation) and assert the receipt reverted."""

--- a/script/smoke/chain.py
+++ b/script/smoke/chain.py
@@ -528,11 +528,8 @@ class Chain:
     ) -> None:
         """Simulate a hand-built call; assert it reverts with a Solidity `Panic(uint256)` of `code`.
 
-        `Panic` is a built-in error (selector 0x4e487b71), not a custom error in any ABI, so it is
-        not resolvable through `expect_raw_revert`'s selector map. Asserts the raw revert data is the
-        Panic selector followed by the 32-byte `code` (e.g. 0x11 for arithmetic overflow). Used to
-        pin that an inner-call system fault propagates raw out of `announce` (see BOP-477) rather
-        than being wrapped as `InternalCallFailed`.
+        Asserts the raw revert data is `PANIC_SELECTOR` followed by the 32-byte `code` (e.g. 0x11 for
+        arithmetic overflow).
         """
         tx = {"to": to, "from": frm or self.DEPLOYER, "data": HexBytes(data), "value": 0}
         try:

--- a/script/smoke/journeys/asset_lifecycle.py
+++ b/script/smoke/journeys/asset_lifecycle.py
@@ -140,6 +140,24 @@ def _edges(c: Chain, tok) -> None:
     reuse = tok.functions.announce([], "smoke-batch-1", "dup", "ipfs://smoke/dup")
     c.expect_revert("AnnouncementIdAlreadyUsed", reuse, c.DEPLOYER)
 
+    step("14b", "announce inner-call system fault propagates raw Panic (not wrapped as InternalCallFailed)")
+    # BOP-477: an inner call that raises a Solidity Panic bubbles the raw Panic unchanged; only
+    # ordinary reverts wrap as InternalCallFailed. The multiplier is 2e18 (step 7), so an inner
+    # toScaledBalance(type(uint256).max) overflows uint256 -> Panic(0x11). Asserting the raw
+    # Panic(uint256) payload from the live precompile is the conformance point.
+    inner_overflow = init_call(c.asset_abi, "toScaledBalance", 2**256 - 1)
+    panic_announce = init_call(
+        c.asset_abi, "announce", [inner_overflow], "smoke-panic-1", "overflow probe", "ipfs://smoke/panic-1"
+    )
+    c.expect_raw_panic(
+        "announce inner overflow -> raw Panic(0x11)", tok.address, panic_announce, 0x11, frm=c.DEPLOYER
+    )
+    c.assert_eq(
+        tok.functions.isAnnouncementIdUsed("smoke-panic-1").call(),
+        False,
+        "reverted announce must not consume the panic-probe id",
+    )
+
 
 def _events(c: Chain, v2: bool) -> None:
     step(15, "expected events emitted across the flow")

--- a/script/smoke/journeys/asset_lifecycle.py
+++ b/script/smoke/journeys/asset_lifecycle.py
@@ -140,11 +140,9 @@ def _edges(c: Chain, tok) -> None:
     reuse = tok.functions.announce([], "smoke-batch-1", "dup", "ipfs://smoke/dup")
     c.expect_revert("AnnouncementIdAlreadyUsed", reuse, c.DEPLOYER)
 
-    step("14b", "announce inner-call system fault propagates raw Panic (not wrapped as InternalCallFailed)")
-    # BOP-477: an inner call that raises a Solidity Panic bubbles the raw Panic unchanged; only
-    # ordinary reverts wrap as InternalCallFailed. The multiplier is 2e18 (step 7), so an inner
-    # toScaledBalance(type(uint256).max) overflows uint256 -> Panic(0x11). Asserting the raw
-    # Panic(uint256) payload from the live precompile is the conformance point.
+    step("14b", "announce inner Panic propagates raw (not wrapped as InternalCallFailed)")
+    # multiplier is 2e18 (step 7), so an inner toScaledBalance(uint256 max) overflows -> Panic(0x11);
+    # assert the live precompile bubbles the raw payload instead of wrapping it.
     inner_overflow = init_call(c.asset_abi, "toScaledBalance", 2**256 - 1)
     panic_announce = init_call(
         c.asset_abi, "announce", [inner_overflow], "smoke-panic-1", "overflow probe", "ipfs://smoke/panic-1"

--- a/src/interfaces/IB20Asset.sol
+++ b/src/interfaces/IB20Asset.sol
@@ -64,8 +64,7 @@ interface IB20Asset is IB20, IERC165, IScaledUIAmount, IScaledUIAmountNewUIMulti
     error InternalCallMalformed(bytes call);
 
     /// @notice An inner call dispatched by `announce` reverted with an ordinary revert; its reason is
-    ///         not bubbled. A system-level Solidity `Panic(uint256)` propagates raw instead of being
-    ///         wrapped here (see the `announce` natspec).
+    ///         not bubbled. A Solidity `Panic` propagates raw instead (see `announce`).
     ///
     /// @param call Offending raw calldata blob.
     error InternalCallFailed(bytes call);
@@ -121,9 +120,9 @@ interface IB20Asset is IB20, IERC165, IScaledUIAmount, IScaledUIAmountNewUIMulti
     /// @dev Reverts with `AnnouncementIdAlreadyUsed` when `id` has previously been consumed.
     /// @dev Reverts with `InternalCallMalformed` when an entry in `internalCalls` is shorter than four bytes.
     /// @dev Reverts with `AnnouncementInProgress` when an entry in `internalCalls` targets `announce` itself.
-    /// @dev An inner call that raises a Solidity Panic (e.g. arithmetic overflow 0x11, enum 0x21,
-    ///      array-out-of-bounds 0x32) propagates the raw Panic unchanged; any other inner revert is
-    ///      wrapped as `InternalCallFailed(call)`. Out-of-gas in an inner call halts the whole call.
+    /// @dev An inner call that raises a Solidity `Panic` (e.g. arithmetic overflow) propagates the
+    ///      raw Panic unchanged; any other inner revert wraps as `InternalCallFailed(call)`. An inner
+    ///      out-of-gas halts the whole call.
     ///
     /// @param internalCalls ABI-encoded calldata blobs executed in order via self-`delegatecall`; may be empty.
     /// @param id            Caller-chosen announcement id; single-use over the token's lifetime.

--- a/src/interfaces/IB20Asset.sol
+++ b/src/interfaces/IB20Asset.sol
@@ -63,7 +63,9 @@ interface IB20Asset is IB20, IERC165, IScaledUIAmount, IScaledUIAmountNewUIMulti
     /// @param call Offending raw calldata blob.
     error InternalCallMalformed(bytes call);
 
-    /// @notice An inner call dispatched by `announce` reverted. The inner revert reason is not bubbled.
+    /// @notice An inner call dispatched by `announce` reverted with an ordinary revert; its reason is
+    ///         not bubbled. A system-level Solidity `Panic(uint256)` propagates raw instead of being
+    ///         wrapped here (see the `announce` natspec).
     ///
     /// @param call Offending raw calldata blob.
     error InternalCallFailed(bytes call);
@@ -119,7 +121,9 @@ interface IB20Asset is IB20, IERC165, IScaledUIAmount, IScaledUIAmountNewUIMulti
     /// @dev Reverts with `AnnouncementIdAlreadyUsed` when `id` has previously been consumed.
     /// @dev Reverts with `InternalCallMalformed` when an entry in `internalCalls` is shorter than four bytes.
     /// @dev Reverts with `AnnouncementInProgress` when an entry in `internalCalls` targets `announce` itself.
-    /// @dev Reverts with `InternalCallFailed` when an entry in `internalCalls` reverts during the inner `delegatecall`.
+    /// @dev An inner call that raises a Solidity Panic (e.g. arithmetic overflow 0x11, enum 0x21,
+    ///      array-out-of-bounds 0x32) propagates the raw Panic unchanged; any other inner revert is
+    ///      wrapped as `InternalCallFailed(call)`. Out-of-gas in an inner call halts the whole call.
     ///
     /// @param internalCalls ABI-encoded calldata blobs executed in order via self-`delegatecall`; may be empty.
     /// @param id            Caller-chosen announcement id; single-use over the token's lifetime.

--- a/test/lib/mocks/MockB20Asset.sol
+++ b/test/lib/mocks/MockB20Asset.sol
@@ -109,16 +109,10 @@ contract MockB20Asset is MockB20, IB20Asset {
             _checkSelector(internalCalls[i]);
             (bool success, bytes memory ret) = address(this).delegatecall(internalCalls[i]);
             if (!success) {
-                // Match the Rust precompile: system-level faults (Solidity `Panic(uint256)`)
-                // propagate unwrapped; only ordinary reverts are wrapped as InternalCallFailed. See
-                // is_system_error() in base/base crates/common/precompile-storage/src/error.rs.
-                // The concretely reachable inner-call fault is arithmetic overflow (Panic 0x11) from
-                // e.g. toScaledBalance under a multiplier > 1; OutOfGas/Fatal/SlotOverflow are
-                // native-precompile faults a Solidity delegatecall cannot faithfully reproduce (OOG
-                // follows the 63/64 rule and yields empty returndata), so only the Panic class is
-                // aligned here.
+                // Match the Rust precompile's is_system_error(): a Solidity Panic propagates
+                // unwrapped; only ordinary reverts wrap as InternalCallFailed.
                 if (ret.length >= 4 && bytes4(ret) == bytes4(0x4e487b71)) {
-                    // Re-raise the exact returndata bytes; offset 0x20 skips the length word.
+                    // Re-raise the exact returndata; offset 0x20 skips the length word.
                     assembly {
                         revert(add(ret, 0x20), mload(ret))
                     }

--- a/test/lib/mocks/MockB20Asset.sol
+++ b/test/lib/mocks/MockB20Asset.sol
@@ -107,8 +107,24 @@ contract MockB20Asset is MockB20, IB20Asset {
 
         for (uint256 i = 0; i < internalCalls.length; i++) {
             _checkSelector(internalCalls[i]);
-            (bool success,) = address(this).delegatecall(internalCalls[i]);
-            if (!success) revert InternalCallFailed(internalCalls[i]);
+            (bool success, bytes memory ret) = address(this).delegatecall(internalCalls[i]);
+            if (!success) {
+                // Match the Rust precompile: system-level faults (Solidity `Panic(uint256)`)
+                // propagate unwrapped; only ordinary reverts are wrapped as InternalCallFailed. See
+                // is_system_error() in base/base crates/common/precompile-storage/src/error.rs.
+                // The concretely reachable inner-call fault is arithmetic overflow (Panic 0x11) from
+                // e.g. toScaledBalance under a multiplier > 1; OutOfGas/Fatal/SlotOverflow are
+                // native-precompile faults a Solidity delegatecall cannot faithfully reproduce (OOG
+                // follows the 63/64 rule and yields empty returndata), so only the Panic class is
+                // aligned here.
+                if (ret.length >= 4 && bytes4(ret) == bytes4(0x4e487b71)) {
+                    // Re-raise the exact returndata bytes; offset 0x20 skips the length word.
+                    assembly {
+                        revert(add(ret, 0x20), mload(ret))
+                    }
+                }
+                revert InternalCallFailed(internalCalls[i]);
+            }
         }
 
         emit EndAnnouncement(id);

--- a/test/unit/B20Asset/announcement/announce.t.sol
+++ b/test/unit/B20Asset/announcement/announce.t.sol
@@ -76,6 +76,29 @@ contract B20AssetAnnounceTest is B20AssetTest {
         asset().announce(_singletonBytes(failingCall), "fail-id", "desc", "uri");
     }
 
+    /// @notice Verifies an inner call that raises a Solidity Panic propagates the raw Panic
+    ///         unchanged instead of being wrapped as InternalCallFailed.
+    /// @dev System-fault parity with the Rust precompile: is_system_error() (see base/base
+    ///      crates/common/precompile-storage/src/error.rs) propagates Panic/OutOfGas/Fatal/
+    ///      SlotOverflow raw; only ordinary reverts wrap as InternalCallFailed. The one inner-call
+    ///      Panic concretely reachable through announce is arithmetic overflow (0x11): a multiplier
+    ///      > 1 makes toScaledBalance(type(uint256).max) overflow uint256. Deliberately NOT skipped
+    ///      under live precompiles — asserting the raw Panic payload from the live precompile is the
+    ///      conformance point. The enum (0x21) and array-out-of-bounds (0x32) Panic classes have no
+    ///      inner-call selector that reaches them (strict ABI decode rejects out-of-range enums
+    ///      before any conversion guard, and no reachable path produces an array-OOB), so only the
+    ///      overflow class is exercised here.
+    function test_announce_innerPanic_propagatesRaw() public {
+        _grantOperator();
+        // Multiplier > 1 WAD so `rawBalance * multiplier` overflows uint256 for a large rawBalance.
+        _updateMultiplier(2 * asset().WAD_PRECISION());
+        bytes memory inner = abi.encodeWithSelector(IB20Asset.toScaledBalance.selector, type(uint256).max);
+
+        vm.prank(operator);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        asset().announce(_singletonBytes(inner), "panic-id", "desc", "uri");
+    }
+
     /// @notice Verifies a failed announcement does NOT consume the id (atomicity)
     /// @dev The whole tx unwinds on inner-call failure, including the
     ///      `usedAnnouncementIds[id] = true` write that announce performs before the

--- a/test/unit/B20Asset/announcement/announce.t.sol
+++ b/test/unit/B20Asset/announcement/announce.t.sol
@@ -77,20 +77,12 @@ contract B20AssetAnnounceTest is B20AssetTest {
     }
 
     /// @notice Verifies an inner call that raises a Solidity Panic propagates the raw Panic
-    ///         unchanged instead of being wrapped as InternalCallFailed.
-    /// @dev System-fault parity with the Rust precompile: is_system_error() (see base/base
-    ///      crates/common/precompile-storage/src/error.rs) propagates Panic/OutOfGas/Fatal/
-    ///      SlotOverflow raw; only ordinary reverts wrap as InternalCallFailed. The one inner-call
-    ///      Panic concretely reachable through announce is arithmetic overflow (0x11): a multiplier
-    ///      > 1 makes toScaledBalance(type(uint256).max) overflow uint256. Deliberately NOT skipped
-    ///      under live precompiles — asserting the raw Panic payload from the live precompile is the
-    ///      conformance point. The enum (0x21) and array-out-of-bounds (0x32) Panic classes have no
-    ///      inner-call selector that reaches them (strict ABI decode rejects out-of-range enums
-    ///      before any conversion guard, and no reachable path produces an array-OOB), so only the
-    ///      overflow class is exercised here.
+    ///         unchanged instead of being wrapped as InternalCallFailed (parity with the Rust impl).
+    /// @dev Arithmetic overflow (0x11) is the one inner-call Panic reachable on both sides: a
+    ///      multiplier > 1 makes toScaledBalance(uint256 max) overflow. NOT skipped under live
+    ///      precompiles — asserting the raw payload from the live precompile is the conformance point.
     function test_announce_innerPanic_propagatesRaw() public {
         _grantOperator();
-        // Multiplier > 1 WAD so `rawBalance * multiplier` overflows uint256 for a large rawBalance.
         _updateMultiplier(2 * asset().WAD_PRECISION());
         bytes memory inner = abi.encodeWithSelector(IB20Asset.toScaledBalance.selector, type(uint256).max);
 


### PR DESCRIPTION
## Summary

Reconciles a base/base (Rust, authoritative) ↔ base-std (Solidity reference) divergence in `IB20Asset.announce`. When an inner call fails, the Rust precompile propagates **system-level faults raw** (`Panic`/`OutOfGas`/`Fatal`/`SlotOverflow`, via `is_system_error()`) and wraps **only ordinary reverts** as `InternalCallFailed`. The Solidity mock wrapped *every* inner failure — so e.g. `announce([toScaledBalance(overflowing)])` reverts `Panic(0x11)` on-chain but `InternalCallFailed` in the reference.

Chosen direction (Rust is authoritative — OOG must halt to preserve EVM gas semantics, and a Panic is a VM-level fault): **fix base-std to match Rust.**

- `MockB20Asset.announce` re-raises an inner Solidity `Panic(uint256)` (selector `0x4e487b71`) unchanged via `assembly { revert(add(ret, 0x20), mload(ret)) }`; ordinary reverts still wrap as `InternalCallFailed`.
- `IB20Asset.announce` natspec corrected: an inner Panic propagates raw; OOG halts the whole call; any other revert wraps as `InternalCallFailed`. `InternalCallFailed` error doc clarified.
- Added fork conformance test `test_announce_innerPanic_propagatesRaw` — asserts the raw `Panic(0x11)` payload from the **live** precompile (no `livePrecompiles` skip).
- Added a smoke probe (asset journey, step 14b) + reusable `expect_raw_panic` helper asserting the raw `Panic(0x11)` payload via `eth_call`.

## Scope / limitation

- Only the arithmetic-overflow Panic (**0x11**) is reachable as an inner call on **both** sides, so that's what the conformance/smoke assert.
- `OutOfGas`/`Fatal`/`SlotOverflow` are native-precompile faults a Solidity `delegatecall` cannot faithfully reproduce (OOG follows the 63/64 rule and yields empty returndata) — not synthesized in the mock.
- Enum (`0x21`) / array-OOB (`0x32`) have **no reachable inner-call selector**: strict ABI decoding rejects an out-of-range enum as `AbiDecodeFailed` (an ordinary revert) *before* any conversion guard, and nothing produces an array-OOB. (Note: a malformed-enum inner call surfaces a decode-time `Panic(0x21)` in Solidity vs `AbiDecodeFailed` in Rust — not part of the conformance matrix.)

## Test plan

- [x] `forge test --match-contract B20AssetAnnounceTest` (reference / mocks) — 14 pass
- [x] Full `test/unit/B20Asset/*` reference suite — 100 pass; `forge fmt --check` clean
- [x] **Fork conformance** vs a live `anvil --base` (Cobalt) node: `test/unit/B20Asset/announcement/*` — 20 pass, incl. `test_announce_innerPanic_propagatesRaw`
- [x] **Smoke** `asset` journey vs the same live node — green, incl. the step-14b raw `Panic(0x11)` probe

Companion (base/base): a test-only self-pin extension asserting every Panic kind classifies as a system error.

Made with [Cursor](https://cursor.com)