### PR TITLE
changelog(denim): add NOT / invert policy spec

### DIFF
--- a/changelog/03_Denim_PolicyRegistry_not_policy.md
+++ b/changelog/03_Denim_PolicyRegistry_not_policy.md
@@ -1,0 +1,183 @@
+# NOT / Invert Policies
+
+- **Feature Name**: not_policy
+- **Start Date**: 2026-09-09
+- **Authors**: Rayyan Alam
+- **Title**: NOT / Invert Policies
+
+## Summary
+
+Issuers may want the inverse of a specific list without maintaining two lists. For example, they may authorize an account only when it is not on a sanctions blocklist. This change adds a query-time invert (NOT) flag in bit 63 of a `uint64` policy ID. When that bit is set, `isAuthorized` resolves the base policy and returns the opposite of that policy's decision.
+
+Members stay on the base policy and are shared, not copied, so an update to the base updates its inverse. Invert therefore creates no new record, no new create path, and no extra storage load (`SLOAD`). The flag applies to every policy type: `ALLOWLIST`, `BLOCKLIST`, and `UNION` / `INTERSECT` composites. 
+
+## Motivation
+
+Issuers may want the inverse of a specific list, and the registry cannot express that. They may authorize an account only when it is not on a sanctions blocklist, or only when it is not Know Your Customer (KYC) verified. Composites often need the same negation: "allowed to transfer" is frequently "on list A and not on list B", where list B is a sanctions list, a blocked list, or a non-KYC'd list. There is no way to say "the opposite of this policy."
+
+The workaround is to maintain two mirror lists: an allowlist and a blocklist seeded with the same addresses. Every membership change must land on both lists. Any lag rejects valid accounts or admits invalid ones. Composite policies do not remove that second list.
+
+The goal is to let one membership set be evaluated as include or exclude, so issuers never maintain two policies for the same address group.
+
+## Background
+
+### Policy Registry
+
+The Policy Registry is a singleton precompile at `0x8453000000000000000000000000000000000002`. B20 tokens call it for pre-operation compliance checks on an address.
+
+B20 stores a `uint64` policy ID per scope (`TRANSFER_FROM`, `TRANSFER_TO`, `MINT_RECEIVER`, `SEIZE_EXEMPT`, and other scopes) and calls `isAuthorized(policyId, account)` before gated operations.
+
+`isAuthorized` never reverts. A malformed or unknown ID returns `false` (deny).
+
+### Policy ID layout
+
+A policy ID is a `uint64` value issued by the Policy Registry. It is the link between the registry and a token: the registry stores the policy, and the token stores only the ID, then passes that ID to `isAuthorized` for each gated operation.
+
+The structure of a policy ID is:
+
+```text
+ 63              56 55                             0
++------------------+-------------------------------+
+| PolicyType byte  | unique counter                |
++------------------+-------------------------------+
+```
+
+- Bits `[0:55]` hold a unique counter value. The type is not stored in a slot.
+- Bits `[56:63]` are reserved for `PolicyType`. Only four types are used today (`0–3`: `BLOCKLIST`, `ALLOWLIST`, `UNION`, `INTERSECT`), occupying bits `56–57`. Bits `58–63` are unused.
+
+Built-in sentinels are `ALWAYS_ALLOW` (id 0) and `ALWAYS_BLOCK` (id 1). The counter starts at 2.
+
+
+## Specs
+
+### Interface Changes
+
+This change introduces `invertedPolicyId`, a view helper that returns the inverted version of a policy ID. Indexers, explorers, externally owned accounts (EOAs), and cross-codebase contracts can call it to obtain that form without knowing the bit layout. Bit 63 of a policy ID is now reserved as the invert bit, so the registry does not add a new create function. Consumers of the Policy Registry can set that bit themselves.
+
+```solidity
+// New constant (single source of truth, in PolicyRegistryConstants)
+uint64 internal constant INVERTED_POLICY_BIT = uint64(1) << 63;
+
+// Helper created for getting the inverted version of a  policy ID 
+function invertedPolicyId(uint64 policyId) external view returns (uint64);
+```
+
+| Symbol | Selector / Topic0 | Status | Notes |
+| ------ | ----------------- | ------ | ----- |
+| `invertedPolicyId(uint64)` | `0x6b468933` | NEW (view) | Pure toggle of bit 63 (`policyId ^ INVERTED_POLICY_BIT`); never reverts, reads no state, involutive |
+| `isAuthorized(uint64,address)` | (unchanged) | extended | An inverted ID resolves the base and returns the negated result; fail-closed on an unknown/malformed base |
+| `policyExists(uint64)` | (unchanged) | extended | Strips to base: `policyExists(invertedPolicyId(id)) == policyExists(id)` |
+| `policyAdmin(uint64)` | (unchanged) | extended | Strips to base: `policyAdmin(invertedPolicyId(id)) == policyAdmin(id)` |
+| `pendingPolicyAdmin(uint64)` | (unchanged) | extended | Strips to base |
+| `compositePolicyChildIds(uint64)` | (unchanged) | extended | Strips the queried composite's own flag; child IDs returned **verbatim**, including any per-child invert |
+| `createCompositePolicy(address,uint8,uint64[])` | (unchanged) | extended | A child ID may carry the invert flag ("A AND NOT X"); validated against its base |
+| `updateComposite(uint64,uint64[])` | (unchanged) | extended | Same per-child invert handling |
+
+`invertedPolicyId` does not check existence. A missing or malformed base is denied later, at `isAuthorized`.
+
+### Behavioural Changes
+
+#### Authorization
+
+`isAuthorized` gains a leading invert branch. All non-inverted paths are byte-identical to today.
+
+```text
+isAuthorized(policyId, account):
+    if policyId has INVERTED_POLICY_BIT set:
+        base = policyId without the bit
+        if not policyExists(base):      # fail-closed guard
+            return false
+        return not isAuthorized(base, account)
+
+    ... existing ALLOWLIST / BLOCKLIST / UNION / INTERSECT dispatch ...
+```
+
+The invert applies to every policy type. Inverting a composite negates the composite's combined result.
+
+#### Getters strip to base
+
+Read views do not look up an inverted ID as its own policy. They strip bit 63 with a shared `_basePolicyId(id) = id & ~INVERTED_POLICY_BIT` helper and read the base. An inverted ID therefore has no record of its own: it mirrors the base's existence, admin, pending admin, and child set. A token can store an inverted policy ID and later re-validate it exactly as it would a plain one.
+
+```mermaid
+flowchart TD
+    Q["read view(policyId)"] --> S["_basePolicyId: clear bit 63"]
+    S --> B["Load the base policy record"]
+    B --> R["Return the base field: exists, admin, pending admin, or child set"]
+```
+
+#### Composite children
+
+A composite child ID may carry the invert bit. The registry evaluates that child as the inverse of its base, and it checks existence and simple type against the base. An inverted simple child is valid. An inverted composite child is rejected (`InvalidChildPolicy`), which preserves the flat-tree invariant. Across the whole child set, `PolicyNotFound` still takes precedence over `InvalidChildPolicy`.
+
+```mermaid
+flowchart TD
+    C["createCompositePolicy / updateComposite child"] --> S["_basePolicyId: clear bit 63"]
+    S --> E{"policyExists(base)?"}
+    E -->|no| NF["revert PolicyNotFound (whole set first)"]
+    E -->|yes| T{"base is ALLOWLIST or BLOCKLIST?"}
+    T -->|no, composite| IC["revert InvalidChildPolicy"]
+    T -->|yes| OK["Accept child ID as stored, invert bit kept"]
+```
+
+#### State / gas
+
+There are no new storage slots. Invert is query-time only. Storage keys, type decode, and existence always resolve against the issued (stripped) ID.
+
+Eval is the existing dispatch plus one boolean flip in memory. There is no extra `SLOAD`.
+
+### Examples
+
+Given a sanctions `BLOCKLIST` `sanctionsId` (authorized means not sanctioned):
+
+```solidity
+uint64 notSanctions = policyRegistry.invertedPolicyId(sanctionsId); // sanctionsId ^ (1 << 63)
+```
+
+"Allowed to transfer = on `kycId` AND not on `sanctionsId`" via a composite with an inverted child:
+
+```solidity
+uint64 notSanctions = policyRegistry.invertedPolicyId(sanctionsId);
+policyRegistry.createCompositePolicy(admin, INTERSECT, [kycId, notSanctions]);
+```
+
+Fail-closed: for any never-created base, `isAuthorized(base | INVERTED_POLICY_BIT, account) == false`. The inverted unknown ID never becomes allow-everyone.
+
+Round-trip: `invertedPolicyId(invertedPolicyId(id)) == id` (involutive). `policyExists(notSanctions) == policyExists(sanctionsId)`.
+
+## Design Decisions & Alternatives Considered
+
+Three options were weighed. The team converged on Option 2 (invert bit on the ID), implemented as Option 2a: Option 2 plus a base-existence guard that makes it fail-closed.
+
+### Chosen: invert bit on the ID
+
+The chosen approach encodes NOT in bit 63 of the policy ID. `isAuthorized` strips the bit, runs the existing dispatch, and returns the opposite result. There is no new storage and no create path. Any policy, simple or composite, can be inverted on its own.
+
+This approach was chosen because:
+
+- There is no extra `SLOAD` for the common case of inverting an `ALLOWLIST` or `BLOCKLIST`.
+- Performance matches Alternative 3, while a simple policy can be inverted standalone, which Alternative 3 cannot do.
+- It aligns with treating membership as a single address list whose include/exclude polarity is chosen by the consumer, rather than baked into `ALLOWLIST` vs `BLOCKLIST`.
+
+Tradeoff: the flag occupies unused `PolicyType` bitspace, and every getter must strip it through `_basePolicyId`.
+
+### Alternative 1 — New `NOT` policy type
+
+`createNot(admin, base)` allocates a fresh record pointing at a base. A first-class NOT node wraps any policy, with the clearest explorer legibility.
+
+This option was rejected. Standalone NOT costs about 3 `SLOAD`s versus 1 for a mirror blocklist. "A AND NOT X" costs about 6 versus the bitmask's 4. The option also adds a new create path. As a composite child it deepens hot-path recursion. It was ruled out on performance. It would be preferable only if performance were a non-issue, for its structural consistency.
+
+### Alternative 3 — Per-child invert bitmask on the composite (doc's original recommendation)
+
+This option stores a ≤4-bit mask packed into the children length word. Bit `i` flips `children[i]` before the gate. `mask = 0` reproduces today's behavior, so existing composites need no migration. It keeps polarity off the policy IDs.
+
+This option was rejected. It only works inside a composite. There is no standalone referenceable inverse of an arbitrary policy. A simple policy cannot be inverted without wrapping it in a composite (minimum 2 children). It is better suited to a different problem, and could later compose on top of the invert bit.
+
+## Migration Steps
+
+This change is not breaking. All existing selectors, events, and errors are unchanged. Existing IDs have bit 63 unset, so behavior is identical. Existing composites are unaffected.
+
+To adopt:
+
+1. Compute the inverse with `invertedPolicyId(policyId)`, or set bit 63 directly.
+2. Bind it to a B20 scope with `updatePolicy`, or pass it as an inverted composite child. B20 needs no change. It treats the ID as an opaque `uint64`.
+3. Consumers that store policy IDs MUST still validate `policyExists(policyId)` at write time. This works for inverted IDs too, because existence resolves to the base.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,10 +16,20 @@ See [AGENTS.md](AGENTS.md) for how to name and write a new entry.
 | --- | --- | --- |
 | `01` | Beryl | Live |
 | `02` | Cobalt | Upcoming |
