### PR TITLE
refactor(b20): seizeWithMemo returns void; keep deprecated burnBlocked in IB20

### DIFF
--- a/src/interfaces/IB20.sol
+++ b/src/interfaces/IB20.sol
@@ -147,7 +147,6 @@ interface IB20 {
     event Memo(address indexed caller, bytes32 indexed memo);
 
     /// @notice Emitted by the deprecated `burnBlocked` in addition to `Transfer(from, address(0), amount)`.
-    ///         `burnBlocked` is no longer part of this interface; the event is retained for the back-compat impl.
     event BurnedBlocked(address indexed caller, address indexed from, uint256 amount);
 
     /// @notice Emitted by `seizeWithMemo` in addition to `Transfer(from, to, amount)` (and the
@@ -212,8 +211,7 @@ interface IB20 {
     /// @return Role constant.
     function BURN_ROLE() external view returns (bytes32);
 
-    /// @notice Required to call the deprecated `burnBlocked` (no longer part of this interface; retained for
-    ///         the back-compat impl).
+    /// @notice Required to call the deprecated `burnBlocked`.
     /// @return Role constant.
     function BURN_BLOCKED_ROLE() external view returns (bytes32);
 
@@ -438,6 +436,22 @@ interface IB20 {
     /// @param memo   Off-chain memo payload.
     function burnWithMemo(uint256 amount, bytes32 memo) external;
 
+    /// @notice DEPRECATED. Burns `amount` from a `from` account that is blocked under
+    ///         `TRANSFER_SENDER_POLICY`, without spending an allowance. Retained for back-compat;
+    ///         prefer `seizeWithMemo` (to a treasury/self address) followed by `burn`.
+    ///         Emits `Transfer(from, address(0), amount)` and `BurnedBlocked(caller, from, amount)`.
+    ///
+    /// @dev Gated by `BURN_BLOCKED_ROLE` and the `BURN` pause vector (not `SEIZE`). Its blocked check
+    ///      reads `TRANSFER_SENDER_POLICY`, distinct from `seizeWithMemo`'s `SEIZE_HOLDER_POLICY`.
+    /// @dev Reverts with `ContractPaused(BURN)` when `BURN` is paused.
+    /// @dev Reverts with `AccessControlUnauthorizedAccount` when the caller does not hold `BURN_BLOCKED_ROLE`.
+    /// @dev Reverts with `AccountNotBlocked` when `from` is currently authorized under `TRANSFER_SENDER_POLICY`.
+    /// @dev Reverts with `InsufficientBalance` when `from`'s balance is below `amount`.
+    ///
+    /// @param from   Account whose blocked balance is being burned.
+    /// @param amount Amount to burn.
+    function burnBlocked(address from, uint256 amount) external;
+
     /// @notice Seizes `amount` of `from`'s balance and reassigns it to `to` in a single admin operation.
     ///         Emits, in order, `Transfer(from, to, amount)`, `Memo(caller, memo)`, and
     ///         `Seized(caller, from, to, amount)`. A memo of `bytes32(0)` is permitted.
@@ -457,9 +471,7 @@ interface IB20 {
     /// @param to     Destination address for the seized balance.
     /// @param amount Amount to seize.
     /// @param memo   Memo payload.
-    ///
-    /// @return Always `true` on success.
-    function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external returns (bool);
+    function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo) external;
 
     /*//////////////////////////////////////////////////////////////
                                   ROLES

--- a/test/lib/mocks/MockB20.sol
+++ b/test/lib/mocks/MockB20.sol
@@ -344,12 +344,10 @@ abstract contract MockB20 is IB20 {
     /// @param to     Destination address for the seized balance.
     /// @param amount Amount to seize.
     /// @param memo   Memo payload emitted via `Memo`.
-    /// @return Always `true` on success.
     function seizeWithMemo(address from, address to, uint256 amount, bytes32 memo)
         external
         whenNotPaused(PausableFeature.SEIZE)
         onlyRole(SEIZE_ROLE)
-        returns (bool)
     {
         if (to == address(0)) revert InvalidReceiver(to);
         _requireSeizable(from);
@@ -360,7 +358,6 @@ abstract contract MockB20 is IB20 {
         // `Seized`.
         emit Memo(msg.sender, memo);
         emit Seized(msg.sender, from, to, amount);
-        return true;
     }
 
     // ============================================================


### PR DESCRIPTION
Two interface design-review follow-ups on the B20 surface.

## 1. `seizeWithMemo` returns void

`seizeWithMemo` no longer returns `bool`. Like `burnBlocked`, it is a void admin operation — the always-`true` return carried no signal. Dropped `returns (bool)` from the `IB20` declaration and the `MockB20` reference (and its `return true`).

The return type is not part of the function selector, so the selector and the ABI fingerprint are unchanged; only the returned bytes change (`true` → empty).

## 2. Keep the deprecated `burnBlocked` in the `IB20` interface

`burnBlocked` was previously removed from the `IB20` interface as a deprecation signal. Removing a still-live selector broke ABI-bound callers (tooling/SDKs bind against the interface ABI) even though the selector still dispatches on the precompile. This restores `burnBlocked` to the interface, marked **DEPRECATED** via natspec (pointing to `seizeWithMemo` → `burn` as the replacement path), so callers keep working while deprecation is still clearly signalled. Reworded the comments that said it was no longer part of the interface.

## Testing

- `forge build`, `forge test` (721 passed, 4 skipped), `forge fmt --check`, `python3 script/check-coverage.py` — all green.
- No test depended on the seize return value; `burnBlocked` mock/impl and its tests are unchanged.

A mirror change in the Rust precompile (base/base) will follow.