### PR TITLE
fix(fork): explicitly pin fork profile to base = "cobalt" (v2.0.x release branch)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -45,7 +45,7 @@ vibenet = "https://rpc.vibes.base.org/"
 runs = 10
 
 [profile.fork]
-base = true
+base = "cobalt"
 
 [fmt]
 line_length = 120


### PR DESCRIPTION
## Summary

Pins `[profile.fork] base` to `"cobalt"` on the `releases/v2.0.x` snapshot, explicitly, instead of
relying on the implicit `base = true` default.

`base = true` resolves to base-anvil's `DEFAULT_BASE_UPGRADE` at build time. As of base-anvil PR #71
that default is Cobalt — correct today — but relying on the implicit default means a future
`DEFAULT_BASE_UPGRADE` bump would silently change which precompile dispatch version this frozen
branch's fork tests run against, without any diff in base-std to explain why.

## Context

Same fix pattern already applied to the frozen Beryl snapshot (`releases/v1.0.x`, commit `520d069`,
tagged `v1.0.1`) after base-anvil's default moved on from Beryl to Cobalt. This closes the same gap
for the new Cobalt release branch before it ships, rather than waiting for a future default bump to
break it the same way.

Cherry-picked from `1d005bc` (originally proposed against `main` in #217, closed unmerged — retargeting
here since the pin only matters for a *frozen* branch, not `main`, which is meant to track whatever
hardfork is currently in development).

## Test plan

- [ ] Cobalt fork tests continue to pass (behavior unchanged today, just explicit)