+| `03` | Denim | Upcoming |
 
 ## Index
 
 Grouped by hardfork, one collapsible section per hardfork, newest first.
+
+<details open>
+<summary><strong>Denim (upcoming)</strong> — ordinal <code>03</code></summary>
+
+| Product(s) | Change | Affected interfaces | Entry |
+| --- | --- | --- | --- |
+| PolicyRegistry | NOT / invert policies | `src/interfaces/IPolicyRegistry.sol` | [03_Denim_PolicyRegistry_not_policy](03_Denim_PolicyRegistry_not_policy.md) |
+
+</details>
 
 <details open>
 <summary><strong>Cobalt (upcoming)</strong> — ordinal <code>02</code></summary>

--- a/docs/concepts/policies.md
+++ b/docs/concepts/policies.md
@@ -61,7 +61,7 @@ A **composite** policy combines two to four existing simple policies. It does no
 | `INTERSECT` | Every child authorizes the account |
 
 
-Children must be existing `ALLOWLIST` or `BLOCKLIST` policies. Another composite is not a valid child. The built-in sentinels in [§2.4](#24-built-in-sentinels) are not valid children either. Updating a child's members changes every composite that references it. There is no flatten-and-copy step.
+Children must be existing `ALLOWLIST` or `BLOCKLIST` policies. Another composite is not a valid child. The built-in sentinels in [§2.5](#25-built-in-sentinels) are not valid children either. Updating a child's members changes every composite that references it. There is no flatten-and-copy step. Any of these types can also be inverted. See [§2.3](#23-inverting-a-policy).
 
 ```mermaid
 flowchart TD
@@ -78,17 +78,38 @@ flowchart TD
 
 
 
-### 2.3 Creating and updating
+### 2.3 Inverting a policy
+
+An issuer may want the opposite of an existing policy without a second member set. Bit 63 of a policy ID is the invert (NOT) flag. That is not a new policy type and not a create path. Members stay on the base. An update to the base updates the inverse.
+
+Call `invertedPolicyId(policyId)` to set or clear that bit. You can also set bit 63 yourself. Bind the inverted ID to a token scope, or pass it as a composite child ("A AND NOT X"). The flag applies to every type: `ALLOWLIST`, `BLOCKLIST`, `UNION`, and `INTERSECT`.
+
+`isAuthorized` on an inverted ID returns the opposite of the base. If the base does not exist, the result is `false`. That fail-closed guard prevents a mistyped inverted ID from becoming allow-everyone.
+
+Read views strip bit 63 and load the base. `policyExists` and `policyAdmin` on an inverted ID match the base. An inverted ID has no record of its own.
+
+```mermaid
+flowchart TD
+    Q["isAuthorized(policyId, account)"] --> Inv{"bit 63 set?"}
+    Inv -->|no| T[Dispatch on policy type]
+    Inv -->|yes| E{"policyExists(base)?"}
+    E -->|no| F[false]
+    E -->|yes| N["not isAuthorized(base)"]
+```
+
+A composite child ID may carry the invert bit. The registry checks existence and simple type against the base. An inverted simple child is valid. An inverted composite child reverts `InvalidChildPolicy`. Across the whole child set, `PolicyNotFound` still takes precedence over `InvalidChildPolicy`.
+
+### 2.4 Creating and updating
 
 Anyone can create a policy. The create call names a single `admin`. That address is the only one that can later change membership, replace a composite's children, transfer administration, or renounce. The creator does not have to be the admin. `admin` cannot be `address(0)`.
 
 You can also skip creation and reuse an existing policy. If another issuer already maintains the list you need, bind their policy ID to your token. You do not become that policy's admin by attaching it.
 
-#### 2.3.1 Creating a policy
+#### 2.4.1 Creating a policy
 
 A simple policy starts as an `ALLOWLIST` or a `BLOCKLIST`. Call `createPolicy(admin, ALLOWLIST)` or `createPolicy(admin, BLOCKLIST)`. The registry assigns a new policy ID and returns it. The member set is empty. `createPolicyWithAccounts(admin, policyType, accounts)` does the same and seeds the set in that call. Membership batches are capped at 64 accounts.
 
-A composite starts from policies that already exist. Call `createCompositePolicy(admin, UNION | INTERSECT, childPolicyIds)`. The child count must be in `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]` (`2` through `4`). The registry stores references, not a snapshot of the children's members.
+A composite starts from policies that already exist. Call `createCompositePolicy(admin, UNION | INTERSECT, childPolicyIds)`. The child count must be in `[MIN_COMPOSITE_CHILD_POLICIES, MAX_COMPOSITE_CHILD_POLICIES]` (`2` through `4`). The registry stores references, not a snapshot of the children's members. A child ID may be inverted. The registry validates the base and stores the child ID with the invert bit set. See [§2.3](#23-inverting-a-policy).
 
 Both paths emit `PolicyCreated` and `PolicyAdminUpdated(policyId, address(0), admin)`. `policyAdmin(policyId)` then returns that admin.
 
@@ -104,7 +125,7 @@ sequenceDiagram
 
 
 
-#### 2.3.2 Updating a policy
+#### 2.4.2 Updating a policy
 
 After creation, only the current admin can change the policy. Any other caller reverts `Unauthorized`. The update must match the policy's type or it reverts `IncompatiblePolicyType`.
 
@@ -126,7 +147,7 @@ sequenceDiagram
 
 
 
-#### 2.3.3 Changing the admin
+#### 2.4.3 Changing the admin
 
 A policy has one admin at a time. To hand it off, the current admin calls `stageUpdateAdmin(policyId, newAdmin)`. That does not change who can update the policy yet. `policyAdmin` still returns the current admin. `pendingPolicyAdmin` returns `newAdmin`. Passing `address(0)` clears a nomination that has not been finalized.
 
@@ -154,7 +175,7 @@ sequenceDiagram
 
 To freeze a policy instead of handing it off, the current admin calls `renounceAdmin(policyId)`. Administration is gone for good. Membership and child sets cannot change. `isAuthorized` keeps working. There is no call that assigns a new admin after renounce.
 
-### 2.4 Built-in sentinels
+### 2.5 Built-in sentinels
 
 Two policy IDs exist without being created:
 
@@ -173,7 +194,7 @@ A scope is an identifier for the policy that runs on a specific function. It wor
 
 ### 3.1 Updating a scope
 
-`updatePolicy(policyScope, newPolicyId)` binds a policy ID to a scope. It requires `DEFAULT_ADMIN_ROLE`. The ID must be a built-in sentinel or an existing registry policy. Otherwise the call reverts `PolicyNotFound`. An unknown `policyScope` reverts `UnsupportedPolicyType`.
+`updatePolicy(policyScope, newPolicyId)` binds a policy ID to a scope. It requires `DEFAULT_ADMIN_ROLE`. The ID must be a built-in sentinel or an existing registry policy. Otherwise the call reverts `PolicyNotFound`. An inverted ID is valid when its base exists, because `policyExists` strips bit 63. The token treats the ID as an opaque `uint64`. An unknown `policyScope` reverts `UnsupportedPolicyType`.
 
 The write takes effect on the next call that hits that scope. It emits `PolicyUpdated`. Until you update a scope, it reads as `0` (`ALWAYS_ALLOW`), so the check passes for every address. The same policy ID can sit on more than one scope and on more than one token. `policyId(policyScope)` reads the current binding.
 
@@ -206,7 +227,7 @@ Most scopes deny when `isAuthorized` is `false` and revert `PolicyForbids`. `SEI
 
 ## 4. Example
 
-Start with a receiver allowlist. Then combine it with a sanctions blocklist so a transfer requires both.
+Start with a receiver allowlist. Then combine it with a sanctions blocklist so a transfer requires both. Then invert an exclusion allowlist so the same gate can say "on KYC and not on that list" without a second member set.
 
 ### 4.1 One allowlist
 
@@ -300,6 +321,61 @@ Alice and Dave are on the KYC list and not on the sanctions list, so both childr
 A later `updateBlocklist` that adds or removes Carol changes the composite on the next call. The token still holds `gateId`. The issuer does not call `updatePolicy` again.
 
 If the issuer later needs the same KYC list or-ed with a token-specific partner allowlist, they create a `UNION` of those two allowlists instead. The token bind step is the same.
+
+### 4.3 Invert: KYC and not on an exclusion allowlist
+
+Section 4.2 stores sanctioned addresses as a `BLOCKLIST`, so "not sanctioned" is already the blocklist's authorization result. Invert is for the other case: the exclusion list is an `ALLOWLIST` of addresses you want to keep out, and you need the opposite of that list without copying it into a blocklist.
+
+Create a KYC allowlist and an exclusion allowlist. Invert the exclusion ID. Pass both into an `INTERSECT` composite.
+
+```mermaid
+flowchart TD
+    C["INTERSECT composite"] --> K[KYC ALLOWLIST]
+    C --> N["inverted exclusion ALLOWLIST"]
+    N --> X[exclusion ALLOWLIST]
+    K --> A1[Alice: member]
+    K --> A2[Bob: not a member]
+    K --> A3[Carol: member]
+    X --> B1[Alice: not listed]
+    X --> B2[Bob: not listed]
+    X --> B3[Carol: listed]
+```
+
+```mermaid
+sequenceDiagram
+    participant Admin
+    participant Registry as Policy Registry
+    participant Token as B20 token
+    participant Alice
+    participant Dave
+    participant Carol
+
+    Admin->>Registry: createPolicy(admin, ALLOWLIST)
+    Registry-->>Admin: kycId
+    Admin->>Registry: updateAllowlist(kycId, true, [Alice, Dave, Carol])
+    Admin->>Registry: createPolicy(admin, ALLOWLIST)
+    Registry-->>Admin: exclusionId
+    Admin->>Registry: updateAllowlist(exclusionId, true, [Carol])
+    Admin->>Registry: invertedPolicyId(exclusionId)
+    Registry-->>Admin: notExcluded
+    Admin->>Registry: createCompositePolicy(admin, INTERSECT, [kycId, notExcluded])
+    Registry-->>Admin: gateId
+    Admin->>Token: updatePolicy(TRANSFER_RECEIVER_POLICY, gateId)
+
+    Alice->>Token: transfer(Dave, amount)
+    Token->>Registry: isAuthorized(gateId, Dave)
+    Registry-->>Token: true
+    Token-->>Alice: allowed
+
+    Alice->>Token: transfer(Carol, amount)
+    Token->>Registry: isAuthorized(gateId, Carol)
+    Registry-->>Token: false
+    Token-->>Alice: revert PolicyForbids(TRANSFER_RECEIVER_POLICY, gateId)
+```
+
+Alice and Dave are on the KYC list and not on the exclusion list. The inverted child authorizes them, so the `INTERSECT` returns `true`. Carol is KYC'd but on the exclusion list. The inverted child returns `false`, so the composite returns `false` and the transfer reverts. Bob is not on the KYC list, so he is denied even though he is not excluded.
+
+A later `updateAllowlist` that adds or removes Carol on `exclusionId` changes the inverted child on the next call. The token still holds `gateId`. The issuer does not call `updatePolicy` again.
 
 ## Events and Errors
 


### PR DESCRIPTION
## Summary
- Registers **Denim** as hardfork ordinal `03` in `changelog/README.md` (next after Cobalt's `02`).
- Adds `changelog/03_Denim_PolicyRegistry_not_policy.md`: full spec for query-time policy inversion — a NOT flag in bit 63 of a `uint64` policy ID, the new `invertedPolicyId` view, `isAuthorized`/getter behavior on inverted IDs, composite-child invert handling, and the two rejected alternatives (new `NOT` policy type, per-child invert bitmask).
- Updates `docs/concepts/policies.md` with the corresponding "Inverting a policy" section (§2.3, renumbering everything after it by one).
- Not breaking: all existing selectors/events/errors are unchanged; existing policy IDs have bit 63 unset, so behavior is identical.

## Test plan
- [x] Docs-only change; no build/test impact.
- [ ] Reviewer check: filename/ordinal matches `changelog/AGENTS.md`'s naming rule, and the `docs/concepts/policies.md` renumbering (2.3 → 2.4, 2.3.1 → 2.4.1, etc.) is internally consistent.