### PR TITLE
docs: add release-cutting process to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,40 +88,35 @@ Deeper reading: `LIVE_PRECOMPILE_TESTING.md` (cross-validation architecture), `d
 
 ## Cutting releases
 
-Versioning is `vMAJOR.MINOR.PATCH`, and which digit moves is decided by the breaking-vs-non-breaking
-test below — **not** by whether a hardfork boundary is involved. Hardforks in this repo are additive
-by design, so most of them land as MINOR, same as any other additive change:
+### Major vs. minor
 
-- **MAJOR**: a change that fails the breaking test. Expect this to be rare — it fires whenever an
-  actual breaking change ships, whether or not that coincides with a hardfork.
-- **MINOR**: a hardfork's frozen interface, once it's fully additive (the common case) — increments
-  once per hardfork, matching the ordinal in `changelog/README.md`'s
-  [Hardfork ordinals](changelog/README.md#hardfork-ordinals) table shifted down by one (`01` Beryl →
-  `1.0`, `02` Cobalt → `1.1`, `03` (next hardfork) → `1.2`, ...). Also covers any other additive,
-  non-breaking interface change outside a hardfork boundary. Freezing happens at tag time, which can
-  be before on-chain activation, not after.
-- **PATCH**: no interface change — tooling, harness, docs, or CI fixes on an already-frozen release
-  (e.g. the fork-profile pin that shipped in `v1.0.1`).
+Versioning is `vMAJOR.MINOR.PATCH`, decided by the breaking change test below — not by hardfork
+boundaries. Hardforks here are additive by design, so most land as MINOR:
 
-If a hardfork's interface *does* contain a breaking change, that pushes MAJOR instead of MINOR (and
-resets MINOR/PATCH to `0`) — see [Branching model](#branching-model) for what that means for
-branching.
+- **MAJOR**: an actual breaking change. Rare.
+- **MINOR**: a hardfork's frozen interface, once it's additive (the common case) — increments once
+  per hardfork, matching `changelog/README.md`'s [Hardfork ordinals](changelog/README.md#hardfork-ordinals)
+  shifted down by one (`01` Beryl → `1.0`, `02` Cobalt → `1.1`, ...). Also covers any other additive
+  change. Freezing happens at tag time, which can be before on-chain activation.
+- **PATCH**: no interface change — tooling, harness, docs, or CI fixes (e.g. `v1.0.1`'s fork-profile
+  pin).
 
-### Breaking vs. non-breaking
+If a hardfork's interface does contain a breaking change, that bumps MAJOR instead (resetting
+MINOR/PATCH to `0`).
+
+### Breaking change test
 
 This repo's invariant is slot-for-slot storage parity with the Rust precompiles plus a stable
-public ABI for integrators — a change is breaking if it violates either.
+public ABI — a change is breaking if it violates either.
 
-**The test**: fix an already-shipped selector and its inputs. If the outcome can differ from what
-it is today — succeeds where it reverted, reverts where it succeeded, reverts with a different
-error, or returns/emits something different — it's breaking, regardless of whether the ABI itself
-gained or lost anything. A new error or event isn't automatically non-breaking; check what it's
-reachable from.
+Fix an already-shipped selector and its inputs. If the outcome can differ from what it is today —
+succeeds where it reverted, reverts where it succeeded, reverts with a different error, or
+returns/emits something different — it's breaking, regardless of whether the ABI itself gained or
+lost anything. A new error or event isn't automatically non-breaking; check what it's reachable from.
 
 **Breaking** (MAJOR only):
 - Removing, renaming, or changing the signature/return type of an existing function, event, or error.
-- Adding, removing, or changing a revert path on an existing, otherwise-unmodified function — any of
-  these changes what that selector does for some input that already worked.
+- Adding, removing, or changing a revert path on an existing, otherwise-unmodified function.
 - Moving, resizing, retyping, or reordering an *existing* field's storage slot (see
   `MockB20Storage.sol`) — diverges from the Rust precompile's real layout and breaks `vm.load` /
   live-precompile parity.
@@ -141,48 +136,23 @@ reachable from.
 non-breaking — nothing could call it before. The existing `transfer` gaining a new revert condition
 is breaking — a call that used to succeed can now fail.
 
-### Branching model
+### Drafting a release
 
-There is **one ongoing release branch per MAJOR line**, `releases/vN.x` — not one per hardfork and
-not one per minor. As long as no breaking change has shipped, `releases/vN.x` just tracks `main`:
-every MINOR and PATCH is cut by fast-forwarding it to the freeze commit and tagging, no divergence,
-no backport needed.
+There is one ongoing release branch per MAJOR line, `releases/vN.x`, fast-forwarded to `main` at
+each freeze point — no per-hardfork or per-minor branch. A new `releases/v(N+1).x` only gets cut the
+day a breaking change actually ships.
 
-A second branch, `releases/v(N+1).x`, only gets cut the day a breaking change is actually ready to
-ship. At that point `releases/vN.x` stops tracking `main` and becomes the maintenance line for the
-old MAJOR — from then on, `main` has moved on to work `vN.x` can't take wholesale, so fixes for
-`vN.x` need a deliberate backport PR rather than a fast-forward.
-
-### Process
-
-1. Land the frozen interface and its `changelog/<ordinal>_<Hardfork>_*.md` entries on `main` (see
-   `changelog/AGENTS.md`), and add the hardfork's summary to root `CHANGELOG.md`.
-2. Fast-forward `releases/vN.x` to that commit (`git push origin main:releases/vN.x`, or open a PR
-   if the branch is protected). Only cut a *new* `releases/v(N+1).x` branch if this release is
-   itself the breaking change that bumps MAJOR — see [Branching model](#branching-model).
-3. Tag from that branch: `git tag vN.M.P && git push origin vN.M.P`.
-4. `gh release create vN.M.P --title "vN.M.P — Base <Hardfork>" --notes-file <notes>` — title and
-   body follow the existing releases (`v1.0.0`, `v1.0.1`): state compatibility with the prior
-   hardfork, link each changelog entry, and link the aligned tag in
-   [base/base](https://github.com/base/base) if one exists.
-5. Once a second MAJOR line exists, patch fixes for the *old* line land on `main` (or its current
-   MAJOR's branch) first, then get backported to that line via a normal PR before tagging its next
-   PATCH — never commit directly to the old branch.
-
-### Draft releases
-
-- Cut the git tag first (`git tag vN.M.P && git push origin vN.M.P`), *then*
-  `gh release create vN.M.P --draft --notes-file <notes>` — a draft anchored to a real, pushed tag.
-  GitHub still shows a synthetic `releases/tag/untagged-<hash>` URL for drafts; that's expected and
-  resolves once you publish, not a sign the tag is wrong.
-- Only create the draft once the release branch tip is where you actually intend to freeze —
-  don't draft speculatively against a commit that's about to get more changes. If the branch moves,
-  delete and recreate the draft (and re-tag) rather than editing notes to describe a different commit.
-- Write notes via `--notes-file`, not an inline `--notes` string, so they're easy to proofread and
-  diff before publishing — read the rendered draft back (`gh release view vN.M.P`) before leaving it.
-- Keep at most one open draft per version. A stale, unpublished draft sitting next to a moved tag is
-  a false signal to other maintainers about what's about to ship — delete it
-  (`gh release delete vN.M.P --yes`) the moment it's superseded, don't leave it for cleanup later.
+1. Land the frozen interface, its `changelog/<ordinal>_<Hardfork>_*.md` entries, and the
+   `CHANGELOG.md` summary on `main`.
+2. Fast-forward `releases/vN.x` to that commit: `git push origin main:releases/vN.x`.
+3. Tag from that branch, draft first: `git tag vN.M.P && git push origin vN.M.P`, then
+   `gh release create vN.M.P --draft --notes-file <notes>` — a draft anchored to a real, pushed tag
+   (GitHub shows a synthetic `untagged-<hash>` URL for drafts; expected, resolves on publish).
+4. Write notes via `--notes-file` and proofread the rendered draft (`gh release view vN.M.P`) before
+   leaving it — title/body follow `v1.0.0`/`v1.0.1`: compatibility statement, one bullet per
+   changelog entry, link the aligned base/base tag if one exists.
+5. Keep at most one open draft per version. If the branch moves before publishing, delete
+   (`gh release delete vN.M.P --yes`) and re-tag rather than leaving a stale draft around.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,67 @@ Deeper reading: `LIVE_PRECOMPILE_TESTING.md` (cross-validation architecture), `d
 - CI on every PR: `forge build`, `forge test`, `forge fmt --check`,
   `python3 script/check-coverage.py`, coverage comment. Live-precompile tests run in a separate workflow.
 
