### PR TITLE
fix(fork): support single base-anvil rev for multi-hardfork fork tests (Beryl backport)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -45,7 +45,7 @@ vibenet = "https://rpc.vibes.base.org/"
 runs = 10
 
 [profile.fork]
-base = true
+base = "beryl"
 
 [fmt]
 line_length = 120

--- a/script/fork/README.md
+++ b/script/fork/README.md
@@ -54,6 +54,7 @@ PYTHONPATH=script script/smoke/.venv/bin/python -m fork --match-test test_transf
 | `PORT` | `8546` | local RPC port for anvil |
 | `ACTIVATION_ADMIN` | `0x9965…A4dc` | address authorized to activate features |
 | `ANVIL_LOG` | `/tmp/anvil.log` | anvil stdout/stderr log path |
+| `BASE_UPGRADE` | _(none)_ | historical Base upgrade to register (e.g. `beryl`, `cobalt`), forwarded as `--base <upgrade>`; unset uses anvil's default upgrade (bare `--base`) |
 | `SKIP_ACTIVATE` | _(none)_ | comma-separated feature names or `0x` ids to leave un-activated (exercises the inactive-feature dispatch path); matched case-insensitively |
 
 ## Exit codes

--- a/script/fork/__main__.py
+++ b/script/fork/__main__.py
@@ -118,11 +118,18 @@ def assert_port_free(port: int) -> None:
 
 
 @contextmanager
-def anvil_running(anvil: Path, port: int, admin: str, log_path: Path) -> Iterator[Web3]:
-    """Launch anvil --base, yield a Web3 once the RPC is live, and tear it down on exit (any outcome)."""
+def anvil_running(
+    anvil: Path, port: int, admin: str, log_path: Path, base_upgrade: str | None = None
+) -> Iterator[Web3]:
+    """Launch anvil --base, yield a Web3 once the RPC is live, and tear it down on exit (any outcome).
+
+    A bare --base registers anvil's default upgrade; passing base_upgrade forwards
+    --base <upgrade> to select a specific historical upgrade instead.
+    """
+    base_flag = ["--base"] if not base_upgrade else ["--base", base_upgrade]
     with open(log_path, "w") as logf:
         proc = subprocess.Popen(
-            [str(anvil), "--base", "--base-activation-admin", admin, "--port", str(port)],
+            [str(anvil), *base_flag, "--base-activation-admin", admin, "--port", str(port)],
             stdout=logf,
             stderr=subprocess.STDOUT,
         )
@@ -199,6 +206,7 @@ def main(forge_args: list[str]) -> int:
         os.environ.get("ACTIVATION_ADMIN", "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc")
     )
     log_path = Path(os.environ.get("ANVIL_LOG", "/tmp/anvil.log"))
+    base_upgrade = os.environ.get("BASE_UPGRADE") or None  # empty string == unset
     skip = skip_set()
 
     anvil, forge = discover_binaries()
@@ -209,10 +217,11 @@ def main(forge_args: list[str]) -> int:
     log(f"port:             {port}")
     log(f"activation admin: {admin}")
     log(f"log file:         {log_path}")
+    log(f"base upgrade:     {base_upgrade or '<default>'}")
     log(f"skip-activate:    {os.environ.get('SKIP_ACTIVATE') or '<none>'}")
 
     log("starting anvil…")
-    with anvil_running(anvil, port, admin, log_path) as w3:
+    with anvil_running(anvil, port, admin, log_path, base_upgrade) as w3:
         reconcile_feature_state(w3, admin, skip)
 
         rpc_url = f"http://localhost:{port}"


### PR DESCRIPTION
## Summary

Cherry-picks two changes onto `v1.0.0` to let the frozen Beryl test suite run correctly against the new shared base-anvil revision (`98e7839c`) used in base/base BOP-585.

**Changes:**
- **`d5c88cb`** `feat(fork): select Base upgrade via BASE_UPGRADE env` — harness reads `BASE_UPGRADE` env var and forwards `--base <upgrade>` to anvil, so one base-anvil binary can be tested against each frozen historical suite. Cherry-picked from `4571b325` (PR #215).
- **`66008b9`** `fix(fork): pin fork profile to base = "beryl" for Beryl harness` — changes `base = true` → `base = "beryl"` in `foundry.toml`'s `[profile.fork]`. The new base-anvil's `DEFAULT_BASE_UPGRADE` is Cobalt, so `base = true` was silently running forge's local precompile dispatcher at V2 (Cobalt) instead of V1 (Beryl), causing 14 test failures in the v1.0.0 suite.

## Test plan

- [ ] Beryl fork tests pass with base-anvil `98e7839c` + `--base beryl` via base/base PR #4865
- [ ] No Solidity source or test files changed — only `script/fork/__main__.py`, `script/fork/README.md`, and `foundry.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)