### PR TITLE
PolicyRegistry: drop ChildPoliciesOutsideOfRange args, add composite child-count getters

### DIFF
--- a/src/interfaces/IPolicyRegistry.sol
+++ b/src/interfaces/IPolicyRegistry.sol
@@ -57,11 +57,9 @@ interface IPolicyRegistry {
     error NoPendingAdmin();
 
     /// @notice A composite policy was created or updated with a child-policy count outside the
-    ///         permitted range. A composite must reference between `min` and `max` simple policies,
-    ///         inclusive.
-    /// @param min Minimum number of child policies permitted.
-    /// @param max Maximum number of child policies permitted.
-    error ChildPoliciesOutsideOfRange(uint256 min, uint256 max);
+    ///         permitted range. A composite must reference between `MIN_COMPOSITE_CHILD_POLICIES`
+    ///         and `MAX_COMPOSITE_CHILD_POLICIES` simple policies, inclusive.
+    error ChildPoliciesOutsideOfRange();
 
     /// @notice Composite policies are not simple policies. Child policies must be existing
     ///         ALLOWLIST or BLOCKLIST policies;
@@ -130,7 +128,8 @@ interface IPolicyRegistry {
     ///      The child-policy set is capped at 4.
     /// @dev Reverts with `IncompatiblePolicyType` when `policyType` is not UNION or INTERSECT.
     /// @dev Reverts with `ZeroAddress` when `admin` is `address(0)`.
-    /// @dev Reverts with `ChildPoliciesOutsideOfRange(2, 4)` when `childPolicyIds.length` is not in `[2, 4]`.
+    /// @dev Reverts with `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is not in
+    ///      `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]`.
     /// @dev Reverts with `PolicyNotFound` when any child policy does not exist.
     /// @dev Reverts with `InvalidChildPolicy` when any child policy is not a simple policy or a built-in policy.
     /// @dev Panics with arithmetic overflow (Panic 0x11) when the policy counter has reached its maximum value.
@@ -206,8 +205,9 @@ interface IPolicyRegistry {
     /// @dev Reverts with `IncompatiblePolicyType` when `policyId` is not a composite (UNION or INTERSECT).
     /// @dev Reverts with `Unauthorized` when the caller is not the current admin. A renounced composite
     ///      (admin `address(0)`) can never be updated.
-    /// @dev Reverts with `ChildPoliciesOutsideOfRange(2, 4)` when `childPolicyIds.length` is not in `[2, 4]`;
-    ///      there is no clear-the-list path (the composite child-policy range, not the 64-account batch limit).
+    /// @dev Reverts with `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is not in
+    ///      `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]`; there is no clear-the-list
+    ///      path (the composite child-policy range, not the 64-account batch limit).
     /// @dev Reverts with `PolicyNotFound` when any child policy does not exist.
     /// @dev Reverts with `InvalidChildPolicy` when any child policy is itself a composite
     ///      (not a simple policy).
@@ -235,6 +235,16 @@ interface IPolicyRegistry {
     /*//////////////////////////////////////////////////////////////
                             POLICY QUERIES
     //////////////////////////////////////////////////////////////*/
+
+    /// @notice Minimum number of child policies a composite must reference, inclusive. Never reverts.
+    ///
+    /// @return Minimum permitted child-policy count.
+    function MIN_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
+
+    /// @notice Maximum number of child policies a composite may reference, inclusive. Never reverts.
+    ///
+    /// @return Maximum permitted child-policy count.
+    function MAX_COMPOSITE_CHILD_POLICIES() external view returns (uint256);
 
     /// @notice Returns whether `policyId` is a built-in sentinel or a previously-assigned custom ID. Never reverts.
     ///

--- a/test/lib/PolicyRegistryTest.sol
+++ b/test/lib/PolicyRegistryTest.sol
@@ -129,7 +129,7 @@ contract PolicyRegistryTest is BaseTest {
     ///         from `MAX_BATCH_SIZE` (64), which caps account membership
     ///         batches; a composite created or updated with a child count
     ///         outside `[MIN_CHILD_POLICIES, MAX_CHILD_POLICIES]` reverts with
-    ///         `ChildPoliciesOutsideOfRange(MIN_CHILD_POLICIES, MAX_CHILD_POLICIES)`.
+    ///         `ChildPoliciesOutsideOfRange()`.
     ///         Kept as a test-side literal so fork tests against the real
     ///         precompile use the same compile-time constant.
     uint256 internal constant MAX_CHILD_POLICIES = 4;

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -80,21 +80,15 @@ contract MockPolicyRegistry is IPolicyRegistry {
     /// @notice Minimum number of child policies a composite must reference.
     ///         `createCompositePolicy` and `updateComposite` revert with
     ///         `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is below this value.
-    uint256 internal constant MIN_CHILD_POLICIES = 2;
+    uint256 public constant MIN_COMPOSITE_CHILD_POLICIES = 2;
 
     /// @notice Maximum number of child policies a composite may reference.
     ///         `createCompositePolicy` and `updateComposite` revert with
     ///         `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is outside
-    ///         `[MIN_CHILD_POLICIES, MAX_CHILD_POLICIES]`.
+    ///         `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]`.
     ///         Distinct from `MAX_BATCH_SIZE` (64), which caps account-membership batches.
     ///         Mirrors the Rust PolicyRegistry precompile.
-    uint256 internal constant MAX_CHILD_POLICIES = 4;
-
-    /// @inheritdoc IPolicyRegistry
-    uint256 public constant MIN_COMPOSITE_CHILD_POLICIES = MIN_CHILD_POLICIES;
-
-    /// @inheritdoc IPolicyRegistry
-    uint256 public constant MAX_COMPOSITE_CHILD_POLICIES = MAX_CHILD_POLICIES;
+    uint256 public constant MAX_COMPOSITE_CHILD_POLICIES = 4;
 
     // ============================================================
     //                       POLICY CREATION
@@ -138,7 +132,9 @@ contract MockPolicyRegistry is IPolicyRegistry {
     {
         if (admin == address(0)) revert ZeroAddress();
         if (!_isCompositeType(policyType)) revert IncompatiblePolicyType();
-        if (childPolicyIds.length < MIN_CHILD_POLICIES || childPolicyIds.length > MAX_CHILD_POLICIES) {
+        if (
+            childPolicyIds.length < MIN_COMPOSITE_CHILD_POLICIES || childPolicyIds.length > MAX_COMPOSITE_CHILD_POLICIES
+        ) {
             revert ChildPoliciesOutsideOfRange();
         }
         _requireCreatedSimplePolicies(childPolicyIds);
@@ -214,13 +210,15 @@ contract MockPolicyRegistry is IPolicyRegistry {
         uint256 packed = _requireCustom(policyId);
         if (!_isComposite(policyId)) revert IncompatiblePolicyType();
         if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
-        if (childPolicyIds.length < MIN_CHILD_POLICIES || childPolicyIds.length > MAX_CHILD_POLICIES) {
+        if (
+            childPolicyIds.length < MIN_COMPOSITE_CHILD_POLICIES || childPolicyIds.length > MAX_COMPOSITE_CHILD_POLICIES
+        ) {
             revert ChildPoliciesOutsideOfRange();
         }
         _requireCreatedSimplePolicies(childPolicyIds);
 
         // Full replacement: assigning a memory array to the storage array resets its
-        // length and overwrites elements. Child sets are ≤ MAX_CHILD_POLICIES, so there
+        // length and overwrites elements. Child sets are ≤ MAX_COMPOSITE_CHILD_POLICIES, so there
         // is no stale-tail concern.
         MockPolicyRegistryStorage.layout().children[policyId] = childPolicyIds;
         emit CompositePolicyUpdated(policyId, msg.sender, childPolicyIds);

--- a/test/lib/mocks/MockPolicyRegistry.sol
+++ b/test/lib/mocks/MockPolicyRegistry.sol
@@ -79,17 +79,22 @@ contract MockPolicyRegistry is IPolicyRegistry {
 
     /// @notice Minimum number of child policies a composite must reference.
     ///         `createCompositePolicy` and `updateComposite` revert with
-    ///         `ChildPoliciesOutsideOfRange(MIN_CHILD_POLICIES, MAX_CHILD_POLICIES)`
-    ///         when `childPolicyIds.length` is below this value.
+    ///         `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is below this value.
     uint256 internal constant MIN_CHILD_POLICIES = 2;
 
     /// @notice Maximum number of child policies a composite may reference.
     ///         `createCompositePolicy` and `updateComposite` revert with
-    ///         `ChildPoliciesOutsideOfRange(MIN_CHILD_POLICIES, MAX_CHILD_POLICIES)`
-    ///         when `childPolicyIds.length` is outside `[MIN_CHILD_POLICIES, MAX_CHILD_POLICIES]`.
+    ///         `ChildPoliciesOutsideOfRange` when `childPolicyIds.length` is outside
+    ///         `[MIN_CHILD_POLICIES, MAX_CHILD_POLICIES]`.
     ///         Distinct from `MAX_BATCH_SIZE` (64), which caps account-membership batches.
     ///         Mirrors the Rust PolicyRegistry precompile.
     uint256 internal constant MAX_CHILD_POLICIES = 4;
+
+    /// @inheritdoc IPolicyRegistry
+    uint256 public constant MIN_COMPOSITE_CHILD_POLICIES = MIN_CHILD_POLICIES;
+
+    /// @inheritdoc IPolicyRegistry
+    uint256 public constant MAX_COMPOSITE_CHILD_POLICIES = MAX_CHILD_POLICIES;
 
     // ============================================================
     //                       POLICY CREATION
@@ -134,7 +139,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
         if (admin == address(0)) revert ZeroAddress();
         if (!_isCompositeType(policyType)) revert IncompatiblePolicyType();
         if (childPolicyIds.length < MIN_CHILD_POLICIES || childPolicyIds.length > MAX_CHILD_POLICIES) {
-            revert ChildPoliciesOutsideOfRange(MIN_CHILD_POLICIES, MAX_CHILD_POLICIES);
+            revert ChildPoliciesOutsideOfRange();
         }
         _requireCreatedSimplePolicies(childPolicyIds);
 
@@ -210,7 +215,7 @@ contract MockPolicyRegistry is IPolicyRegistry {
         if (!_isComposite(policyId)) revert IncompatiblePolicyType();
         if (_decodeAdmin(packed) != msg.sender) revert Unauthorized();
         if (childPolicyIds.length < MIN_CHILD_POLICIES || childPolicyIds.length > MAX_CHILD_POLICIES) {
-            revert ChildPoliciesOutsideOfRange(MIN_CHILD_POLICIES, MAX_CHILD_POLICIES);
+            revert ChildPoliciesOutsideOfRange();
         }
         _requireCreatedSimplePolicies(childPolicyIds);
 

--- a/test/unit/PolicyRegistry/compositeChildPolicyLimits.t.sol
+++ b/test/unit/PolicyRegistry/compositeChildPolicyLimits.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
+
+contract PolicyRegistryCompositeChildPolicyLimitsTest is PolicyRegistryTest {
+    /// @notice MIN_COMPOSITE_CHILD_POLICIES() returns the registry's composite child-policy floor.
+    function test_minCompositeChildPolicies_success() public view {
+        assertEq(policyRegistry.MIN_COMPOSITE_CHILD_POLICIES(), MIN_CHILD_POLICIES);
+    }
+
+    /// @notice MAX_COMPOSITE_CHILD_POLICIES() returns the registry's composite child-policy cap.
+    function test_maxCompositeChildPolicies_success() public view {
+        assertEq(policyRegistry.MAX_COMPOSITE_CHILD_POLICIES(), MAX_CHILD_POLICIES);
+    }
+}

--- a/test/unit/PolicyRegistry/createCompositePolicy.t.sol
+++ b/test/unit/PolicyRegistry/createCompositePolicy.t.sol
@@ -40,7 +40,7 @@ contract PolicyRegistryCreateCompositePolicyTest is PolicyRegistryTest {
 
     /// @notice Verifies createCompositePolicy reverts when the child count is outside [2, 4]
     /// @dev A composite must reference between MIN_CHILD_POLICIES (2) and MAX_CHILD_POLICIES (4)
-    ///      simple policies, inclusive; checks ChildPoliciesOutsideOfRange(2, 4). Exercises both
+    ///      simple policies, inclusive; checks ChildPoliciesOutsideOfRange(). Exercises both
     ///      under-range (0 and 1 children) and over-range (5..8 children) cases. The composite
     ///      child-policy range is distinct from the 64-account membership limit.
     function test_createCompositePolicy_revert_childPoliciesOutsideOfRange(
@@ -52,9 +52,7 @@ contract PolicyRegistryCreateCompositePolicyTest is PolicyRegistryTest {
         _assumeValidCaller(caller);
         vm.assume(admin_ != address(0));
         IPolicyRegistry.PolicyType pt = _creatableCompositeType(typeIdx);
-        bytes memory expectedRevert = abi.encodeWithSelector(
-            IPolicyRegistry.ChildPoliciesOutsideOfRange.selector, MIN_CHILD_POLICIES, MAX_CHILD_POLICIES
-        );
+        bytes memory expectedRevert = abi.encodeWithSelector(IPolicyRegistry.ChildPoliciesOutsideOfRange.selector);
 
         // Under range: 0 children.
         uint64[] memory none = new uint64[](0);

--- a/test/unit/PolicyRegistry/createCompositePolicy_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/createCompositePolicy_revertOrder.t.sol
@@ -10,7 +10,7 @@ import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 /// @notice **Canonical order:**
 ///         1. ZERO-ADMIN (`admin == address(0)`) → `ZeroAddress`
 ///         2. INCOMPATIBLE-TYPE (`policyType` not UNION/INTERSECT) → `IncompatiblePolicyType`
-///         3. COUNT-OUTSIDE-RANGE (`childPolicyIds.length` not in `[2, 4]`) → `ChildPoliciesOutsideOfRange(2, 4)`
+///         3. COUNT-OUTSIDE-RANGE (`childPolicyIds.length` not in `[2, 4]`) → `ChildPoliciesOutsideOfRange()`
 ///         4. CHILD-NOT-FOUND (a child does not exist) → `PolicyNotFound`
 ///         5. INVALID-CHILD (a child is itself a composite) → `InvalidChildPolicy`
 ///
@@ -55,9 +55,7 @@ contract PolicyRegistryCreateCompositePolicyRevertOrderTest is PolicyRegistryTes
         // 3. COUNT-OUTSIDE-RANGE: composite type, but a child count outside [2, 4] (all nonexistent)
         //    → ChildPoliciesOutsideOfRange fires before the existence check. Exercises both the
         //    under-range (1 child) and over-range (> MAX_CHILD_POLICIES) ends.
-        bytes memory outsideRange = abi.encodeWithSelector(
-            IPolicyRegistry.ChildPoliciesOutsideOfRange.selector, MIN_CHILD_POLICIES, MAX_CHILD_POLICIES
-        );
+        bytes memory outsideRange = abi.encodeWithSelector(IPolicyRegistry.ChildPoliciesOutsideOfRange.selector);
         uint64[] memory one = new uint64[](1);
         one[0] = neverCreatedWellFormedPolicy;
         vm.expectRevert(outsideRange);

--- a/test/unit/PolicyRegistry/updateComposite.t.sol
+++ b/test/unit/PolicyRegistry/updateComposite.t.sol
@@ -64,14 +64,12 @@ contract PolicyRegistryUpdateCompositeTest is PolicyRegistryTest {
 
     /// @notice Verifies updateComposite reverts when the new child count is outside [2, 4]
     /// @dev A composite must reference between MIN_CHILD_POLICIES (2) and MAX_CHILD_POLICIES (4)
-    ///      simple policies, inclusive; checks ChildPoliciesOutsideOfRange(2, 4). There is no
+    ///      simple policies, inclusive; checks ChildPoliciesOutsideOfRange(). There is no
     ///      clear-the-list path. Exercises both under-range (0 and 1 children) and over-range
     ///      (5..8 children) cases.
     function test_updateComposite_revert_childPoliciesOutsideOfRange(uint8 typeIdx, uint8 overflow) public {
         uint64 composite = _createComposite(_creatableCompositeType(typeIdx), 2);
-        bytes memory expectedRevert = abi.encodeWithSelector(
-            IPolicyRegistry.ChildPoliciesOutsideOfRange.selector, MIN_CHILD_POLICIES, MAX_CHILD_POLICIES
-        );
+        bytes memory expectedRevert = abi.encodeWithSelector(IPolicyRegistry.ChildPoliciesOutsideOfRange.selector);
 
         // Under range: 0 children.
         uint64[] memory none = new uint64[](0);

--- a/test/unit/PolicyRegistry/updateComposite_revertOrder.t.sol
+++ b/test/unit/PolicyRegistry/updateComposite_revertOrder.t.sol
@@ -11,7 +11,7 @@ import {PolicyRegistryTest} from "base-std-test/lib/PolicyRegistryTest.sol";
 ///         1. POLICY-NOT-FOUND (composite `policyId` does not exist) → `PolicyNotFound`
 ///         2. INCOMPATIBLE-TYPE (`policyId` is a simple policy) → `IncompatiblePolicyType`
 ///         3. UNAUTHORIZED (caller is not the admin) → `Unauthorized`
-///         4. COUNT-OUTSIDE-RANGE (`childPolicyIds.length` not in `[2, 4]`) → `ChildPoliciesOutsideOfRange(2, 4)`
+///         4. COUNT-OUTSIDE-RANGE (`childPolicyIds.length` not in `[2, 4]`) → `ChildPoliciesOutsideOfRange()`
 ///         5. CHILD-NOT-FOUND (a child does not exist) → `PolicyNotFound`
 ///         6. INVALID-CHILD (a child is itself a composite) → `InvalidChildPolicy`
 ///
@@ -62,9 +62,7 @@ contract PolicyRegistryUpdateCompositeRevertOrderTest is PolicyRegistryTest {
         // 4. COUNT-OUTSIDE-RANGE: admin, but a child count outside [2, 4] (all nonexistent); fires
         //    before the existence check. Exercises both the under-range (1 child) and over-range
         //    (> MAX_CHILD_POLICIES) ends.
-        bytes memory outsideRange = abi.encodeWithSelector(
-            IPolicyRegistry.ChildPoliciesOutsideOfRange.selector, MIN_CHILD_POLICIES, MAX_CHILD_POLICIES
-        );
+        bytes memory outsideRange = abi.encodeWithSelector(IPolicyRegistry.ChildPoliciesOutsideOfRange.selector);
         uint64[] memory one = new uint64[](1);
         one[0] = ghostChild;
         vm.prank(alice);


### PR DESCRIPTION
## Summary
- Removes the `(min, max)` args from `IPolicyRegistry.ChildPoliciesOutsideOfRange`; it now reverts with no args.
- Adds two new view functions to `IPolicyRegistry`: `MIN_COMPOSITE_CHILD_POLICIES()` and `MAX_COMPOSITE_CHILD_POLICIES()`, so the valid composite child-count range is discoverable via a call instead of parsed from the error args.
- `MockPolicyRegistry` implements the new getters as `public constant`s aliasing the existing `MIN_CHILD_POLICIES`/`MAX_CHILD_POLICIES` internal constants (same pattern already used for `ALWAYS_ALLOW_ID`/`ALWAYS_BLOCK_ID`), and both revert sites (`createCompositePolicy`, `updateComposite`) now throw the argless error.
- Updates existing `PolicyRegistry` unit tests' revert expectations/NatSpec to match, and adds `compositeChildPolicyLimits.t.sol` covering the two new getters.

## Test plan
- [x] `forge build` — compiles clean, `MockPolicyRegistry` still satisfies `IPolicyRegistry`
- [x] `forge test --match-path "test/unit/PolicyRegistry/*"` — 135 passed, 0 failed
- [x] `forge test` (full suite) — 715 passed, 0 failed