+## Cutting releases
+
+Versioning maps onto hardforks, not onto arbitrary feature batches:
+
+- **MAJOR** (`vN.0.0`): a new hardfork boundary. Cutting the tag freezes the Solidity interface for
+  that hardfork — this can happen before on-chain activation, not after. Pick `N` from the
+  hardfork's ordinal in `changelog/README.md`'s [Hardfork ordinals](changelog/README.md#hardfork-ordinals)
+  table (`01` Beryl → `v1`, `02` Cobalt → `v2`, ...).
+- **MINOR** (`vN.M.0`): additive, non-breaking interface changes to the *current*, not-yet-frozen
+  hardfork — new selectors, events, or errors layered onto what's already tagged.
+- **PATCH** (`vN.M.P`): no interface change — tooling, harness, docs, or CI fixes on an
+  already-frozen release (e.g. `v1.0.1`'s fork-profile pin).
+
+### Breaking vs. non-breaking
+
+This repo's invariant is slot-for-slot storage parity with the Rust precompiles plus a stable
+public ABI for integrators — a change is breaking if it violates either.
+
+**Breaking** — requires a new MAJOR/hardfork boundary, never a MINOR/PATCH:
+- Removing or renaming an existing function, event, or error (selector-changing).
+- Changing an existing function's signature, parameter types, or return types.
+- Changing the storage slot layout for existing state (see `MockB20Storage.sol`).
+- Changing precompile addresses or feature IDs in `src/StdPrecompiles.sol` /
+  `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical constants shared with
+  base/base — coordinate there first, see Boundaries below).
+- Changing the observable behavior of an existing, unchanged selector.
+
+**Non-breaking** — fine within a MINOR or PATCH:
+- Adding a new function, event, or error that doesn't collide with an existing selector.
+- Deprecating a symbol (NatSpec `@deprecated` + changelog note) while leaving it callable, unchanged.
+- Documentation, test, tooling, harness, or CI changes.
+
+### Process
+
+1. Land the frozen interface and its `changelog/<ordinal>_<Hardfork>_*.md` entries on `main` (see
+   `changelog/AGENTS.md`), and add the hardfork's summary to root `CHANGELOG.md`.
+2. Cut `releases/vN.0.x` from `main` at the freeze commit (or fast-forward it, if the branch already
+   exists for an in-progress hardfork).
+3. Tag from that branch: `git tag vN.0.0 && git push origin vN.0.0`.
+4. `gh release create vN.0.0 --title "vN.0.0 — Base <Hardfork>" --notes-file <notes>` — title and
+   body follow the existing releases (`v1.0.0`, `v1.0.1`): state compatibility with the prior
+   hardfork, link each changelog entry, and link the aligned tag in
+   [base/base](https://github.com/base/base) if one exists.
+5. Patch fixes land on `main` first, then backport to the `releases/vN.0.x` branch (the
+   `backport-loop` skill automates finding/porting them) before tagging `vN.0.P`.
+
+### Draft releases
+
+- Cut the git tag first (`git tag vN.0.0 && git push origin vN.0.0`), *then*
+  `gh release create vN.0.0 --draft --notes-file <notes>` — a draft anchored to a real, pushed tag.
+  GitHub still shows a synthetic `releases/tag/untagged-<hash>` URL for drafts; that's expected and
+  resolves once you publish, not a sign the tag is wrong.
+- Only create the draft once the release branch tip is where you actually intend to freeze —
+  don't draft speculatively against a commit that's about to get more changes. If the branch moves,
+  delete and recreate the draft (and re-tag) rather than editing notes to describe a different commit.
+- Write notes via `--notes-file`, not an inline `--notes` string, so they're easy to proofread and
+  diff before publishing — read the rendered draft back (`gh release view vN.0.0`) before leaving it.
+- Keep at most one open draft per version. A stale, unpublished draft sitting next to a moved tag is
+  a false signal to other maintainers about what's about to ship — delete it
+  (`gh release delete vN.0.0 --yes`) the moment it's superseded, don't leave it for cleanup later.
+
 ## Boundaries
 
 - **Don't change the precompile addresses** in `src/StdPrecompiles.sol` or the feature IDs in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,36 @@ public ABI for integrators — a change is breaking if it violates either.
    body follow the existing releases (`v1.0.0`, `v1.0.1`): state compatibility with the prior
    hardfork, link each changelog entry, and link the aligned tag in
    [base/base](https://github.com/base/base) if one exists.
-5. Patch fixes land on `main` first, then backport to the `releases/vN.0.x` branch (the
-   `backport-loop` skill automates finding/porting them) before tagging `vN.0.P`.
+5. Patch fixes land on `main` first, then backport to the `releases/vN.0.x` branch (see
+   [Backporting](#backporting)) before tagging `vN.0.P`.
+
+### Backporting
+
+Patch fixes always land on `main` first, then get ported to the release branch — never commit
+directly to `releases/vN.0.x`.
+
+1. Ground truth is the tip-to-tip diff, not commit history:
+   `git diff origin/releases/vN.0.x origin/main -- <paths>`. Empty output means that path is fully
+   backported; anything else is missing.
+2. For each differing file, find the commit on `main` that introduced the difference:
+   ```bash
+   MERGE_BASE=$(git merge-base origin/releases/vN.0.x origin/main)
+   git log --oneline $MERGE_BASE..origin/main -- <file>
+   ```
+   Group files by commit SHA so you backport one PR per upstream commit, not one PR per file.
+3. Branch from the release branch, cherry-pick, push, and open a PR back against the release
+   branch — never against `main`:
+   ```bash
+   git checkout -b backport/pr-<NUM>-to-vN.0.x origin/releases/vN.0.x
+   git cherry-pick <SHA>
+   git push origin backport/pr-<NUM>-to-vN.0.x
+   gh pr create --base releases/vN.0.x --title "[backport] <original PR title>"
+   ```
+   On a conflict, take `main`'s version for straightforward/additive cases
+   (`git checkout origin/main -- <file> && git add <file> && git cherry-pick --continue`); for
+   anything non-trivial, resolve deliberately rather than guessing — a backport must produce the
+   same code as `main` for those files.
+4. Re-run the diff in step 1 after merging. Repeat until it's empty, then tag `vN.0.P`.
 
 ### Draft releases
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,28 +114,6 @@ succeeds where it reverted, reverts where it succeeded, reverts with a different
 returns/emits something different — it's breaking, regardless of whether the ABI itself gained or
 lost anything. A new error or event isn't automatically non-breaking; check what it's reachable from.
 
-**Breaking** (MAJOR only):
-- Removing, renaming, or changing the signature/return type of an existing function, event, or error.
-- Adding, removing, or changing a revert path on an existing, otherwise-unmodified function.
-- Moving, resizing, retyping, or reordering an *existing* field's storage slot (see
-  `MockB20Storage.sol`) — diverges from the Rust precompile's real layout and breaks `vm.load` /
-  live-precompile parity.
-- Changing precompile addresses or feature IDs in `src/StdPrecompiles.sol` /
-  `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical, shared with base/base —
-  coordinate there first, see Boundaries below).
-- Any other change to what an existing, unchanged selector returns or emits for the same inputs.
-
-**Non-breaking** (MINOR/PATCH):
-- A new function, and any event or error only reachable through it.
-- Appending new ERC-7201 namespaced state — new slots, existing ones untouched (how Cobalt added
-  `SEIZE_EXEMPT_POLICY`/`SEIZE_RECEIVER_POLICY` without touching Beryl's layout).
-- Deprecating a symbol (NatSpec `@deprecated`) while it stays callable, unchanged.
-- Docs, tests, tooling, harness, or CI.
-
-**Example**: `seizeWithMemo` (a new function) reverting with a new `AlreadySeized` error is
-non-breaking — nothing could call it before. The existing `transfer` gaining a new revert condition
-is breaking — a call that used to succeed can now fail.
-
 ### Drafting a release
 
 There is one ongoing release branch per MAJOR line, `releases/vN.x`, fast-forwarded to `main` at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,19 +104,38 @@ Versioning maps onto hardforks, not onto arbitrary feature batches:
 This repo's invariant is slot-for-slot storage parity with the Rust precompiles plus a stable
 public ABI for integrators — a change is breaking if it violates either.
 
+**The test**: take any function that already shipped, with its selector and inputs held fixed. Can
+its outcome differ from what it is today — succeeds where it used to revert, reverts where it used
+to succeed, reverts with a different error, or returns/emits something different? If yes, it's
+breaking, *regardless of whether the ABI itself gained or lost anything*. New errors, new events, and
+new functions are not automatically non-breaking — only check where they're reachable from.
+
 **Breaking** — requires a new MAJOR/hardfork boundary, never a MINOR/PATCH:
 - Removing or renaming an existing function, event, or error (selector-changing).
 - Changing an existing function's signature, parameter types, or return types.
+- Adding a new revert path — a new `error` — reachable from an existing, otherwise-unmodified
+  function. The error itself is new, but an input that used to succeed on that selector now
+  reverts, which is exactly the kind of caller-visible change MAJOR exists for.
+- Removing an existing revert path, or changing which error an existing one throws — an input that
+  used to fail now succeeds, or fails differently.
 - Changing the storage slot layout for existing state (see `MockB20Storage.sol`).
 - Changing precompile addresses or feature IDs in `src/StdPrecompiles.sol` /
   `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical constants shared with
   base/base — coordinate there first, see Boundaries below).
-- Changing the observable behavior of an existing, unchanged selector.
+- Any other change to what an existing, unchanged selector returns or emits for the same inputs.
 
 **Non-breaking** — fine within a MINOR or PATCH:
-- Adding a new function, event, or error that doesn't collide with an existing selector.
+- Adding an entirely new function (new selector), including any events or errors that are only
+  reachable through that new function — no existing selector's behavior changes, so no existing
+  caller is affected.
+- Adding a new event emitted only from a new function, for the same reason.
 - Deprecating a symbol (NatSpec `@deprecated` + changelog note) while leaving it callable, unchanged.
 - Documentation, test, tooling, harness, or CI changes.
+
+**Worked example**: adding `error AlreadySeized()` and having `seizeWithMemo` (a brand-new
+function) revert with it → non-breaking, nothing could call `seizeWithMemo` before. Adding
+`error TransferPaused()` and having the *existing* `transfer` throw it under some new condition →
+breaking, because a `transfer` call that used to succeed can now revert.
 
 ### Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,10 @@ new functions are not automatically non-breaking — only check where they're re
   reverts, which is exactly the kind of caller-visible change MAJOR exists for.
 - Removing an existing revert path, or changing which error an existing one throws — an input that
   used to fail now succeeds, or fails differently.
-- Changing the storage slot layout for existing state (see `MockB20Storage.sol`).
+- Moving, resizing, retyping, or reordering the storage slot of any *existing* field (see
+  `MockB20Storage.sol`) — this diverges from the Rust precompile's real layout, breaks
+  `vm.load` slot assertions and live-precompile cross-validation, and breaks any external tooling
+  that reads that state by raw slot.
 - Changing precompile addresses or feature IDs in `src/StdPrecompiles.sol` /
   `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical constants shared with
   base/base — coordinate there first, see Boundaries below).
@@ -129,6 +132,9 @@ new functions are not automatically non-breaking — only check where they're re
   reachable through that new function — no existing selector's behavior changes, so no existing
   caller is affected.
 - Adding a new event emitted only from a new function, for the same reason.
+- Appending new state via the existing ERC-7201 namespaced-storage pattern — new fields land in new
+  slots, and every existing field keeps the slot it already has (how Cobalt added
+  `SEIZE_EXEMPT_POLICY`/`SEIZE_RECEIVER_POLICY` without touching Beryl's layout).
 - Deprecating a symbol (NatSpec `@deprecated` + changelog note) while leaving it callable, unchanged.
 - Documentation, test, tooling, harness, or CI changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,44 +112,34 @@ branching.
 This repo's invariant is slot-for-slot storage parity with the Rust precompiles plus a stable
 public ABI for integrators — a change is breaking if it violates either.
 
-**The test**: take any function that already shipped, with its selector and inputs held fixed. Can
-its outcome differ from what it is today — succeeds where it used to revert, reverts where it used
-to succeed, reverts with a different error, or returns/emits something different? If yes, it's
-breaking, *regardless of whether the ABI itself gained or lost anything*. New errors, new events, and
-new functions are not automatically non-breaking — only check where they're reachable from.
+**The test**: fix an already-shipped selector and its inputs. If the outcome can differ from what
+it is today — succeeds where it reverted, reverts where it succeeded, reverts with a different
+error, or returns/emits something different — it's breaking, regardless of whether the ABI itself
+gained or lost anything. A new error or event isn't automatically non-breaking; check what it's
+reachable from.
 
-**Breaking** — requires a MAJOR bump, never a MINOR/PATCH:
-- Removing or renaming an existing function, event, or error (selector-changing).
-- Changing an existing function's signature, parameter types, or return types.
-- Adding a new revert path — a new `error` — reachable from an existing, otherwise-unmodified
-  function. The error itself is new, but an input that used to succeed on that selector now
-  reverts, which is exactly the kind of caller-visible change MAJOR exists for.
-- Removing an existing revert path, or changing which error an existing one throws — an input that
-  used to fail now succeeds, or fails differently.
-- Moving, resizing, retyping, or reordering the storage slot of any *existing* field (see
-  `MockB20Storage.sol`) — this diverges from the Rust precompile's real layout, breaks
-  `vm.load` slot assertions and live-precompile cross-validation, and breaks any external tooling
-  that reads that state by raw slot.
+**Breaking** (MAJOR only):
+- Removing, renaming, or changing the signature/return type of an existing function, event, or error.
+- Adding, removing, or changing a revert path on an existing, otherwise-unmodified function — any of
+  these changes what that selector does for some input that already worked.
+- Moving, resizing, retyping, or reordering an *existing* field's storage slot (see
+  `MockB20Storage.sol`) — diverges from the Rust precompile's real layout and breaks `vm.load` /
+  live-precompile parity.
 - Changing precompile addresses or feature IDs in `src/StdPrecompiles.sol` /
-  `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical constants shared with
-  base/base — coordinate there first, see Boundaries below).
+  `script/smoke/config.py` / `ActivationRegistryFeatureList.sol` (canonical, shared with base/base —
+  coordinate there first, see Boundaries below).
 - Any other change to what an existing, unchanged selector returns or emits for the same inputs.
 
-**Non-breaking** — fine within a MINOR or PATCH:
-- Adding an entirely new function (new selector), including any events or errors that are only
-  reachable through that new function — no existing selector's behavior changes, so no existing
-  caller is affected.
-- Adding a new event emitted only from a new function, for the same reason.
-- Appending new state via the existing ERC-7201 namespaced-storage pattern — new fields land in new
-  slots, and every existing field keeps the slot it already has (how Cobalt added
+**Non-breaking** (MINOR/PATCH):
+- A new function, and any event or error only reachable through it.
+- Appending new ERC-7201 namespaced state — new slots, existing ones untouched (how Cobalt added
   `SEIZE_EXEMPT_POLICY`/`SEIZE_RECEIVER_POLICY` without touching Beryl's layout).
-- Deprecating a symbol (NatSpec `@deprecated` + changelog note) while leaving it callable, unchanged.
-- Documentation, test, tooling, harness, or CI changes.
+- Deprecating a symbol (NatSpec `@deprecated`) while it stays callable, unchanged.
+- Docs, tests, tooling, harness, or CI.
 
-**Worked example**: adding `error AlreadySeized()` and having `seizeWithMemo` (a brand-new
-function) revert with it → non-breaking, nothing could call `seizeWithMemo` before. Adding
-`error TransferPaused()` and having the *existing* `transfer` throw it under some new condition →
-breaking, because a `transfer` call that used to succeed can now revert.
+**Example**: `seizeWithMemo` (a new function) reverting with a new `AlreadySeized` error is
+non-breaking — nothing could call it before. The existing `transfer` gaining a new revert condition
+is breaking — a call that used to succeed can now fail.
 
 ### Branching model
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,16 +88,24 @@ Deeper reading: `LIVE_PRECOMPILE_TESTING.md` (cross-validation architecture), `d
 
 ## Cutting releases
 
-Versioning maps onto hardforks, not onto arbitrary feature batches:
+Versioning is `vMAJOR.MINOR.PATCH`, and which digit moves is decided by the breaking-vs-non-breaking
+test below — **not** by whether a hardfork boundary is involved. Hardforks in this repo are additive
+by design, so most of them land as MINOR, same as any other additive change:
 
-- **MAJOR** (`vN.0.0`): a new hardfork boundary. Cutting the tag freezes the Solidity interface for
-  that hardfork — this can happen before on-chain activation, not after. Pick `N` from the
-  hardfork's ordinal in `changelog/README.md`'s [Hardfork ordinals](changelog/README.md#hardfork-ordinals)
-  table (`01` Beryl → `v1`, `02` Cobalt → `v2`, ...).
-- **MINOR** (`vN.M.0`): additive, non-breaking interface changes to the *current*, not-yet-frozen
-  hardfork — new selectors, events, or errors layered onto what's already tagged.
-- **PATCH** (`vN.M.P`): no interface change — tooling, harness, docs, or CI fixes on an
-  already-frozen release (e.g. `v1.0.1`'s fork-profile pin).
+- **MAJOR**: a change that fails the breaking test. Expect this to be rare — it fires whenever an
+  actual breaking change ships, whether or not that coincides with a hardfork.
+- **MINOR**: a hardfork's frozen interface, once it's fully additive (the common case) — increments
+  once per hardfork, matching the ordinal in `changelog/README.md`'s
+  [Hardfork ordinals](changelog/README.md#hardfork-ordinals) table shifted down by one (`01` Beryl →
+  `1.0`, `02` Cobalt → `1.1`, `03` (next hardfork) → `1.2`, ...). Also covers any other additive,
+  non-breaking interface change outside a hardfork boundary. Freezing happens at tag time, which can
+  be before on-chain activation, not after.
+- **PATCH**: no interface change — tooling, harness, docs, or CI fixes on an already-frozen release
+  (e.g. the fork-profile pin that shipped in `v1.0.1`).
+
+If a hardfork's interface *does* contain a breaking change, that pushes MAJOR instead of MINOR (and
+resets MINOR/PATCH to `0`) — see [Branching model](#branching-model) for what that means for
+branching.
 
 ### Breaking vs. non-breaking
 
@@ -110,7 +118,7 @@ to succeed, reverts with a different error, or returns/emits something different
 breaking, *regardless of whether the ABI itself gained or lost anything*. New errors, new events, and
 new functions are not automatically non-breaking — only check where they're reachable from.
 
-**Breaking** — requires a new MAJOR/hardfork boundary, never a MINOR/PATCH:
+**Breaking** — requires a MAJOR bump, never a MINOR/PATCH:
 - Removing or renaming an existing function, event, or error (selector-changing).
 - Changing an existing function's signature, parameter types, or return types.
 - Adding a new revert path — a new `error` — reachable from an existing, otherwise-unmodified
@@ -143,62 +151,77 @@ function) revert with it → non-breaking, nothing could call `seizeWithMemo` be
 `error TransferPaused()` and having the *existing* `transfer` throw it under some new condition →
 breaking, because a `transfer` call that used to succeed can now revert.
 
+### Branching model
+
+There is **one ongoing release branch per MAJOR line**, `releases/vN.x` — not one per hardfork and
+not one per minor. As long as no breaking change has shipped, `releases/vN.x` just tracks `main`:
+every MINOR and PATCH is cut by fast-forwarding it to the freeze commit and tagging, no divergence,
+no backport needed.
+
+A second branch, `releases/v(N+1).x`, only gets cut the day a breaking change is actually ready to
+ship. At that point `releases/vN.x` stops tracking `main` and becomes the maintenance line for the
+old MAJOR — from then on, fixes for `vN.x` need the [Backporting](#backporting) procedure, because
+`main` has moved on to work that `vN.x` can't take wholesale.
+
 ### Process
 
 1. Land the frozen interface and its `changelog/<ordinal>_<Hardfork>_*.md` entries on `main` (see
    `changelog/AGENTS.md`), and add the hardfork's summary to root `CHANGELOG.md`.
-2. Cut `releases/vN.0.x` from `main` at the freeze commit (or fast-forward it, if the branch already
-   exists for an in-progress hardfork).
-3. Tag from that branch: `git tag vN.0.0 && git push origin vN.0.0`.
-4. `gh release create vN.0.0 --title "vN.0.0 — Base <Hardfork>" --notes-file <notes>` — title and
+2. Fast-forward `releases/vN.x` to that commit (`git push origin main:releases/vN.x`, or open a PR
+   if the branch is protected). Only cut a *new* `releases/v(N+1).x` branch if this release is
+   itself the breaking change that bumps MAJOR — see [Branching model](#branching-model).
+3. Tag from that branch: `git tag vN.M.P && git push origin vN.M.P`.
+4. `gh release create vN.M.P --title "vN.M.P — Base <Hardfork>" --notes-file <notes>` — title and
    body follow the existing releases (`v1.0.0`, `v1.0.1`): state compatibility with the prior
    hardfork, link each changelog entry, and link the aligned tag in
    [base/base](https://github.com/base/base) if one exists.
-5. Patch fixes land on `main` first, then backport to the `releases/vN.0.x` branch (see
-   [Backporting](#backporting)) before tagging `vN.0.P`.
+5. Once a second MAJOR line exists, patch fixes for the *old* line land on `main` (or its current
+   MAJOR's branch) first, then backport via the procedure below before tagging that line's next
+   PATCH.
 
 ### Backporting
 
-Patch fixes always land on `main` first, then get ported to the release branch — never commit
-directly to `releases/vN.0.x`.
+Only relevant once more than one MAJOR line is being maintained — before that, `releases/vN.x` just
+tracks `main` and there's nothing to backport. Patch fixes always land upstream first, then get
+ported to the older release branch — never commit directly to `releases/vN.x`.
 
 1. Ground truth is the tip-to-tip diff, not commit history:
-   `git diff origin/releases/vN.0.x origin/main -- <paths>`. Empty output means that path is fully
+   `git diff origin/releases/vN.x origin/main -- <paths>`. Empty output means that path is fully
    backported; anything else is missing.
 2. For each differing file, find the commit on `main` that introduced the difference:
    ```bash
-   MERGE_BASE=$(git merge-base origin/releases/vN.0.x origin/main)
+   MERGE_BASE=$(git merge-base origin/releases/vN.x origin/main)
    git log --oneline $MERGE_BASE..origin/main -- <file>
    ```
    Group files by commit SHA so you backport one PR per upstream commit, not one PR per file.
 3. Branch from the release branch, cherry-pick, push, and open a PR back against the release
    branch — never against `main`:
    ```bash
-   git checkout -b backport/pr-<NUM>-to-vN.0.x origin/releases/vN.0.x
+   git checkout -b backport/pr-<NUM>-to-vN.x origin/releases/vN.x
    git cherry-pick <SHA>
-   git push origin backport/pr-<NUM>-to-vN.0.x
-   gh pr create --base releases/vN.0.x --title "[backport] <original PR title>"
+   git push origin backport/pr-<NUM>-to-vN.x
+   gh pr create --base releases/vN.x --title "[backport] <original PR title>"
    ```
    On a conflict, take `main`'s version for straightforward/additive cases
    (`git checkout origin/main -- <file> && git add <file> && git cherry-pick --continue`); for
    anything non-trivial, resolve deliberately rather than guessing — a backport must produce the
    same code as `main` for those files.
-4. Re-run the diff in step 1 after merging. Repeat until it's empty, then tag `vN.0.P`.
+4. Re-run the diff in step 1 after merging. Repeat until it's empty, then tag `vN.M.P`.
 
 ### Draft releases
 
-- Cut the git tag first (`git tag vN.0.0 && git push origin vN.0.0`), *then*
-  `gh release create vN.0.0 --draft --notes-file <notes>` — a draft anchored to a real, pushed tag.
+- Cut the git tag first (`git tag vN.M.P && git push origin vN.M.P`), *then*
+  `gh release create vN.M.P --draft --notes-file <notes>` — a draft anchored to a real, pushed tag.
   GitHub still shows a synthetic `releases/tag/untagged-<hash>` URL for drafts; that's expected and
   resolves once you publish, not a sign the tag is wrong.
 - Only create the draft once the release branch tip is where you actually intend to freeze —
   don't draft speculatively against a commit that's about to get more changes. If the branch moves,
   delete and recreate the draft (and re-tag) rather than editing notes to describe a different commit.
 - Write notes via `--notes-file`, not an inline `--notes` string, so they're easy to proofread and
-  diff before publishing — read the rendered draft back (`gh release view vN.0.0`) before leaving it.
+  diff before publishing — read the rendered draft back (`gh release view vN.M.P`) before leaving it.
 - Keep at most one open draft per version. A stale, unpublished draft sitting next to a moved tag is
   a false signal to other maintainers about what's about to ship — delete it
-  (`gh release delete vN.0.0 --yes`) the moment it's superseded, don't leave it for cleanup later.
+  (`gh release delete vN.M.P --yes`) the moment it's superseded, don't leave it for cleanup later.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,8 +150,8 @@ no backport needed.
 
 A second branch, `releases/v(N+1).x`, only gets cut the day a breaking change is actually ready to
 ship. At that point `releases/vN.x` stops tracking `main` and becomes the maintenance line for the
-old MAJOR — from then on, fixes for `vN.x` need the [Backporting](#backporting) procedure, because
-`main` has moved on to work that `vN.x` can't take wholesale.
+old MAJOR — from then on, `main` has moved on to work `vN.x` can't take wholesale, so fixes for
+`vN.x` need a deliberate backport PR rather than a fast-forward.
 
 ### Process
 
@@ -166,37 +166,8 @@ old MAJOR — from then on, fixes for `vN.x` need the [Backporting](#backporting
    hardfork, link each changelog entry, and link the aligned tag in
    [base/base](https://github.com/base/base) if one exists.
 5. Once a second MAJOR line exists, patch fixes for the *old* line land on `main` (or its current
-   MAJOR's branch) first, then backport via the procedure below before tagging that line's next
-   PATCH.
-
-### Backporting
-
-Only relevant once more than one MAJOR line is being maintained — before that, `releases/vN.x` just
-tracks `main` and there's nothing to backport. Patch fixes always land upstream first, then get
-ported to the older release branch — never commit directly to `releases/vN.x`.
-
-1. Ground truth is the tip-to-tip diff, not commit history:
-   `git diff origin/releases/vN.x origin/main -- <paths>`. Empty output means that path is fully
-   backported; anything else is missing.
-2. For each differing file, find the commit on `main` that introduced the difference:
-   ```bash
-   MERGE_BASE=$(git merge-base origin/releases/vN.x origin/main)
-   git log --oneline $MERGE_BASE..origin/main -- <file>
-   ```
-   Group files by commit SHA so you backport one PR per upstream commit, not one PR per file.
-3. Branch from the release branch, cherry-pick, push, and open a PR back against the release
-   branch — never against `main`:
-   ```bash
-   git checkout -b backport/pr-<NUM>-to-vN.x origin/releases/vN.x
-   git cherry-pick <SHA>
-   git push origin backport/pr-<NUM>-to-vN.x
-   gh pr create --base releases/vN.x --title "[backport] <original PR title>"
-   ```
-   On a conflict, take `main`'s version for straightforward/additive cases
-   (`git checkout origin/main -- <file> && git add <file> && git cherry-pick --continue`); for
-   anything non-trivial, resolve deliberately rather than guessing — a backport must produce the
-   same code as `main` for those files.
-4. Re-run the diff in step 1 after merging. Repeat until it's empty, then tag `vN.M.P`.
+   MAJOR's branch) first, then get backported to that line via a normal PR before tagging its next
+   PATCH — never commit directly to the old branch.
 
 ### Draft releases
 


### PR DESCRIPTION
## Summary
- Adds a **Cutting releases** section to `AGENTS.md`: how semver maps onto hardfork boundaries (MAJOR/MINOR/PATCH), what counts as a breaking vs. non-breaking change given this repo's slot-parity and stable-ABI invariants, and the tag/branch/changelog steps to cut a release.
- Adds a **Draft releases** subsection with best practices (tag before drafting, `--notes-file`, don't leave stale/superseded drafts around) — motivated by cleaning up a stale `v2.0.0` draft release/tag that had been cut speculatively and left with a typo in the notes.

## Test plan
- [x] Docs-only change; no build/test impact.
- [ ] Reviewer sanity-check: version-bump rules and breaking/non-breaking list match actual practice for `v1.0.0`/`v1.0.1`/the (now-deleted) `v2.0.0` draft.