### PR TITLE
fix(fork): explicitly pin fork profile to base = "cobalt"

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -45,7 +45,7 @@ vibenet = "https://rpc.vibes.base.org/"
 runs = 10
 
 [profile.fork]
-base = true
+base = "cobalt"
 
 [fmt]
 line_length = 120


### PR DESCRIPTION
## Summary
- `base = true` in `[profile.fork]` resolved to base-anvil's `DEFAULT_BASE_UPGRADE` at build time. As of base-anvil PR #71 that default is Cobalt (correct today), but relying on an implicit default is fragile — a future `DEFAULT_BASE_UPGRADE` bump would silently change test behavior. Pin explicitly to `"cobalt"`.
- This is a re-application of #219, which landed directly on `releases/v2.0.x` instead of `main`. Per the branching model we're settling on (one ongoing `releases/v1.x` branch tracking `main`, no per-hardfork branch), this fix belongs on `main` so it flows into the next tagged release.

## Test plan
- [x] Docs/tooling-only change (no interface change).
- [ ] `base-forge test` / `make fork-tests` still dispatch at the intended (Cobalt) precompile version after this change.