### PR TITLE
feat(fork): select Base upgrade via BASE_UPGRADE env

### DIFF
--- a/script/fork/README.md
+++ b/script/fork/README.md
@@ -54,6 +54,7 @@ PYTHONPATH=script script/smoke/.venv/bin/python -m fork --match-test test_transf
 | `PORT` | `8546` | local RPC port for anvil |
 | `ACTIVATION_ADMIN` | `0x9965…A4dc` | address authorized to activate features |
 | `ANVIL_LOG` | `/tmp/anvil.log` | anvil stdout/stderr log path |
+| `BASE_UPGRADE` | _(none)_ | historical Base upgrade to register (e.g. `beryl`, `cobalt`), forwarded as `--base <upgrade>`; unset uses anvil's default upgrade (bare `--base`) |
 | `SKIP_ACTIVATE` | _(none)_ | comma-separated feature names or `0x` ids to leave un-activated (exercises the inactive-feature dispatch path); matched case-insensitively |
 
 ## Exit codes

--- a/script/fork/__main__.py
+++ b/script/fork/__main__.py
@@ -118,11 +118,18 @@ def assert_port_free(port: int) -> None:
 
 
 @contextmanager
-def anvil_running(anvil: Path, port: int, admin: str, log_path: Path) -> Iterator[Web3]:
-    """Launch anvil --base, yield a Web3 once the RPC is live, and tear it down on exit (any outcome)."""
+def anvil_running(
+    anvil: Path, port: int, admin: str, log_path: Path, base_upgrade: str | None = None
+) -> Iterator[Web3]:
+    """Launch anvil --base, yield a Web3 once the RPC is live, and tear it down on exit (any outcome).
+
+    A bare --base registers anvil's default upgrade; passing base_upgrade forwards
+    --base <upgrade> to select a specific historical upgrade instead.
+    """
+    base_flag = ["--base"] if not base_upgrade else ["--base", base_upgrade]
     with open(log_path, "w") as logf:
         proc = subprocess.Popen(
-            [str(anvil), "--base", "--base-activation-admin", admin, "--port", str(port)],
+            [str(anvil), *base_flag, "--base-activation-admin", admin, "--port", str(port)],
             stdout=logf,
             stderr=subprocess.STDOUT,
         )
@@ -199,6 +206,7 @@ def main(forge_args: list[str]) -> int:
         os.environ.get("ACTIVATION_ADMIN", "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc")
     )
     log_path = Path(os.environ.get("ANVIL_LOG", "/tmp/anvil.log"))
+    base_upgrade = os.environ.get("BASE_UPGRADE") or None  # empty string == unset
     skip = skip_set()
 
     anvil, forge = discover_binaries()
@@ -209,10 +217,11 @@ def main(forge_args: list[str]) -> int:
     log(f"port:             {port}")
     log(f"activation admin: {admin}")
     log(f"log file:         {log_path}")
+    log(f"base upgrade:     {base_upgrade or '<default>'}")
     log(f"skip-activate:    {os.environ.get('SKIP_ACTIVATE') or '<none>'}")
 
     log("starting anvil…")
-    with anvil_running(anvil, port, admin, log_path) as w3:
+    with anvil_running(anvil, port, admin, log_path, base_upgrade) as w3:
         reconcile_feature_state(w3, admin, skip)
 
         rpc_url = f"http://localhost:{port}"


### PR DESCRIPTION
## What

The fork-test harness (`script/fork/__main__.py`) hardcoded a bare `--base` when
launching anvil, so it always registered anvil's **default** upgrade. This adds
an optional `BASE_UPGRADE` env var that, when set, is forwarded as
`--base <upgrade>` (e.g. `--base beryl`).

Unset/empty preserves today's behavior (bare `--base` → default upgrade), so
existing callers are unaffected.

## Why

anvil's `--base` flag can now pin a specific historical upgrade at runtime. That
lets a single current base-anvil revision test the latest precompile
implementation against each frozen historical base-std suite, instead of pinning
a distinct anvil revision per hardfork. This harness change is what actually
selects the upgrade at launch; CI passes the fork to test via `BASE_UPGRADE`.

## Changes

- `script/fork/__main__.py`: read `BASE_UPGRADE`, thread it into
  `anvil_running(...)`, build the `--base [<upgrade>]` argv conditionally, and
  log the selected upgrade.
- `script/fork/README.md`: document `BASE_UPGRADE` in the Environment table.

## How to test

Requires patched anvil/forge built from a base-anvil revision that supports
`--base <upgrade>`:

```bash
BASE_UPGRADE=beryl ANVIL_BIN=<…/anvil> FORGE_BIN=<…/forge> ANVIL_LOG=/tmp/a.log \
  make fork-tests ARGS="--match-test <any>"
```

- `[run-fork-tests] base upgrade: beryl` appears and anvil boots.
- Repeat with `BASE_UPGRADE=cobalt` and with it unset (unset → default, unchanged).
- An invalid value makes anvil exit during startup and the harness reports the
  environment error — confirming the value is actually forwarded.