### PR TITLE
fix(fork): explicitly pin fork profile to base = "cobalt"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -45,7 +45,7 @@ vibenet = "https://rpc.vibes.base.org/"
 runs = 10
 
 [profile.fork]
-base = true
+base = "cobalt"
 
 [fmt]
 line_length = 120


### PR DESCRIPTION
## Summary

`base = true` in `[profile.fork]` relied on the base-anvil's `DEFAULT_BASE_UPGRADE` at build time. As of base-anvil PR #71 that default is Cobalt — correct today — but a future default bump would silently break Cobalt fork tests.

Pins to `base = "cobalt"` to make the intent explicit.

## Context

This is the same fix pattern applied to the frozen Beryl snapshot (`beryl-harness-patch`), where `base = "beryl"` was required because the new shared base-anvil defaults to Cobalt. Pinning both snapshots to their explicit hardfork name removes the fragile implicit dependency.

## Test plan

- [ ] Cobalt fork tests continue to pass (behavior unchanged today, just explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)